### PR TITLE
Add DEPENDS_ON to multiValue args for parsing in blt_register_library

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -184,6 +184,7 @@ macro(blt_register_library)
 
     set(singleValueArgs NAME TREAT_INCLUDES_AS_SYSTEM)
     set(multiValueArgs INCLUDES 
+                       DEPENDS_ON
                        FORTRAN_MODULES
                        LIBRARIES
                        COMPILE_FLAGS


### PR DESCRIPTION
DEPENDS_ON was not parsed out of the macro arguments, hence was always empty.