### PR TITLE
Improve flags for better support of xlC and nvcc combinations

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -229,8 +229,18 @@ if( BLT_CXX_STD STREQUAL c++98 )
     set(CMAKE_CXX_STANDARD 98)
 elseif( BLT_CXX_STD STREQUAL c++11 )
     set(CMAKE_CXX_STANDARD 11)
+    if (COMPILER_FAMILY_IS_XL)
+      blt_append_custom_compiler_flag(
+        FLAGS_VAR CMAKE_CXX_FLAGS
+        DEFAULT "-std=c++11")
+    endif ()
 elseif( BLT_CXX_STD STREQUAL c++14 )
     set(CMAKE_CXX_STANDARD 14)
+    if (COMPILER_FAMILY_IS_XL)
+      blt_append_custom_compiler_flag(
+        FLAGS_VAR CMAKE_CXX_FLAGS
+        DEFAULT "-std=c++1y")
+    endif ()
 else()
     message(FATAL_ERROR "${BLT_CXX_STD} is an invalid entry for BLT_CXX_STD.
     Valid Options are ( c++98, c++11, c++14 )")

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -8,6 +8,14 @@ message(STATUS "CUDA version:      ${CUDA_VERSION_STRING}")
 message(STATUS "CUDA Include Path: ${CUDA_INCLUDE_DIRS}")
 message(STATUS "CUDA Libraries:    ${CUDA_LIBRARIES}")
 
+# don't propagate host flags - too easy to break stuff!
+set (CUDA_PROPAGATE_HOST_FLAGS Off)
+if (CMAKE_CXX_COMPILER)
+  set (CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+else ()
+  set (CUDA_HOST_COMPILER ${CMAKE_C_COMPILER})
+endif ()
+
 # depend on 'cuda', if you need to use cuda
 # headers, link to cuda libs, and need to run your source
 # through a cuda compiler (nvcc)


### PR DESCRIPTION
Ran into some issues building with xlC and nvcc - these changes fix that, by separating host and device flags, and adding support for C++ standards when xlC is used.