### PR TITLE
Feature/add folder support

### DIFF
--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -82,6 +82,14 @@ if (NOT BLT_LOADED)
   endif()
 
   ################################
+  # Enable cmake generator folder feature
+  # if ENABLE_FOLDERS == ON
+  ################################
+  if(ENABLE_FOLDERS)
+      set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+  endif()
+
+  ################################
   # Macros
   ################################
   include(${BLT_ROOT_DIR}/cmake/BLTMacros.cmake)

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -116,6 +116,49 @@ endmacro(blt_add_target_compile_flags)
 
 
 ##------------------------------------------------------------------------------
+## blt_set_target_folder (TO <target> NAME <name>)
+##
+## Sets the FOLDER property of cmake target <target> to <name>.
+##
+## This feature is only available when blt's ENABLE_FOLDERS option is ON and 
+## in cmake generators that support folders (but is safe to call regardless
+## of the generator or value of ENABLE_FOLDERS).
+##
+## Note: Do not use this macro on header-only (INTERFACE) library targets, since 
+## this will generate a cmake configuration error.
+##------------------------------------------------------------------------------
+macro(blt_set_target_folder)
+
+    set(options)
+    set(singleValuedArgs TO NAME)
+    set(multiValuedArgs)
+
+    ## parse the arguments to the macro
+    cmake_parse_arguments(arg
+         "${options}" "${singleValuedArgs}" "${multiValuedArgs}" ${ARGN} )
+
+    ## check for required arguments
+    if(NOT DEFINED arg_TO)
+        message(FATAL_ERROR "TO is a required parameter for blt_set_target_folder macro")
+    endif()
+
+    if(NOT TARGET ${arg_TO})
+        message(FATAL_ERROR "Target ${arg_TO} passed to blt_set_target_folder is not a valid cmake target")
+    endif()
+
+    if(NOT DEFINED arg_NAME)
+        message(FATAL_ERROR "NAME is a required parameter for blt_set_target_folder macro")
+    endif()
+
+    ## set the folder property for this target
+    if(ENABLE_FOLDERS AND NOT "${arg_NAME}" STREQUAL "")
+        set_property(TARGET ${arg_TO} PROPERTY FOLDER "${arg_NAME}")
+    endif()
+
+endmacro(blt_set_target_folder)
+
+
+##------------------------------------------------------------------------------
 ## blt_add_target_link_flags (TO <target> FLAGS [FOO [BAR ...]])
 ##
 ## Adds linker flags to a target by appending to the target's existing flags.
@@ -260,6 +303,7 @@ endmacro(blt_register_library)
 ##                  OUTPUT_DIR [dir]
 ##                  HEADERS_OUTPUT_SUBDIR [dir]
 ##                  SHARED [TRUE | FALSE]
+##                  FOLDER [name]
 ##                 )
 ##
 ## Adds a library target, called <libname>, to be built from the given sources.
@@ -287,10 +331,15 @@ endmacro(blt_register_library)
 ## It's useful when multiple libraries with the same name need to be created
 ## by different targets. NAME is the target name, OUTPUT_NAME is the library name.
 ##
+## FOLDER is an optional keyword to organize the target into a folder in an IDE.
+## This is available when ENABLE_FOLDERS is ON and when the cmake generator
+## supports this feature and will otherwise be ignored. 
+## Note: Do not use with header-only (INTERFACE)libraries, as this will generate 
+## a cmake configuration error.
 ##------------------------------------------------------------------------------
 macro(blt_add_library)
 
-    set(singleValueArgs NAME OUTPUT_NAME OUTPUT_DIR HEADERS_OUTPUT_SUBDIR SHARED)
+    set(singleValueArgs NAME OUTPUT_NAME OUTPUT_DIR HEADERS_OUTPUT_SUBDIR SHARED FOLDER)
     set(multiValueArgs SOURCES HEADERS DEPENDS_ON)
 
     # parse the arguments
@@ -401,6 +450,11 @@ macro(blt_add_library)
             PREFIX "" )
     endif()
 
+    # Handle optional FOLDER keyword for this target
+    if(ENABLE_FOLDERS AND DEFINED arg_FOLDER)
+        blt_set_target_folder(TO ${arg_NAME} NAME "${arg_FOLDER}")
+    endif()
+
     blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} ${arg_HEADERS})
 
 endmacro(blt_add_library)
@@ -410,6 +464,7 @@ endmacro(blt_add_library)
 ##                     SOURCES [source1 [source2 ...]]
 ##                     DEPENDS_ON [dep1 [dep2 ...]]
 ##                     OUTPUT_DIR [dir])
