### PR TITLE
System includes for external libraries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,9 +10,6 @@ George Zagaris (zagaris2@llnl.gov)
 Kenneth Weiss (kweiss@llnl.gov)
 Lee Taylor (taylor16@llnl.gov)
 Aaron Black (black27@llnl.gov)
-
-Contributors include:
-
 David A. Beckingsale (beckingsale1@llnl.gov)
 Richard Hornung (hornung1@llnl.gov)
 Randolph Settgast (settgast1@llnl.gov)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ Developers include:
  * Kenneth Weiss (kweiss@llnl.gov)
  * Lee Taylor (taylor16@llnl.gov)
  * Aaron Black (black27@llnl.gov)
-
-Contributors include:
-
  * David A. Beckingsale (beckingsale1@llnl.gov)
  * Richard Hornung (hornung1@llnl.gov)
  * Randolph Settgast (settgast1@llnl.gov)

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -147,7 +147,8 @@ endmacro(blt_add_target_link_flags)
 ##------------------------------------------------------------------------------
 ## blt_register_library( NAME <libname>
 ##                       DEPENDS_ON [dep1 [dep2 ...]]
-##                       INCLUDES [include1 [include2 ...]] 
+##                       INCLUDES [include1 [include2 ...]]
+##                       USE_SYSTEM_INCLUDES [ON] 
 ##                       FORTRAN_MODULES [ path1 [ path2 ..]]
 ##                       LIBRARIES [lib1 [lib2 ...]]
 ##                       COMPILE_FLAGS [ flag1 [ flag2 ..]]
@@ -161,12 +162,17 @@ endmacro(blt_add_target_link_flags)
 ## the DEPENDS_ON in your blt_add_executable call and it will add the INCLUDES
 ## and LIBRARIES to that executable.
 ##
+## USE_SYSTEM_INCLUDES marks the utilizes the compiler's system include path 
+## setting for this libraries include directories.  This is useful if the headers
+## generate warnings you want to not have them reported in your build.
+##
 ## This does not actually build the library.  This is strictly to ease use after
 ## discovering it on your system or building it yourself inside your project.
 ##
 ## Output variables (name = "foo"):
 ##  BLT_FOO_DEPENDS_ON
 ##  BLT_FOO_INCLUDES
+##  BLT_FOO_USE_SYSTEM_INCLUDES
 ##  BLT_FOO_FORTRAN_MODULES
 ##  BLT_FOO_LIBRARIES
 ##  BLT_FOO_COMPILE_FLAGS
@@ -175,7 +181,7 @@ endmacro(blt_add_target_link_flags)
 ##------------------------------------------------------------------------------
 macro(blt_register_library)
 
