### PR TITLE
Feature/add windows host config

### DIFF
--- a/host-configs/llnl-sqa-uno-windows-msvc@15.cmake
+++ b/host-configs/llnl-sqa-uno-windows-msvc@15.cmake
@@ -1,0 +1,52 @@
+#------------------------------------------------------------------------------
+# Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-725085
+#
+# All rights reserved.
+#
+# This file is part of BLT.
+#
+# For additional details, please also read BLT/LICENSE.
+#------------------------------------------------------------------------------
+# Example host-config file for 'sqa-uno` windows machine at LLNL
+#------------------------------------------------------------------------------
+#
+# This file provides CMake with paths / details for:
+# The Microsoft Visual Studio 15 compiler + MPI
+#
+# Run the following from a build dir for a 32-bit configuration
+#   cmake -G "Visual Studio 15 2017"                         \
+#         -C ..\host-configs\llnl-sqa-uno-windows-msvc@15.cmake  \
+#         <path-to-blt-project>
+#
+# Run the following from a build dir for a 64-bit configuration
+#   cmake -G "Visual Studio 15 2017 Win64"                   \
+#         -C ..\host-configs\llnl-sqa-uno-windows-msvc@15.cmake  \
+#         <path-to-blt-project>
+#
+# Build the code from the command line as follows 
+# (use -m for parallel build in msbuild, if desired):
+#   cmake --build . --config {Release,Debug,RelWithDebInfo} [-- /m:8]
+#
+# Test the code as follows (use -j for parallel testing):
+#   ctest -j8 -C {Release,Debug,RelWithDebInfo}
+# 
+# Install the code from the command line as follows:
+#   cmake --build . --config {Release,Debug,RelWithDebInfo} --target install
+#
+#------------------------------------------------------------------------------
+
+# Set the HOME variable (%USERPROFILE% in Windows)
+string(REPLACE "\\" "/" HOME "$ENV{USERPROFILE}")
+
+# Setup MPI -- assumes MPI is installed in default location
+set(ENABLE_MPI ON CACHE BOOL "")
+set(MPI_HOME  "C:/Program Files/Microsoft HPC Pack 2008 R2" CACHE PATH "")
+set(MPI_GUESS_LIBRARY_NAME "MSMPI" CACHE STRING "")
+
+### Set some additional options
+set(ENABLE_FOLDERS ON CACHE BOOL "")
+set(ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "")

--- a/tests/internal/src/combine_static_library_test/CMakeLists.txt
+++ b/tests/internal/src/combine_static_library_test/CMakeLists.txt
@@ -1,8 +1,20 @@
- 
-if(NOT BLT_SOURCE_DIR)
-    set(BLT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../../..")
-endif()
-
+###############################################################################
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-725085
+#
+# All rights reserved.
+#
+# This file is part of BLT.
+#
+# For additional details, please also read BLT/LICENSE.
+###############################################################################
+#
+# Simple example that uses the blt_combine_static_libraries macro
+#
+###############################################################################
 
 blt_add_library( NAME Foo1
                  SOURCES Foo1.cpp
@@ -23,27 +35,28 @@ blt_combine_static_libraries( NAME FooStatic
                        LINK_POSTPEND ""
                      )
 
-blt_combine_static_libraries( NAME FooShared
+blt_add_executable( NAME blt_combine_static_libraries_static_smoke
+                    SOURCES blt_combine_static_libraries_static_smoke.cpp
+                    DEPENDS_ON FooStatic gtest
+                  )
+blt_add_test( NAME blt_combine_static_libraries_static_smoke
+              COMMAND blt_combine_static_libraries_static_smoke
+            )
+
+if(NOT WIN32)
+    blt_combine_static_libraries( NAME FooShared
                        SOURCE_LIBS Foo1 Foo23
                        LIB_TYPE SHARED
                        LINK_PREPEND ""
                        LINK_POSTPEND ""
                      )
 
-blt_add_executable( NAME blt_combine_static_libraries_static_smoke
-                    SOURCES blt_combine_static_libraries_static_smoke.cpp
-                    DEPENDS_ON FooStatic gtest
-                  )
-
-blt_add_test( NAME blt_combine_static_libraries_static_smoke
-              COMMAND blt_combine_static_libraries_static_smoke
-            )
-
-blt_add_executable( NAME blt_combine_static_libraries_shared_smoke
+    blt_add_executable( NAME blt_combine_static_libraries_shared_smoke
                     SOURCES blt_combine_static_libraries_shared_smoke.cpp
                     DEPENDS_ON FooStatic gtest
                   )
 
-blt_add_test( NAME blt_combine_static_libraries_shard_smoke
+    blt_add_test( NAME blt_combine_static_libraries_shared_smoke
               COMMAND blt_combine_static_libraries_shared_smoke
             )
+endif()


### PR DESCRIPTION
Adds a host-config for windows.  

~~Looks like we haven't been exercising the blt internal tests for a while.~~

There was a linker error in the shared version of the ``blt_combine_static_libraries`` example, so I temporarily disabled the example on Windows.  A future PR will address this.
> LINK : fatal error LNK1356: cannot find library `Foo1.lib' specified to be whole archived [<blt>\build-win\src\combine_static_library_test\FooShared.vcxproj]

UPDATE: The appveyor script was fine -- I missed a line where the internal tests are copied. 