### PR TITLE
add blt options for gtest and fruit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,15 @@ env:
       BLT_FORTRAN=ON
       BLT_OPENMP=ON
       BLT_GMOCK=ON
+    # gcc w/ cmake 3.8.0, gtest and fruit off
+    - CMAKE_MAJOR=3.8
+      CMAKE_MINOR=0
+      BLT_CC=gcc-4.9
+      BLT_CXX=g++-4.9
+      BLT_FC=gfortran-4.9
+      BLT_FORTRAN=ON
+      BLT_GTEST=OFF
+      BLT_FRUIT=OFF
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ env:
       BLT_FC=gfortran-4.9
       BLT_FORTRAN=ON
       BLT_OPENMP=ON
+      BLT_GTEST=ON
+      BLT_FRUIT=ON
       BLT_GMOCK=OFF
     # gcc w/ cmake 3.4.1
     - CMAKE_MAJOR=3.4
@@ -68,6 +70,8 @@ env:
       BLT_FC=gfortran-4.9
       BLT_FORTRAN=ON
       BLT_OPENMP=ON
+      BLT_GTEST=ON
+      BLT_FRUIT=ON
       BLT_GMOCK=OFF
     # gcc w/ cmake 3.8.0
     - CMAKE_MAJOR=3.8
@@ -77,6 +81,8 @@ env:
       BLT_FC=gfortran-4.9
       BLT_FORTRAN=ON
       BLT_OPENMP=ON
+      BLT_GTEST=ON
+      BLT_FRUIT=ON
       BLT_GMOCK=OFF
     # gcc w/ cmake 3.8.0, gmock on
     - CMAKE_MAJOR=3.8
@@ -86,6 +92,8 @@ env:
       BLT_FC=gfortran-4.9
       BLT_FORTRAN=ON
       BLT_OPENMP=ON
+      BLT_GTEST=ON
+      BLT_FRUIT=ON
       BLT_GMOCK=ON
     # gcc w/ cmake 3.8.0, gtest and fruit off
     - CMAKE_MAJOR=3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,12 @@ script:
   # c & c++ compilers
   - CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_C_COMPILER=${BLT_CC}"
   - CMAKE_OPTS="${CMAKE_OPTS} -DCMAKE_CXX_COMPILER=${BLT_CXX}"
+  # gtest support
+  - CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_GTEST=${BLT_GTEST}"
   # gmock support
   - CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_GMOCK=${BLT_GMOCK}"
+  # fruit support
+  - CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_FRUIT=${BLT_FRUIT}"
   # benchmarking
   - CMAKE_OPTS="${CMAKE_OPTS} -DENABLE_BENCHMARKS=ON"
   # enable fortran support

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -61,9 +61,13 @@ option(ENABLE_MPI          "Enables MPI support" OFF)
 option(ENABLE_OPENMP       "Enables OpenMP compiler support" OFF)
 option(ENABLE_CUDA         "Enable CUDA support" OFF)
 
-# Controls if Google Mock is built and available for use. 
-# If ENABLE_TESTS=OFF, no testing support is built and this option is ignored.
+# Options that control if Google Test, Google Mock, and Fruit are built 
+# and available for use. 
+# If ENABLE_TESTS=OFF, no testing support is built and these option are ignored.
+option(ENABLE_GTEST        "Enable Google Test testing support (if ENABLE_TESTS=ON)" ON)
 option(ENABLE_GMOCK        "Enable Google Mock testing support (if ENABLE_TESTS=ON)" OFF)
+option(ENABLE_FRUIT        "Enable Fruit testing support (if ENABLE_TESTS=ON and ENABLE_FORTRAN=ON)" ON)
+    
 
 ################################
 # Compiler Options

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -63,7 +63,11 @@ option(ENABLE_CUDA         "Enable CUDA support" OFF)
 
 # Options that control if Google Test, Google Mock, and Fruit are built 
 # and available for use. 
+#
 # If ENABLE_TESTS=OFF, no testing support is built and these option are ignored.