-    set(singleValueArgs NAME )
+    set(singleValueArgs NAME USE_SYSTEM_INCLUDES)
     set(multiValueArgs INCLUDES 
                        FORTRAN_MODULES
                        LIBRARIES
@@ -197,6 +203,11 @@ macro(blt_register_library)
     if( arg_INCLUDES )
         set(BLT_${uppercase_name}_INCLUDES ${arg_INCLUDES} CACHE PATH "" FORCE)
         mark_as_advanced(BLT_${uppercase_name}_INCLUDES)
+    endif()
+
+    if( arg_USE_SYSTEM_INCLUDES )
+        set(BLT_${uppercase_name}_USE_SYSTEM_INCLUDES ON CACHE BOOL "" FORCE)
+        mark_as_advanced(BLT_${uppercase_name}_USE_SYSTEM_INCLUDES)
     endif()
 
     if( ENABLE_FORTRAN AND arg_FORTRAN_MODULES )

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -148,7 +148,7 @@ endmacro(blt_add_target_link_flags)
 ## blt_register_library( NAME <libname>
 ##                       DEPENDS_ON [dep1 [dep2 ...]]
 ##                       INCLUDES [include1 [include2 ...]]
-##                       USE_SYSTEM_INCLUDES [ON] 
+##                       TREAT_INCLUDES_AS_SYSTEM [ON] 
 ##                       FORTRAN_MODULES [ path1 [ path2 ..]]
 ##                       LIBRARIES [lib1 [lib2 ...]]
 ##                       COMPILE_FLAGS [ flag1 [ flag2 ..]]
@@ -162,7 +162,7 @@ endmacro(blt_add_target_link_flags)
 ## the DEPENDS_ON in your blt_add_executable call and it will add the INCLUDES
 ## and LIBRARIES to that executable.
 ##
-## USE_SYSTEM_INCLUDES marks the utilizes the compiler's system include path 
+## TREAT_INCLUDES_AS_SYSTEM marks the utilizes the compiler's system include path 
 ## setting for this libraries include directories.  This is useful if the headers
 ## generate warnings you want to not have them reported in your build.
 ##
@@ -172,7 +172,7 @@ endmacro(blt_add_target_link_flags)
 ## Output variables (name = "foo"):
 ##  BLT_FOO_DEPENDS_ON
 ##  BLT_FOO_INCLUDES
-##  BLT_FOO_USE_SYSTEM_INCLUDES
+##  BLT_FOO_TREAT_INCLUDES_AS_SYSTEM
 ##  BLT_FOO_FORTRAN_MODULES
 ##  BLT_FOO_LIBRARIES
 ##  BLT_FOO_COMPILE_FLAGS

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -181,7 +181,7 @@ endmacro(blt_add_target_link_flags)
 ##------------------------------------------------------------------------------
 macro(blt_register_library)
 
-    set(singleValueArgs NAME USE_SYSTEM_INCLUDES)
+    set(singleValueArgs NAME TREAT_INCLUDES_AS_SYSTEM)
     set(multiValueArgs INCLUDES 
                        FORTRAN_MODULES
                        LIBRARIES
@@ -205,9 +205,9 @@ macro(blt_register_library)
         mark_as_advanced(BLT_${uppercase_name}_INCLUDES)
     endif()
 
-    if( arg_USE_SYSTEM_INCLUDES )
-        set(BLT_${uppercase_name}_USE_SYSTEM_INCLUDES ON CACHE BOOL "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_USE_SYSTEM_INCLUDES)
+    if( arg_TREAT_INCLUDES_AS_SYSTEM )
+        set(BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM ON CACHE BOOL "" FORCE)
+        mark_as_advanced(BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM)
     endif()
 
     if( ENABLE_FORTRAN AND arg_FORTRAN_MODULES )

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -136,7 +136,7 @@ macro(blt_setup_target)
         string(TOUPPER ${dependency} uppercase_dependency )
 
         if ( DEFINED BLT_${uppercase_dependency}_INCLUDES )
-            if ( BLT_${uppercase_dependency}_USE_SYSTEM_INCLUDES )
+            if ( BLT_${uppercase_dependency}_TREAT_INCLUDES_AS_SYSTEM )
                 target_include_directories( ${arg_NAME} SYSTEM PUBLIC
                     ${BLT_${uppercase_dependency}_INCLUDES} )
             else()

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -136,8 +136,13 @@ macro(blt_setup_target)
         string(TOUPPER ${dependency} uppercase_dependency )
 
         if ( DEFINED BLT_${uppercase_dependency}_INCLUDES )
-            target_include_directories( ${arg_NAME} PUBLIC
-                ${BLT_${uppercase_dependency}_INCLUDES} )
+            if ( BLT_${uppercase_dependency}_USE_SYSTEM_INCLUDES )
+                target_include_directories( ${arg_NAME} SYSTEM PUBLIC
+                    ${BLT_${uppercase_dependency}_INCLUDES} )
+            else()
+                target_include_directories( ${arg_NAME} PUBLIC
+                    ${BLT_${uppercase_dependency}_INCLUDES} )
+            endif()
         endif()
 
         if ( DEFINED BLT_${uppercase_dependency}_FORTRAN_MODULES )


### PR DESCRIPTION
This is to enable using system includes (as long as the compiler supports it) to suppress warnings from external header files.