### PR TITLE
add flags to avoid gtest 1.8 dll-iface warnings on windows

### DIFF
--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -97,7 +97,7 @@ if(ENABLE_TESTS)
         
         blt_append_custom_compiler_flag( FLAGS_VAR gtest_extra_flags
                                          DEFAULT " " 
-                                         MSVC  "/wd4251 /wd4251" )
+                                         MSVC  "/wd4251 /wd4275" )
                 
         # Enable builtin google test 
         add_subdirectory(googletest-release-1.8.0)

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -86,17 +86,33 @@ if(ENABLE_TESTS)
     #
     
     if(ENABLE_GTEST)
+        
+        set(gtest_extra_flags "")
+        
+        if(COMPILER_FAMILY_IS_MSVC)
+            #
+            # gtest 1.8 emits many warnings related to dll-interface 
+            # issues on windows, so we add flags to work around these
+            # warnings, so they don't mask warnings we care about
+            #
+            # For more info see: https://github.com/LLNL/blt/issues/79
+            # 
+            set(gtest_extra_flags "/wd4251 /wd4251")
+        endif()
+        
         # Enable builtin google test 
         add_subdirectory(googletest-release-1.8.0)
 
         blt_register_library(NAME gtest
                              INCLUDES ${gtest_SOURCE_DIR}/include
                              LIBRARIES gtest_main gtest
+                             COMPILE_FLAGS ${gtest_extra_flags}
                              DEFINES  ${gtest_defines})
          if(ENABLE_GMOCK)
              blt_register_library(NAME gmock
                                   INCLUDES ${gmock_SOURCE_DIR}/include
                                   LIBRARIES gmock_main gmock
+                                  COMPILE_FLAGS ${gtest_extra_flags}
                                   DEFINES  ${gtest_defines})
          endif()
     endif()

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -87,19 +87,18 @@ if(ENABLE_TESTS)
     
     if(ENABLE_GTEST)
         
-        set(gtest_extra_flags "")
+        #
+        # gtest 1.8 emits many warnings related to dll-interface 
+        # issues on windows, so we add flags to work around these
+        # warnings, so they don't mask warnings we care about
+        #
+        # For more info see: https://github.com/LLNL/blt/issues/79
+        # 
         
-        if(COMPILER_FAMILY_IS_MSVC)
-            #
-            # gtest 1.8 emits many warnings related to dll-interface 
-            # issues on windows, so we add flags to work around these
-            # warnings, so they don't mask warnings we care about
-            #
-            # For more info see: https://github.com/LLNL/blt/issues/79
-            # 
-            set(gtest_extra_flags "/wd4251 /wd4251")
-        endif()
-        
+        blt_append_custom_compiler_flag( FLAGS_VAR gtest_extra_flags
+                                         DEFAULT " " 
+                                         MSVC  "/wd4251 /wd4251" )
+                
         # Enable builtin google test 
         add_subdirectory(googletest-release-1.8.0)
 


### PR DESCRIPTION
Avoid warnings described in #79.

WIP since I need to test in conduit on windows to double check it works as expected. 
