### PR TITLE
Enables using BLT with the Intel toolchain in Visual Studio

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -617,24 +617,27 @@ endmacro(blt_add_benchmark)
 
 ##------------------------------------------------------------------------------
 ## blt_append_custom_compiler_flag( 
-##                    FLAGS_VAR flagsVar     (required)
-##                    DEFAULT   defaultFlag  (optional)
-##                    GNU       gnuFlag      (optional)
-##                    CLANG     clangFlag    (optional)
-##                    INTEL     intelFlag    (optional)
-##                    XL        xlFlag       (optional)
-##                    MSVC      msvcFlag     (optional)
+##                    FLAGS_VAR  flagsVar       (required)
+##                    DEFAULT    defaultFlag    (optional)
+##                    GNU        gnuFlag        (optional)
+##                    CLANG      clangFlag      (optional)
+##                    INTEL      intelFlag      (optional)
+##                    XL         xlFlag         (optional)
+##                    MSVC       msvcFlag       (optional)
+##                    MSVC_INTEL msvcIntelFlag  (optional)
 ## )
 ##
 ## Appends compiler-specific flags to a given variable of flags
 ##
-## If a custom flag is given for the current compiler, we use that,
+## If a custom flag is given for the current compiler, we use that.
 ## Otherwise, we will use the DEFAULT flag (if present)
+## When using the Intel toolchain within visual studio, we use the 
+## MSVC_INTEL flag, when provided, with a fallback to the MSVC flag.
 ##------------------------------------------------------------------------------
 macro(blt_append_custom_compiler_flag)
 
    set(options)
-   set(singleValueArgs FLAGS_VAR DEFAULT GNU CLANG INTEL XL MSVC)
+   set(singleValueArgs FLAGS_VAR DEFAULT GNU CLANG INTEL XL MSVC MSVC_INTEL)
    set(multiValueArgs)
 
    # Parse the arguments
@@ -655,7 +658,9 @@ macro(blt_append_custom_compiler_flag)
       set (${arg_FLAGS_VAR} "${${arg_FLAGS_VAR}} ${arg_INTEL} " )
    elseif( DEFINED arg_GNU AND COMPILER_FAMILY_IS_GNU )
       set (${arg_FLAGS_VAR} "${${arg_FLAGS_VAR}} ${arg_GNU} " )
-   elseif( DEFINED arg_MSVC AND COMPILER_FAMILY_IS_MSVC )
+   elseif( DEFINED arg_MSVC_INTEL AND COMPILER_FAMILY_IS_MSVC_INTEL )
+      set (${arg_FLAGS_VAR} "${${arg_FLAGS_VAR}} ${arg_MSVC_INTEL} " )
+   elseif( DEFINED arg_MSVC AND (COMPILER_FAMILY_IS_MSVC OR COMPILER_FAMILY_IS_MSVC_INTEL) )
       set (${arg_FLAGS_VAR} "${${arg_FLAGS_VAR}} ${arg_MSVC} " )
    elseif( DEFINED arg_DEFAULT )
       set (${arg_FLAGS_VAR} "${${arg_FLAGS_VAR}} ${arg_DEFAULT} ")

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -72,7 +72,12 @@ endif()
 if("${CMAKE_BUILD_TOOL}" MATCHES "(msdev|devenv|nmake|MSBuild)")
     set(COMPILER_FAMILY_IS_MSVC 1)
     message(STATUS "Compiler family is MSVC")
-
+    
+    if(CMAKE_GENERATOR_TOOLSET AND "${CMAKE_GENERATOR_TOOLSET}" MATCHES "Intel")
+        set(COMPILER_FAMILY_IS_MSVC_INTEL 1) 
+        message(STATUS "Toolset is ${CMAKE_GENERATOR_TOOLSET}")
+    endif()
+    
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(COMPILER_FAMILY_IS_GNU 1)
     message(STATUS "Compiler family is GNU")
@@ -90,6 +95,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     message(STATUS "Compiler family is Intel")
 
 endif()
+
+
 
 
 ################################################
@@ -263,17 +270,17 @@ message(STATUS "Standard C++${CMAKE_CXX_STANDARD} selected")
 
 blt_append_custom_compiler_flag(
     FLAGS_VAR BLT_ENABLE_ALL_WARNINGS_FLAG
-     DEFAULT "-Wall -Wextra"
-     CLANG   "-Wall -Wextra" 
-                    # Additional  possibilities for clang include: 
-                    #       "-Wdocumentation -Wdeprecated -Weverything"
-     MSVC    "/W4"
-                    # Additional  possibilities for visual studio include:
-                    # "/Wall /wd4619 /wd4668 /wd4820 /wd4571 /wd4710"
-     XL      ""     # qinfo=<grp> produces additional messages on XL
-                    # qflag=<x>:<x> defines min severity level to produce messages on XL
-                    #     where x is i info, w warning, e error, s severe; default is: 
-                    # (default is  qflag=i:i)
+     DEFAULT    "-Wall -Wextra"
+     CLANG      "-Wall -Wextra" 
+                       # Additional  possibilities for clang include: 
+                       #       "-Wdocumentation -Wdeprecated -Weverything"
+     MSVC       "/W4"
+                       # Additional  possibilities for visual studio include:
+                       # "/Wall /wd4619 /wd4668 /wd4820 /wd4571 /wd4710"
+     XL         ""     # qinfo=<grp> produces additional messages on XL
+                       # qflag=<x>:<x> defines min severity level to produce messages on XL
+                       #     where x is i info, w warning, e error, s severe; default is: 
+                       # (default is  qflag=i:i)
      )
 
 blt_append_custom_compiler_flag(

--- a/thirdparty_builtin/googletest-release-1.8.0/googletest/include/gtest/gtest-printers.h
+++ b/thirdparty_builtin/googletest-release-1.8.0/googletest/include/gtest/gtest-printers.h
@@ -394,6 +394,7 @@ void DefaultPrintTo(IsContainer /* dummy */,
   *os << '}';
 }
 
+
 // Used to print a pointer that is neither a char pointer nor a member
 // pointer, when the user doesn't define PrintTo() for it.  (A member
 // variable pointer or member function pointer doesn't really point to
@@ -423,9 +424,9 @@ void DefaultPrintTo(IsNotContainer /* dummy */,
       // void*.  However, we cannot cast it to const void* directly,
       // even using reinterpret_cast, as earlier versions of gcc
       // (e.g. 3.4.5) cannot compile the cast when p is a function
-      // pointer.  Casting to UInt64 first solves the problem.
+      // pointer.  Casting to an unsigned int first solves the problem.
       *os << reinterpret_cast<const void*>(
-          reinterpret_cast<internal::UInt64>(p));
+            reinterpret_cast<internal::TypeWithSize<sizeof(int*)>::UInt>(p));
     }
   }
 }


### PR DESCRIPTION
This PR enables using BLT with the Intel toolchain in Visual Studio builds.

It adds a new keyword ``MSVC_INTEL`` to the ``blt_append_custom_compiler_flag`` macro that is active when using the intel toolchain in MSVC.  If ``MSVC_INTEL`` is not present and ``MSVC`` is, we prefer that to ``DEFAULT``.

It also fixes a bug in gtest for 32 bit builds on 64 bit systems, where they assumed that pointers were always 8 bytes.

This PR addresses issue #81 