+##                     FOLDER [name]
 ##
 ## Adds an executable target, called <name>.
 ##
@@ -423,11 +478,14 @@ endmacro(blt_add_library)
 ## If the first entry in SOURCES is a Fortran source file, the fortran linker 
 ## is used. (via setting the CMake target property LINKER_LANGUAGE to Fortran )
 ##
+## FOLDER is an optional keyword to organize the target into a folder in an IDE.
+## This is available when ENABLE_FOLDERS is ON and when using a cmake generator
+## that supports this feature and will otherwise be ignored.
 ##------------------------------------------------------------------------------
 macro(blt_add_executable)
 
     set(options )
-    set(singleValueArgs NAME OUTPUT_DIR)
+    set(singleValueArgs NAME OUTPUT_DIR FOLDER)
     set(multiValueArgs SOURCES DEPENDS_ON)
 
     # Parse the arguments to the macro
@@ -470,6 +528,11 @@ macro(blt_add_executable)
     if ( arg_OUTPUT_DIR AND NOT (WIN32 AND BUILD_SHARED_LIBS) )
            set_target_properties(${arg_NAME} PROPERTIES
            RUNTIME_OUTPUT_DIRECTORY ${arg_OUTPUT_DIR} )
+    endif()
+
+    # Handle optional FOLDER keyword for this target
+    if(ENABLE_FOLDERS AND DEFINED arg_FOLDER)
+        blt_set_target_folder(TO ${arg_NAME} NAME "${arg_FOLDER}")
     endif()
 
     blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} )

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -116,9 +116,9 @@ endmacro(blt_add_target_compile_flags)
 
 
 ##------------------------------------------------------------------------------
-## blt_set_target_folder (TO <target> NAME <name>)
+## blt_set_target_folder (TARGET <target> FOLDER <folder>)
 ##
-## Sets the FOLDER property of cmake target <target> to <name>.
+## Sets the folder property of cmake target <target> to <folder>.
 ##
 ## This feature is only available when blt's ENABLE_FOLDERS option is ON and 
 ## in cmake generators that support folders (but is safe to call regardless
@@ -130,7 +130,7 @@ endmacro(blt_add_target_compile_flags)
 macro(blt_set_target_folder)
 
     set(options)
-    set(singleValuedArgs TO NAME)
+    set(singleValuedArgs TARGET FOLDER)
     set(multiValuedArgs)
 
     ## parse the arguments to the macro
@@ -138,21 +138,21 @@ macro(blt_set_target_folder)
          "${options}" "${singleValuedArgs}" "${multiValuedArgs}" ${ARGN} )
 
     ## check for required arguments
-    if(NOT DEFINED arg_TO)
-        message(FATAL_ERROR "TO is a required parameter for blt_set_target_folder macro")
+    if(NOT DEFINED arg_TARGET)
+        message(FATAL_ERROR "TARGET is a required parameter for blt_set_target_folder macro")
     endif()
 
-    if(NOT TARGET ${arg_TO})
-        message(FATAL_ERROR "Target ${arg_TO} passed to blt_set_target_folder is not a valid cmake target")
+    if(NOT TARGET ${arg_TARGET})
+        message(FATAL_ERROR "Target ${arg_TARGET} passed to blt_set_target_folder is not a valid cmake target")
     endif()
 
-    if(NOT DEFINED arg_NAME)
-        message(FATAL_ERROR "NAME is a required parameter for blt_set_target_folder macro")
+    if(NOT DEFINED arg_FOLDER)
+        message(FATAL_ERROR "FOLDER is a required parameter for blt_set_target_folder macro")
     endif()
 
     ## set the folder property for this target
-    if(ENABLE_FOLDERS AND NOT "${arg_NAME}" STREQUAL "")
-        set_property(TARGET ${arg_TO} PROPERTY FOLDER "${arg_NAME}")
+    if(ENABLE_FOLDERS AND NOT "${arg_FOLDER}" STREQUAL "")
+        set_property(TARGET ${arg_TARGET} PROPERTY FOLDER "${arg_FOLDER}")
     endif()
 
 endmacro(blt_set_target_folder)
@@ -452,7 +452,7 @@ macro(blt_add_library)
 
     # Handle optional FOLDER keyword for this target
     if(ENABLE_FOLDERS AND DEFINED arg_FOLDER)
-        blt_set_target_folder(TO ${arg_NAME} NAME "${arg_FOLDER}")
+        blt_set_target_folder(TARGET ${arg_NAME} FOLDER "${arg_FOLDER}")
     endif()
 
     blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} ${arg_HEADERS})