+#
+# Google Mock requires and always builds Google Test, so ENABLE_GMOCK=ON implies ENABLE_GTEST=ON.
+#
 option(ENABLE_GTEST        "Enable Google Test testing support (if ENABLE_TESTS=ON)" ON)
 option(ENABLE_GMOCK        "Enable Google Mock testing support (if ENABLE_TESTS=ON)" OFF)
 option(ENABLE_FRUIT        "Enable Fruit testing support (if ENABLE_TESTS=ON and ENABLE_FORTRAN=ON)" ON)

--- a/cmake/blt-test/CMakeLists.txt
+++ b/cmake/blt-test/CMakeLists.txt
@@ -63,93 +63,96 @@ blt_add_library( NAME example
                  HEADERS "src/Example.hpp"
                  )
 
-################################
-# Add an executable
-# (which happens to be a test)
-################################
-blt_add_executable(
-         NAME t_example_smoke
-         SOURCES "src/t_example_smoke.cpp"
-         DEPENDS_ON example gtest)
+if(ENABLE_GTEST)
+    ################################
+    # Add an executable
+    # (which happens to be a test)
+    ################################
+    blt_add_executable(
+             NAME t_example_smoke
+             SOURCES "src/t_example_smoke.cpp"
+             DEPENDS_ON example gtest)
 
-################################
-# Register our test w/ ctest
-################################
-blt_add_test(NAME t_example_smoke
-             COMMAND t_example_smoke)
+    ################################
+    # Register our test w/ ctest
+    ################################
+    blt_add_test(NAME t_example_smoke
+                 COMMAND t_example_smoke)
 
 
-####################
-#  Header-only test
-####################
+    ####################
+    #  Header-only test
+    ####################
 
-blt_add_library(NAME blt_header_only
-                HEADERS "src/HeaderOnly.hpp")
+    blt_add_library(NAME blt_header_only
+                    HEADERS "src/HeaderOnly.hpp")
 
-# This executable depends on the header-only library
-
-blt_add_executable(
-  NAME t_header_only_smoke
-  SOURCES "src/t_header_only_smoke.cpp"
-  DEPENDS_ON blt_header_only gtest)
-
-blt_add_test(NAME t_header_only_smoke
-             COMMAND t_header_only_smoke)
-
-####################
-# Git Macros test
-####################
-if ( GIT_FOUND )
-
-  blt_is_git_repo( OUTPUT_STATE is_git_repo
-                   SOURCE_DIR ${PROJECT_SOURCE_DIR} )
-
-  if ( ${is_git_repo} )
-
-    ## get the latest tag from the master branch
-    blt_git_tag( OUTPUT_TAG blt_tag
-                 RETURN_CODE rc
-                 ON_BRANCH master
-                 SOURCE_DIR ${PROJECT_SOURCE_DIR}
-                 )
-    if ( NOT ${rc} EQUAL 0 )
-      message(FATAL_ERROR "blt_git_tag failed!")
-    endif()
-
-    ## get the name of the current (i.e., checked out) branch
-    blt_git_branch( BRANCH_NAME blt_branch
-                    RETURN_CODE rc
-                    SOURCE_DIR ${PROJECT_SOURCE_DIR}
-                    )
-    if ( NOT ${rc} EQUAL 0 )
-      message(FATAL_ERROR "blt_git_branch failed!" )
-    endif()
-
-    ## get sha1 at the tip of the current branch
-    blt_git_hashcode ( HASHCODE blt_sha1
-                       RETURN_CODE rc
-                       SOURCE_DIR ${PROJECT_SOURCE_DIR}
-                       )
-    if ( NOT ${rc} EQUAL 0 )
-      message(FATAL_ERROR "blt_git_hashcode failed!")
-    endif()
-
-    set(BLT_TEST_TAG ${blt_tag})
-    set(BLT_TEST_SHA1 ${blt_sha1})
-    set(BLT_TEST_BRANCH ${blt_branch})
-
-    configure_file( src/t_git_macros_smoke.cpp.in
-                    ${CMAKE_BINARY_DIR}/t_git_macros_smoke.cpp )
+    # This executable depends on the header-only library
 
     blt_add_executable(
-      NAME t_git_macros_smoke
-      SOURCES "${CMAKE_BINARY_DIR}/t_git_macros_smoke.cpp"
-      DEPENDS_ON gtest
-      )
+      NAME t_header_only_smoke
+      SOURCES "src/t_header_only_smoke.cpp"
+      DEPENDS_ON blt_header_only gtest)
 
