### PR TITLE
Fix issue where device code was relocated too early in library builds.

### DIFF
--- a/cmake/thirdparty/FindCUDA.cmake
+++ b/cmake/thirdparty/FindCUDA.cmake
@@ -1784,11 +1784,14 @@ macro(CUDA_ADD_LIBRARY cuda_target)
   if (NOT CUDA_LINK_WITH_NVCC)
       CUDA_LINK_SEPARABLE_COMPILATION_OBJECTS("${link_file}" ${cuda_target} "${_options}" "${${cuda_target}_SEPARABLE_COMPILATION_OBJECTS}")
   endif()
-  ####################
-  # END BLT CHANGE 
-  ####################
 
-  if(CUDA_SEPARABLE_COMPILATION)
+  #BLT edit: added AND NOT CUDA_LINK_WITH_NVCC
+  if(CUDA_SEPARABLE_COMPILATION AND NOT CUDA_LINK_WITH_NVCC)
+    # end up with duplicate symbols if cudadevrt is on the executable link line
+    # when linking with NVCC
+    ####################
+    # END BLT CHANGE 
+    ####################
     target_link_libraries(${cuda_target} PUBLIC
         ${CUDA_LIBRARIES} ${CUDA_cudadevrt_LIBRARY}
       )
@@ -1798,27 +1801,10 @@ macro(CUDA_ADD_LIBRARY cuda_target)
         )
   endif()
   
-  ####################
-  # BEGIN BLT CHANGE #
-  ####################
-  if (CUDA_LINK_WITH_NVCC)
-      # We need to link with nvcc. Host linking prevents calling device methods in one library from kernels in 
-      #another (yes, even with separable  compilation)
-      string (REPLACE ";" " " LD_FLAGS_STR "${CUDA_NVCC_FLAGS}")
-      set (CMAKE_CUDA_CREATE_STATIC_LIBRARY "${CUDA_NVCC_EXECUTABLE} --lib ${LD_FLAGS_STR} <OBJECTS>  -o <TARGET> " CACHE PATH "" )
-      set (CMAKE_CUDA_CREATE_SHARED_LIBRARY "${CUDA_NVCC_EXECUTABLE} --shared ${LD_FLAGS_STR} <OBJECTS>  -o <TARGET> " CACHE PATH "" )
-      set_target_properties(${cuda_target} PROPERTIES LINKER_LANGUAGE "CUDA")
-  else() 
-      # We need to set the linker language based on what the expected generated file
-      # would be. CUDA_C_OR_CXX is computed based on CUDA_HOST_COMPILATION_CPP.
-      set_target_properties(${cuda_target}
-        PROPERTIES
-        LINKER_LANGUAGE ${CUDA_C_OR_CXX}
-        )
-  endif()
-  ####################
-  # END BLT CHANGE #
-  ####################
+  set_target_properties(${cuda_target}
+    PROPERTIES
+    LINKER_LANGUAGE ${CUDA_C_OR_CXX}
+  )
 
 endmacro()
 
@@ -1844,6 +1830,8 @@ macro(CUDA_ADD_EXECUTABLE cuda_target)
   ####################
   if (NOT CUDA_LINK_WITH_NVCC)
       CUDA_COMPUTE_SEPARABLE_COMPILATION_OBJECT_FILE_NAME(link_file ${cuda_target} "${${cuda_target}_SEPARABLE_COMPILATION_OBJECTS}")
+  else()
+     set(link_file "")
   endif()
   ####################
   # END BLT CHANGE   #
@@ -1872,7 +1860,7 @@ macro(CUDA_ADD_EXECUTABLE cuda_target)
       # We need to link with nvcc. Host linking prevents calling device methods in one library from kernels in another (yes, even with separable
       # compilation)
       string (REPLACE ";" " " LD_FLAGS_STR "${CUDA_NVCC_FLAGS}")
-      set (CMAKE_CUDA_LINK_EXECUTABLE  "${CUDA_NVCC_EXECUTABLE}  <FLAGS> <LINK_FLAGS> <OBJECTS>  -o <TARGET> <LINK_LIBRARIES>" CACHE PATH "" )
+      set (CMAKE_CUDA_LINK_EXECUTABLE  "${CUDA_NVCC_EXECUTABLE}  <FLAGS> <LINK_FLAGS> <OBJECTS>  -o <TARGET> <LINK_LIBRARIES>" CACHE STRING "" )
       set_target_properties(${cuda_target} PROPERTIES LINKER_LANGUAGE "CUDA")
       set_target_properties(${cuda_target} PROPERTIES LINK_FLAGS "${LD_FLAGS_STR}")
   else()


### PR DESCRIPTION
Fixes an issue where LINK_WITH_NVCC would cause device symbols in libraries to be invisible at final link time. Only affected libraries that provided device side functionality, callable from kernels. 