### PR TITLE
Bugfix for nvcc builds on blueos

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -189,7 +189,7 @@ if (ENABLE_CUDA)
    # --expt-extended-lambda is being used so cmake can get past the compiler check, 
    # but the CMAKE_CUDA_STANDARD stuff adds another definition in which breaks things. 
    # So we rip it out here, but it ends up being inserted in the final build rule by cmake. 
-   if (${CMAKE_CUDA_FLAGS})
+   if (CMAKE_CUDA_FLAGS)
       STRING(REPLACE "-std=c++11" " " CMAKE_CUDA_FLAGS ${CMAKE_CUDA_FLAGS} )
    endif()
 endif()


### PR DESCRIPTION
Otherwise, nvcc complains about redefining std:
```bash
nvcc fatal   : redefinition of argument 'std'
```

Looks like the previous attempt to resolve this no longer works (See #154).