-    blt_add_test( NAME t_git_macros_smoke
-                  COMMAND t_git_macros_smoke )
+    blt_add_test(NAME t_header_only_smoke
+                 COMMAND t_header_only_smoke)
 
-  endif() # endif is_git_repo
+    ####################
+    # Git Macros test
+    ####################
+    if ( GIT_FOUND )
 
-endif() # endif Git_FOUND
+      blt_is_git_repo( OUTPUT_STATE is_git_repo
+                       SOURCE_DIR ${PROJECT_SOURCE_DIR} )
+
+      if ( ${is_git_repo} )
+
+        ## get the latest tag from the master branch
+        blt_git_tag( OUTPUT_TAG blt_tag
+                     RETURN_CODE rc
+                     ON_BRANCH master
+                     SOURCE_DIR ${PROJECT_SOURCE_DIR}
+                     )
+        if ( NOT ${rc} EQUAL 0 )
+          message(FATAL_ERROR "blt_git_tag failed!")
+        endif()
+
+        ## get the name of the current (i.e., checked out) branch
+        blt_git_branch( BRANCH_NAME blt_branch
+                        RETURN_CODE rc
+                        SOURCE_DIR ${PROJECT_SOURCE_DIR}
+                        )
+        if ( NOT ${rc} EQUAL 0 )
+          message(FATAL_ERROR "blt_git_branch failed!" )
+        endif()
+
+        ## get sha1 at the tip of the current branch
+        blt_git_hashcode ( HASHCODE blt_sha1
+                           RETURN_CODE rc
+                           SOURCE_DIR ${PROJECT_SOURCE_DIR}
+                           )
+        if ( NOT ${rc} EQUAL 0 )
+          message(FATAL_ERROR "blt_git_hashcode failed!")
+        endif()
+
+        set(BLT_TEST_TAG ${blt_tag})
+        set(BLT_TEST_SHA1 ${blt_sha1})
+        set(BLT_TEST_BRANCH ${blt_branch})
+
+        configure_file( src/t_git_macros_smoke.cpp.in
+                        ${CMAKE_BINARY_DIR}/t_git_macros_smoke.cpp )
+
+        blt_add_executable(
+          NAME t_git_macros_smoke
+          SOURCES "${CMAKE_BINARY_DIR}/t_git_macros_smoke.cpp"
+          DEPENDS_ON gtest
+          )
+
+        blt_add_test( NAME t_git_macros_smoke
+                      COMMAND t_git_macros_smoke )
+
+      endif() # endif is_git_repo
+
+    endif() # endif Git_FOUND
+
+endif() # endif ENABLE_GTEST

--- a/cmake/blt-test/CMakeLists.txt
+++ b/cmake/blt-test/CMakeLists.txt
@@ -47,7 +47,7 @@
 ################################
 cmake_minimum_required(VERSION 3.1)
 
-project(blt-example LANGUAGES CXX)
+project(blt-example LANGUAGES C CXX)
 
 ################################
 # Include BLT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,13 +47,15 @@
 ################
 # gtest test
 ################
-blt_add_executable(NAME blt_gtest_smoke
-                   SOURCES blt_gtest_smoke.cpp
-                   OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                   DEPENDS_ON gtest)
+if(ENABLE_GTEST)
+    blt_add_executable(NAME blt_gtest_smoke
+                       SOURCES blt_gtest_smoke.cpp
+                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                       DEPENDS_ON gtest)
 
