### PR TITLE
only apply cmake rpath settings when creating shared libs

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -205,7 +205,7 @@ endif()
 # RPath Settings
 ################################
 # only apply rpath settings for builds using shared libs
-if(BUILD_SHARED_LIBS)
+if(ENABLE_SHARED_LIBS)
     # use, i.e. don't skip the full RPATH for the build tree
     set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -204,24 +204,26 @@ endif()
 ################################
 # RPath Settings
 ################################
+# only apply rpath settings for builds using shared libs
+if(BUILD_SHARED_LIBS)
+    # use, i.e. don't skip the full RPATH for the build tree
+    set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
-# use, i.e. don't skip the full RPATH for the build tree
-set(CMAKE_SKIP_BUILD_RPATH  FALSE)
-
-# when building, don't use the install RPATH already
-# (but later on when installing)
-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
-
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# the RPATH to be used when installing, but only if it's not a system directory
-list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-if("${isSystemDir}" STREQUAL "-1")
+    # when building, don't use the install RPATH already
+    # (but later on when installing)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    set(CMAKE_INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+    # the RPATH to be used when installing, but only if it's not a system directory
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    if("${isSystemDir}" STREQUAL "-1")
+        set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+    endif()
 endif()
 
 ################################


### PR DESCRIPTION
avoid setting cmake rpath settings when building shared libs.

Avoids install errors like the following:

```
CMake Error at libs/relay/cmake_install.cmake:62 (file):
  file RPATH_CHANGE could not write new RPATH:

    /project/projectdirs/.../conduit/install/lib

  to the file:

    /project/projectdirs/.../conduit/install/bin/conduit_relay_node_viewer

  No valid ELF RPATH or RUNPATH entry exists in the file;
Call Stack (most recent call first):
  libs/cmake_install.cmake:38 (include)
  cmake_install.cmake:60 (include)
```



