### PR TITLE
Add option for turning off Find mpi

### DIFF
--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -58,6 +58,8 @@ option(ENABLE_FORTRAN      "Enables Fortran compiler support" OFF)
 option(ENABLE_SHARED_LIBS  "Enables shared libraries." OFF)
 
 option(ENABLE_MPI          "Enables MPI support" OFF)
+option(ENABLE_FIND_MPI     "Enables CMake's Find MPI support (Turn off when compiling with the mpi wrapper directly)" ON)
+
 option(ENABLE_OPENMP       "Enables OpenMP compiler support" OFF)
 option(ENABLE_CUDA         "Enable CUDA support" OFF)
 option(ENABLE_CLANG_CUDA   "Enable Clang's native CUDA support" OFF)

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -58,8 +58,6 @@ option(ENABLE_FORTRAN      "Enables Fortran compiler support" OFF)
 option(ENABLE_SHARED_LIBS  "Enables shared libraries." OFF)
 
 option(ENABLE_MPI          "Enables MPI support" OFF)
-option(ENABLE_FIND_MPI     "Enables CMake's Find MPI support (Turn off when compiling with the mpi wrapper directly)" ON)
-
 option(ENABLE_OPENMP       "Enables OpenMP compiler support" OFF)
 option(ENABLE_CUDA         "Enable CUDA support" OFF)
 option(ENABLE_CLANG_CUDA   "Enable Clang's native CUDA support" OFF)
@@ -100,6 +98,8 @@ endif()
 # Advanced configuration options
 ################################
 
+option(ENABLE_FIND_MPI     "Enables CMake's Find MPI support (Turn off when compiling with the mpi wrapper directly)" ON)
+
 option(
     ENABLE_GTEST_DEATH_TESTS
     "Enables tests that assert application failure. Only valid when tests are enabled"
@@ -111,7 +111,8 @@ option(
     OFF )
 
 # All advanced options should be marked as advanced
-mark_as_advanced( 
+mark_as_advanced(
+    ENABLE_FIND_MPI
     ENABLE_GTEST_DEATH_TESTS
     ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC )
        

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -46,17 +46,17 @@
 
 if (ENABLE_FIND_MPI)
     find_package(MPI REQUIRED)
+
+    message(STATUS "MPI C Compile Flags:  ${MPI_C_COMPILE_FLAGS}")
+    message(STATUS "MPI C Include Path:   ${MPI_C_INCLUDE_PATH}")
+    message(STATUS "MPI C Link Flags:     ${MPI_C_LINK_FLAGS}")
+    message(STATUS "MPI C Libraries:      ${MPI_C_LIBRARIES}")
+
+    message(STATUS "MPI CXX Compile Flags: ${MPI_CXX_COMPILE_FLAGS}")
+    message(STATUS "MPI CXX Include Path:  ${MPI_CXX_INCLUDE_PATH}")
+    message(STATUS "MPI CXX Link Flags:    ${MPI_CXX_LINK_FLAGS}")
+    message(STATUS "MPI CXX Libraries:     ${MPI_CXX_LIBRARIES}")
 endif()
-
-message(STATUS "MPI C Compile Flags:  ${MPI_C_COMPILE_FLAGS}")
-message(STATUS "MPI C Include Path:   ${MPI_C_INCLUDE_PATH}")
-message(STATUS "MPI C Link Flags:     ${MPI_C_LINK_FLAGS}")
-message(STATUS "MPI C Libraries:      ${MPI_C_LIBRARIES}")
-
-message(STATUS "MPI CXX Compile Flags: ${MPI_CXX_COMPILE_FLAGS}")
-message(STATUS "MPI CXX Include Path:  ${MPI_CXX_INCLUDE_PATH}")
-message(STATUS "MPI CXX Link Flags:    ${MPI_CXX_LINK_FLAGS}")
-message(STATUS "MPI CXX Libraries:     ${MPI_CXX_LIBRARIES}")
 
 message(STATUS "MPI Executable:       ${MPIEXEC}")
 message(STATUS "MPI Num Proc Flag:    ${MPIEXEC_NUMPROC_FLAG}")

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -44,7 +44,10 @@
 # MPI
 ################################
 
-find_package(MPI REQUIRED)
+if (ENABLE_FIND_MPI)
+    find_package(MPI REQUIRED)
+endif()
+
 message(STATUS "MPI C Compile Flags:  ${MPI_C_COMPILE_FLAGS}")
 message(STATUS "MPI C Include Path:   ${MPI_C_INCLUDE_PATH}")
 message(STATUS "MPI C Link Flags:     ${MPI_C_LINK_FLAGS}")


### PR DESCRIPTION
This is useful on systems where find_package(MPI) just doesn't seem to return the correct information.  This allows you to compile with the just the mpi wrapper.