### PR TITLE
Add "inl" to list of file extensions for code checks

### DIFF
--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -101,7 +101,7 @@ macro(blt_add_code_checks)
 
     # Setup default parameters
     if (NOT DEFINED arg_C_FILE_EXTS)
-        set(arg_C_FILE_EXTS ".cpp" ".hpp" ".cxx" ".hxx" ".cc" ".c" ".h" ".hh")
+        set(arg_C_FILE_EXTS ".cpp" ".hpp" ".cxx" ".hxx" ".cc" ".c" ".h" ".hh" ".inl")
     endif()
     if (NOT DEFINED arg_F_FILE_EXTS)
         set(arg_F_FILE_EXTS ".F" ".f" ".f90" ".F90")


### PR DESCRIPTION
`.inl` is nice for templates or inline functions, and I don't want to have to duplicate the whole list of C file extensions.