### PR TITLE
Set CMP0048 in gbenchmark to avoid warnings about project version

### DIFF
--- a/thirdparty_builtin/gbenchmark-master-2017-05-19/CMakeLists.txt
+++ b/thirdparty_builtin/gbenchmark-master-2017-05-19/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required (VERSION 2.8.12)
 
+if (POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif ()
+
 project (benchmark)
 
 foreach(p

--- a/thirdparty_builtin/gbenchmark-master-2017-05-19/CMakeLists.txt
+++ b/thirdparty_builtin/gbenchmark-master-2017-05-19/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 2.8.12)
 
+##########################################################
+# BLT FIX:
+# Add policy setting to avoid warnings for project command
+# without VERSION argument
+##########################################################
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif ()


### PR DESCRIPTION
A call to cmake_minimum_required resets policies, so we need to add this or suffer warnings about project VERSION_* variables 😞 