-blt_add_test( NAME blt_gtest_smoke
-              COMMAND blt_gtest_smoke)
+    blt_add_test( NAME blt_gtest_smoke
+                  COMMAND blt_gtest_smoke)
+endif()
 
 ################
 # gmock test
@@ -86,7 +88,7 @@ endif()
 ################
 # fruit test
 ################
-if (ENABLE_FORTRAN)
+if (ENABLE_FORTRAN AND ENABLE_FRUIT)
     blt_add_executable(NAME blt_fruit_smoke
                        SOURCES blt_fruit_smoke.f
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -63,11 +63,18 @@ if(ENABLE_TESTS)
     #
     
     if(ENABLE_GMOCK)
+        
+        # In BLT ENABLE_GMOCK implies ENABLE_GTEST,
+        # IF ENABLE_GTEST is OFF, force to ON
+        if(NOT ENABLE_GTEST)
+            set(ENABLE_GTEST ON CACHE BOOL "")
+        endif()
+        
         set(BUILD_GMOCK ON  CACHE BOOL "")
         set(BUILD_GTEST OFF CACHE BOOL "")
     else()
         set(BUILD_GMOCK OFF CACHE BOOL "")
-        set(BUILD_GTEST ON  CACHE BOOL "")        
+        set(BUILD_GTEST ON  CACHE BOOL "")
     endif()
 
     message(STATUS "Google Test Support is ${ENABLE_GTEST}")

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -70,27 +70,36 @@ if(ENABLE_TESTS)
         set(BUILD_GTEST ON  CACHE BOOL "")        
     endif()
 
-
-    # Enable builtin google test 
-    add_subdirectory(googletest-release-1.8.0)
-
-    blt_register_library(NAME gtest
-                         INCLUDES ${gtest_SOURCE_DIR}/include
-                         LIBRARIES gtest_main gtest
-                         DEFINES  ${gtest_defines})
-    
+    message(STATUS "Google Test Support is ${ENABLE_GTEST}")
     message(STATUS "Google Mock Support is ${ENABLE_GMOCK}")
     
-    if(ENABLE_GMOCK)
-        blt_register_library(NAME gmock
-                             INCLUDES ${gmock_SOURCE_DIR}/include
-                             LIBRARIES gmock_main gmock
+    #
+    # Guard of googletest w/ ENABLE_GTEST
+    # In BTL ENABLE_GTEST is also required when using ENABLE_GMOCK
+    #
+    
+    if(ENABLE_GTEST)
+        # Enable builtin google test 
+        add_subdirectory(googletest-release-1.8.0)
+
+        blt_register_library(NAME gtest
+                             INCLUDES ${gtest_SOURCE_DIR}/include
+                             LIBRARIES gtest_main gtest
                              DEFINES  ${gtest_defines})
+         if(ENABLE_GMOCK)
+             blt_register_library(NAME gmock
+                                  INCLUDES ${gmock_SOURCE_DIR}/include
+                                  LIBRARIES gmock_main gmock
+                                  DEFINES  ${gtest_defines})
+         endif()
     endif()
 
     # Enable Fruit (FortRan UnIT testing) support
     if (ENABLE_FORTRAN)
-        add_subdirectory(fruit-3.4.1)
+        message(STATUS "Fruit Support is ${ENABLE_FRUIT}")
+        if(ENABLE_FRUIT)
+            add_subdirectory(fruit-3.4.1)
+        endif()
     endif()
 
     if(ENABLE_BENCHMARKS)


### PR DESCRIPTION
Adds:

 `ENABLE_GTEST` (default = ON)
 `ENABLE_FRUIT` (default = ON (also guarded by `ENABLE_FORTRAN` = ON)


Like `ENABLE_GMOCK`, these are guarded by `ENABLE_TESTS`.


gmock is also guarded by `ENABLE_GTEST`, 
I think this makes sense b/c building gmock always builds gtest.


