### PR TITLE
Adds support for ensuring that all tests are invoked through mpiexec.

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -567,6 +567,12 @@ macro(blt_add_test)
     endif()
     set(test_command ${runtime_output_directory}/${arg_COMMAND} )
 
+    # If configuration option ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC is set, 
+    # ensure NUM_PROCS is at least one. This invokes the test through MPIEXEC.
+    if ( ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC AND NOT arg_NUM_PROCS )
+        set( arg_NUM_PROCS 1 )
+    endif()
+
     # Handle mpi
     if ( ${arg_NUM_PROCS} )
         set(test_command ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${arg_NUM_PROCS} ${test_command} )

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -77,3 +77,17 @@ if( NOT ( ( BLT_CXX_STD STREQUAL "c++98" )
     message(FATAL_ERROR "${BLT_CXX_STD} is an invalid entry for BLT_CXX_STD.
 Valid Options are ( c++98, c++11, c++14 )")
 endif()
+
+
+################################
+# Advanced configuration options
+################################
+
+option(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC
+       "Option to ensure that all tests are invoked through mpiexec. Required on some platforms, like IBM's BG/Q."
+       OFF
+       )
+
+# All advanced options should be marked as advanced
+mark_as_advanced( ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC )
+       


### PR DESCRIPTION
Some platforms, like IBM's BG/Q, require all executables to be run
on 'back end' compute nodes through a call to mpiexec.  This commit gives
the blt_add_test() macro the ability to ensure that all tests are wrapped with
a call to ${MPIEXEC} with at least one mpi rank.

To enable this feature, users must configure their code with
the cmake cache variable BLT_ALWAYS_WRAP_TESTS_WITH_MPIEXEC  set to TRUE.
E.g.
    set(BLT_ALWAYS_WRAP_TESTS_WITH_MPIEXEC TRUE CACHE BOOL
        "Ensures that tests will be invoked through mpiexec")