@@ -532,7 +532,7 @@ macro(blt_add_executable)
 
     # Handle optional FOLDER keyword for this target
     if(ENABLE_FOLDERS AND DEFINED arg_FOLDER)
-        blt_set_target_folder(TO ${arg_NAME} NAME "${arg_FOLDER}")
+        blt_set_target_folder(TARGET ${arg_NAME} FOLDER "${arg_FOLDER}")
     endif()
 
     blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} )

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -95,6 +95,12 @@ endif()
 
 
 ################################
+# Generator Options
+################################
+option(ENABLE_FOLDERS "Organize projects using folders (in generators that support this)" OFF)
+
+
+################################
 # Advanced configuration options
 ################################
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,7 +51,8 @@ if(ENABLE_GTEST)
     blt_add_executable(NAME blt_gtest_smoke
                        SOURCES blt_gtest_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON gtest)
+                       DEPENDS_ON gtest
+                       FOLDER blt/tests )
 
     blt_add_test( NAME blt_gtest_smoke
                   COMMAND blt_gtest_smoke)
@@ -64,7 +65,8 @@ if(ENABLE_GMOCK)
     blt_add_executable(NAME blt_gmock_smoke
                        SOURCES blt_gmock_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON gtest gmock)
+                       DEPENDS_ON gtest gmock
+                       FOLDER blt/tests )
 
     blt_add_test( NAME blt_gmock_smoke
                   COMMAND blt_gmock_smoke)
@@ -78,7 +80,8 @@ if (ENABLE_BENCHMARKS)
     blt_add_executable(NAME blt_gbenchmark_smoke
                        SOURCES blt_gbenchmark_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON gbenchmark)
+                       DEPENDS_ON gbenchmark
+                       FOLDER blt/benchmarks )
 
     blt_add_benchmark( NAME blt_gbenchmark_smoke 
                        COMMAND  blt_gbenchmark_smoke "--benchmark_min_time=0.0001")
@@ -92,7 +95,8 @@ if (ENABLE_FORTRAN AND ENABLE_FRUIT)
     blt_add_executable(NAME blt_fruit_smoke
                        SOURCES blt_fruit_smoke.f
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON fruit)
+                       DEPENDS_ON fruit
+                       FOLDER blt/tests )
 
     blt_add_test(NAME blt_fruit_smoke
                  COMMAND blt_fruit_smoke)
@@ -106,7 +110,8 @@ if (ENABLE_OPENMP)
     blt_add_executable(NAME blt_openmp_smoke 
                        SOURCES blt_openmp_smoke.cpp 
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON openmp)
+                       DEPENDS_ON openmp
+                       FOLDER blt/tests )
 
     blt_add_test(NAME blt_openmp_smoke
                  COMMAND blt_openmp_smoke)
@@ -120,7 +125,8 @@ if (ENABLE_MPI)
     blt_add_executable(NAME blt_mpi_smoke
                        SOURCES blt_mpi_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON mpi)
+                       DEPENDS_ON mpi
+                       FOLDER blt/tests )
 
     blt_add_test(NAME blt_mpi_smoke
                  COMMAND blt_mpi_smoke
@@ -134,7 +140,8 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_smoke
                        SOURCES blt_cuda_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda gtest)
+                       DEPENDS_ON cuda gtest
+                       FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_smoke
                  COMMAND blt_cuda_smoke)
@@ -142,7 +149,8 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_runtime_smoke
                        SOURCES blt_cuda_runtime_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda_runtime gtest)
+                       DEPENDS_ON cuda_runtime gtest
+                       FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_runtime_smoke
                  COMMAND blt_cuda_runtime_smoke)

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -173,7 +173,7 @@ if(ENABLE_TESTS)
     # Set the folder property of the blt thirdparty libraries 
     if(ENABLE_FOLDERS)
         foreach(tpl ${_blt_thirdparty})
-            blt_set_target_folder(TO ${tpl} NAME blt/thirdparty)
+            blt_set_target_folder(TARGET ${tpl} FOLDER blt/thirdparty)
         endforeach()
     endif()
 

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -43,7 +43,7 @@
 if(ENABLE_TESTS)
     include(CTest)
 
-    set(_blt_thirdparty)
+    set(_blt_tpl_targets) # tracks names of enabled tpl targets
 
     if(WIN32 AND BUILD_SHARED_LIBS)
         add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=1)
@@ -118,7 +118,7 @@ if(ENABLE_TESTS)
                              TREAT_INCLUDES_AS_SYSTEM ON
                              )
 
