### PR TITLE
added TREAT_INCLUDES_AS_SYSTEM ON for thirdparty_builtin

### DIFF
--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -112,13 +112,17 @@ if(ENABLE_TESTS)
                              INCLUDES ${gtest_SOURCE_DIR}/include
                              LIBRARIES gtest_main gtest ${gtest_extra_libs}
                              COMPILE_FLAGS ${gtest_extra_flags}
-                             DEFINES  ${gtest_defines})
+                             DEFINES  ${gtest_defines}
+                             TREAT_INCLUDES_AS_SYSTEM ON
+                             )
          if(ENABLE_GMOCK)
              blt_register_library(NAME gmock
                                   INCLUDES ${gmock_SOURCE_DIR}/include
                                   LIBRARIES gmock_main gmock
                                   COMPILE_FLAGS ${gtest_extra_flags}
-                                  DEFINES  ${gtest_defines})
+                                  DEFINES  ${gtest_defines}
+                                  TREAT_INCLUDES_AS_SYSTEM ON
+                                  )
          endif()
     endif()
 
@@ -147,6 +151,7 @@ if(ENABLE_TESTS)
         blt_register_library(NAME gbenchmark
                              INCLUDES ${benchmark_SOURCE_DIR}/include ${benchmark_SOURCE_DIR}
                              LIBRARIES benchmark ${RT_LIBRARIES}
+                             TREAT_INCLUDES_AS_SYSTEM ON
                              )
 
         # This sets up a target to run the benchmarks


### PR DESCRIPTION
added TREAT_INCLUDES_AS_SYSTEM ON to blt_register_library calls in thirdparty_builtin/CMakeLists.txt

This is done to remove compiler warnings in codes using blt's gtest.