### PR TITLE
Remove gtest from all smoke tests except for gtest/gmock ones

### DIFF
--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -140,7 +140,7 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_smoke
                        SOURCES blt_cuda_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda gtest
+                       DEPENDS_ON cuda
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_smoke
@@ -149,7 +149,7 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_runtime_smoke
                        SOURCES blt_cuda_runtime_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda_runtime gtest
+                       DEPENDS_ON cuda_runtime
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_runtime_smoke
@@ -165,7 +165,7 @@ if (ENABLE_ROCM)
     blt_add_executable(NAME blt_rocm_smoke
                        SOURCES blt_rocm_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON rocm gtest
+                       DEPENDS_ON rocm
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_rocm_smoke
@@ -174,7 +174,7 @@ if (ENABLE_ROCM)
     blt_add_executable(NAME blt_rocm_runtime_smoke
                        SOURCES blt_rocm_runtime_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON rocm gtest
+                       DEPENDS_ON rocm
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_rocm_runtime_smoke

--- a/tests/smoke/blt_cuda_runtime_smoke.cpp
+++ b/tests/smoke/blt_cuda_runtime_smoke.cpp
@@ -51,11 +51,10 @@
 //-----------------------------------------------------------------------------
 
 #include <iostream>
-#include "gtest/gtest.h"
 #include "cuda_runtime_api.h"
 #include <stdio.h>
 
-TEST(blt_cuda_runtime_smoke, basic_cuda_runtime_example)
+int main()
 {
     int nDevices;
 
@@ -74,6 +73,6 @@ TEST(blt_cuda_runtime_smoke, basic_cuda_runtime_example)
                2.0*prop.memoryClockRate*(prop.memoryBusWidth/8)/1.0e6);
     }
 
-    EXPECT_TRUE( true );
+    return 0;
 }
 

--- a/tests/smoke/blt_cuda_smoke.cpp
+++ b/tests/smoke/blt_cuda_smoke.cpp
@@ -50,7 +50,6 @@
 //-----------------------------------------------------------------------------
 
 #include <iostream>
-#include "gtest/gtest.h"
 #include <stdio.h>
 
 __device__ const char *STR = "HELLO WORLD!";
@@ -61,14 +60,14 @@ __global__ void hello()
     printf("%c\n", STR[threadIdx.x % STR_LENGTH]);
 }
 
-TEST(blt_cuda_smoke,basic_cuda_example)
+int main()
 {
     int num_threads = STR_LENGTH;
     int num_blocks = 1;
     hello<<<num_blocks,num_threads>>>();
     cudaDeviceSynchronize();
     
-    EXPECT_TRUE( true );
+    return 0;
 }
 
 

--- a/tests/smoke/blt_rocm_runtime_smoke.cpp
+++ b/tests/smoke/blt_rocm_runtime_smoke.cpp
@@ -50,14 +50,11 @@
 
 #include <iostream>
 #include <vector>
-#include "gtest/gtest.h"
 #include "hc.hpp"
 
-
-
-TEST(blt_rocm_runtime_smoke, basic_rocm_runtime_example)
+int main()
 {
-using namespace hc;
+   using namespace hc;
    accelerator acc;
    std::vector<accelerator> accv = acc.get_all() ;
 
@@ -79,6 +76,6 @@ using namespace hc;
    std::cout << "Default Accelerator " << ": " << idefault << " : " ;
    std::wcout << acc.get_device_path() <<  std::endl;
 
-   EXPECT_TRUE( true );
+   return 0;
 }
 

--- a/tests/smoke/blt_rocm_smoke.cpp
+++ b/tests/smoke/blt_rocm_smoke.cpp
@@ -48,19 +48,16 @@
 ///
 //-----------------------------------------------------------------------------
 
-#include "gtest/gtest.h"
-
 #include <hc.hpp>
 #include <hc_printf.hpp>
 
-
-TEST(blt_rocm_smoke,basic_rocm_example)
+int main()
 {
-  hc::parallel_for_each(hc::extent<1>(1), []() [[hc]] {
-      hc::printf("Accelerator: Hello World!\n");
-  }).wait();
-    
-    EXPECT_TRUE( true );
+    hc::parallel_for_each(hc::extent<1>(1), []() [[hc]] {
+        hc::printf("Accelerator: Hello World!\n");
+    }).wait();
+
+    return 0;
 }
 
 


### PR DESCRIPTION
This caused build errors if you turn off gtest but still want ENABLE_TESTS to be on.