-        list(APPEND _blt_thirdparty gtest gtest_main)
+        list(APPEND _blt_tpl_targets gtest gtest_main)
 
         if(ENABLE_GMOCK)
             blt_register_library(NAME gmock
@@ -128,7 +128,7 @@ if(ENABLE_TESTS)
                                  DEFINES  ${gtest_defines}
                                  TREAT_INCLUDES_AS_SYSTEM ON
                                  )
-            list(APPEND _blt_thirdparty gmock gmock_main)
+            list(APPEND _blt_tpl_targets gmock gmock_main)
         endif()
     endif()
 
@@ -138,7 +138,7 @@ if(ENABLE_TESTS)
         if(ENABLE_FRUIT)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)
-            list(APPEND _blt_thirdparty fruit)
+            list(APPEND _blt_tpl_targets fruit)
         endif()
     endif()
 
@@ -161,7 +161,7 @@ if(ENABLE_TESTS)
                              TREAT_INCLUDES_AS_SYSTEM ON
                              )
 
-        list(APPEND _blt_thirdparty benchmark)
+        list(APPEND _blt_tpl_targets benchmark)
 
         # This sets up a target to run the benchmarks
         add_custom_target(run_benchmarks 
@@ -172,7 +172,7 @@ if(ENABLE_TESTS)
 
     # Set the folder property of the blt thirdparty libraries 
     if(ENABLE_FOLDERS)
-        foreach(tpl ${_blt_thirdparty})
+        foreach(tpl ${_blt_tpl_targets})
             blt_set_target_folder(TARGET ${tpl} FOLDER blt/thirdparty)
         endforeach()
     endif()

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -43,6 +43,8 @@
 if(ENABLE_TESTS)
     include(CTest)
 
+    set(_blt_thirdparty)
+
     if(WIN32 AND BUILD_SHARED_LIBS)
         add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=1)
         list(APPEND gtest_defines "-DGTEST_LINKED_AS_SHARED_LIBRARY=1")
@@ -115,15 +117,19 @@ if(ENABLE_TESTS)
                              DEFINES  ${gtest_defines}
                              TREAT_INCLUDES_AS_SYSTEM ON
                              )
-         if(ENABLE_GMOCK)
-             blt_register_library(NAME gmock
-                                  INCLUDES ${gmock_SOURCE_DIR}/include
-                                  LIBRARIES gmock_main gmock
-                                  COMPILE_FLAGS ${gtest_extra_flags}
-                                  DEFINES  ${gtest_defines}
-                                  TREAT_INCLUDES_AS_SYSTEM ON
-                                  )
-         endif()
+
+        list(APPEND _blt_thirdparty gtest gtest_main)
+
+        if(ENABLE_GMOCK)
+            blt_register_library(NAME gmock
+                                 INCLUDES ${gmock_SOURCE_DIR}/include
+                                 LIBRARIES gmock_main gmock
+                                 COMPILE_FLAGS ${gtest_extra_flags}
+                                 DEFINES  ${gtest_defines}
+                                 TREAT_INCLUDES_AS_SYSTEM ON
+                                 )
+            list(APPEND _blt_thirdparty gmock gmock_main)
+        endif()
     endif()
 
     # Enable Fruit (FortRan UnIT testing) support
@@ -132,6 +138,7 @@ if(ENABLE_TESTS)
         if(ENABLE_FRUIT)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)
+            list(APPEND _blt_thirdparty fruit)
         endif()
     endif()
 
@@ -154,10 +161,20 @@ if(ENABLE_TESTS)
                              TREAT_INCLUDES_AS_SYSTEM ON
                              )
 
+        list(APPEND _blt_thirdparty benchmark)
+
         # This sets up a target to run the benchmarks
         add_custom_target(run_benchmarks 
                           COMMAND ctest -C Benchmark -VV -R benchmark
                           WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
                           )
     endif()
+
+    # Set the folder property of the blt thirdparty libraries 
+    if(ENABLE_FOLDERS)
+        foreach(tpl ${_blt_thirdparty})
+            blt_set_target_folder(TO ${tpl} NAME blt/thirdparty)
+        endforeach()
+    endif()
+
 endif()


### PR DESCRIPTION
* Adds a new cmake option to blt: ``ENABLE_FOLDERS``, which helps organize cmake targets within an IDE.  This is off by default.
* Adds a new blt macro: ``blt_set_target_folder`` to add the folder property to a cmake target
* Adds optional keyword ``FOLDER`` to ``blt_add_library`` and ``blt_add_executable`` macros
* Applies the folder property to blt's test and buildtin thirdparty targets.