### PR TITLE
bugfix: fix to avoid cmake policy CMP0048 warnings

### DIFF
--- a/thirdparty_builtin/googletest-release-1.8.0/CMakeLists.txt
+++ b/thirdparty_builtin/googletest-release-1.8.0/CMakeLists.txt
@@ -1,5 +1,17 @@
 cmake_minimum_required(VERSION 2.6.2)
 
+##########################################################
+# BLT FIX:
+# Add policy setting until we upgrade to gtest
+# with a fix for:
+#   https://github.com/google/googletest/issues/709
+#
+# As of 7/14/17 -- there is an open PR to add this line
+#   https://github.com/google/googletest/pull/782/files
+##########################################################
+# avoid warnings for project commands w/o VERSION
+cmake_policy(SET CMP0048 NEW)
+
 project( googletest-distribution )
 
 enable_testing()


### PR DESCRIPTION
resolves: https://github.com/LLNL/blt/issues/46

I tested this in a cmake build with a project that is using the new style project command (which includes the VERSION arg). Travis will test it for the non-VERSION case. 
