### PR TITLE
Feature/print property list

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1021,7 +1021,7 @@ macro(blt_print_target_properties)
 
     set(_is_blt_registered_target FALSE)
     string(TOUPPER ${arg_TARGET} _target_upper)
-    if(BLT_${_target_upper}_INCLUDES)
+    if(BLT_${_target_upper}_IS_REGISTERED_LIBRARY)
         set(_is_blt_registered_target TRUE)
         message (STATUS "[${arg_TARGET} property] '${arg_TARGET}' is a blt_registered target")
     endif()

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1036,21 +1036,15 @@ macro(blt_print_target_properties)
         execute_process(COMMAND cmake --help-property-list OUTPUT_VARIABLE _property_list)
         string(REGEX REPLACE ";" "\\\\;" _property_list "${_property_list}")
         string(REGEX REPLACE "\n" ";" _property_list "${_property_list}")
-        list(FILTER _property_list EXCLUDE REGEX "^LOCATION$|^LOCATION_|_LOCATION$")
+        blt_filter_list(TO _property_list REGEX "^LOCATION$|^LOCATION_|_LOCATION$" OPERATION "exclude")
         list(REMOVE_DUPLICATES _property_list)   
 
         ## For interface targets, filter against whitelist of valid properties
         get_property(_targetType TARGET ${arg_TARGET} PROPERTY TYPE)
         if(${_targetType} STREQUAL "INTERFACE_LIBRARY")
-            set(_interface_property_list)
-            foreach(prop ${_property_list})
-                if(prop MATCHES "^(INTERFACE_|IMPORTED_LIBNAME_|COMPATIBLE_INTERFACE_|MAP_IMPORTED_CONFIG_)|^(NAME|TYPE|EXPORT_NAME)$")
-                    list(APPEND _interface_property_list ${prop})
-                endif()
-            endforeach()
-
-            set(_property_list ${_interface_property_list})
-            unset(_interface_property_list)
+            blt_filter_list(TO _property_list
+                            REGEX "^(INTERFACE_|IMPORTED_LIBNAME_|COMPATIBLE_INTERFACE_|MAP_IMPORTED_CONFIG_)|^(NAME|TYPE|EXPORT_NAME)$"
+                            OPERATION "include")
         endif()
 
         ## Print all such properties that have been SET
@@ -1066,8 +1060,8 @@ macro(blt_print_target_properties)
         unset(_propval)
     endif()
 
+    ## Additionally, output variables generated via blt_register_target of the form "BLT_<target>_*"
     if(_is_blt_registered_target)
-        ## Additionally, output variables generated via blt_register_target of the form "BLT_<target>_*"
         set(_target_prefix "BLT_${_target_upper}_")
 
         ## Filter to get variables of the form BLT_<target>_ and print

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -227,6 +227,7 @@ endmacro(blt_add_target_link_flags)
 ## discovering it on your system or building it yourself inside your project.
 ##
 ## Output variables (name = "foo"):
+##  BLT_FOO_IS_REGISTERED_LIBRARY
 ##  BLT_FOO_DEPENDS_ON
 ##  BLT_FOO_INCLUDES
 ##  BLT_FOO_TREAT_INCLUDES_AS_SYSTEM
@@ -252,6 +253,8 @@ macro(blt_register_library)
         "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
 
     string(TOUPPER ${arg_NAME} uppercase_name)
+
+    set(BLT_${uppercase_name}_IS_REGISTERED_LIBRARY TRUE CACHE BOOL "" FORCE)
 
     if( arg_DEPENDS_ON )
         set(BLT_${uppercase_name}_DEPENDS_ON ${arg_DEPENDS_ON} CACHE LIST "" FORCE)

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -314,3 +314,71 @@ macro(blt_update_project_sources)
     mark_as_advanced("${PROJECT_NAME}_ALL_SOURCES")
 
 endmacro(blt_update_project_sources)
+
+##------------------------------------------------------------------------------
+## blt_filter_list( TO <list_var> REGEX <string> OPERATION <string> )
+##
+## This macro provides the same functionality as cmake's list(FILTER )
+## which is only available in cmake-3.6+.
+##
+## The TO argument (required) is the name of a list variable.
+## The REGEX argument (required) is a string containing a regex.
+## The OPERATION argument (required) is a string that defines the macro's operation.
+## Supported values are "include" and "exclude"
+##
+## The filter is applied to the input list, which is modified in place.
+##------------------------------------------------------------------------------
+macro(blt_filter_list)
+
+    set(options )
+    set(singleValueArgs TO REGEX OPERATION)
+    set(multiValueArgs )
+
+    # Parse arguments
+    cmake_parse_arguments(arg "${options}" "${singleValueArgs}" 
+                            "${multiValueArgs}" ${ARGN} )
+
+    # Check arguments
+    if( NOT DEFINED arg_TO )
+        message(FATAL_ERROR "blt_filter_list macro requires a TO <list> argument")
+    endif()
+
+    if( NOT DEFINED arg_REGEX )
+        message(FATAL_ERROR "blt_filter_list macro requires a REGEX <string> argument")
+    endif()
+
+    # Ensure OPERATION argument is provided with value "include" or "exclude"
+    set(_exclude)
+    if( NOT DEFINED arg_OPERATION )
+        message(FATAL_ERROR "blt_filter_list macro requires a OPERATION <string> argument")
+    elseif(NOT arg_OPERATION MATCHES "^(include|exclude)$")
+        message(FATAL_ERROR "blt_filter_list macro's OPERATION argument must be either 'include' or 'exclude'")
+    else()
+        if(${arg_OPERATION} MATCHES "exclude")
+            set(_exclude TRUE)
+        else()
+            set(_exclude FALSE)
+        endif()
+    endif()
+
+    # Filter the list
+    set(_resultList)
+    foreach(elem ${${arg_TO}})
+        if(elem MATCHES ${arg_REGEX})
+            if(NOT ${_exclude})
+                list(APPEND _resultList ${elem})
+            endif()
+        else()
+            if(${_exclude})
+                list(APPEND _resultList ${elem})
+            endif()
+        endif()
+    endforeach()
+
+    # Copy result back to input list variable
+    set(${arg_TO} ${_resultList})
+
+    unset(_exclude)
+    unset(_resultList)
+endmacro(blt_filter_list)
+

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -184,3 +184,10 @@ if(ENABLE_GTEST)
     endif()
 
 endif() # endif ENABLE_GTEST
+
+message(STATUS "Exercising blt_print_target_properties macro on some targets and non-targets.")
+message(STATUS "")
+foreach(_target gtest example t_example_smoke not-a-target blt_header_only mpi)
+    blt_print_target_properties(TARGET ${_target})
+endforeach()
+


### PR DESCRIPTION
Added a new blt macro to print all cmake and blt properties for a given target, which should be a helpful diagnostic (e.g. for #184 )

Here is some sample output for a registered library that is also a target (gtest), a static library (example), a header only library (blt_header_only) and an executable (t_example_smoke):
```cmake
-- [gtest property] BINARY_DIR: <blt_root>/build-blt/blt/thirdparty_builtin/googletest-master-2018-02-01/googletest
-- [gtest property] BUILD_WITH_INSTALL_RPATH: OFF
-- [gtest property] COMPILE_FLAGS:      -Wall -Wextra  -Wall -Wshadow -Werror -DGTEST_HAS_PTHREAD=1 -fexceptions -Wextra -Wno-unused-parameter -Wno-missing-field-initializers
-- [gtest property] CXX_EXTENSIONS: OFF
-- [gtest property] CXX_STANDARD: 11
-- [gtest property] CXX_STANDARD_REQUIRED: ON
-- [gtest property] Fortran_MODULE_DIRECTORY: <blt_root>/build-blt/lib/fortran
-- [gtest property] IMPORTED: FALSE
-- [gtest property] INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include;<blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest
-- [gtest property] INSTALL_RPATH:
-- [gtest property] INSTALL_RPATH_USE_LINK_PATH: OFF
-- [gtest property] INTERFACE_INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [gtest property] INTERFACE_LINK_LIBRARIES: -pthread
-- [gtest property] INTERFACE_SYSTEM_INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [gtest property] LINK_LIBRARIES: -pthread
-- [gtest property] NAME: gtest
-- [gtest property] POSITION_INDEPENDENT_CODE: TRUE
-- [gtest property] RUNTIME_OUTPUT_DIRECTORY: <blt_root>/build-blt/bin
-- [gtest property] SKIP_BUILD_RPATH: OFF
-- [gtest property] SOURCES: src/gtest-all.cc
-- [gtest property] SOURCE_DIR: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest
-- [gtest property] TYPE: STATIC_LIBRARY
-- [gtest property] BLT_GTEST_COMPILE_FLAGS:
-- [gtest property] BLT_GTEST_DEFINES: -DGTEST_HAS_DEATH_TEST=0
-- [gtest property] BLT_GTEST_INCLUDES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [gtest property] BLT_GTEST_LIBRARIES: gtest_main;gtest;-pthread
-- [gtest property] BLT_GTEST_TREAT_INCLUDES_AS_SYSTEM: ON
-- [example property] BINARY_DIR: <blt_root>/build-blt
-- [example property] BUILD_WITH_INSTALL_RPATH: OFF
-- [example property] CXX_EXTENSIONS: OFF
-- [example property] CXX_STANDARD: 11
-- [example property] CXX_STANDARD_REQUIRED: ON
-- [example property] Fortran_MODULE_DIRECTORY: <blt_root>/build-blt/lib/fortran
-- [example property] IMPORTED: FALSE
-- [example property] INSTALL_RPATH:
-- [example property] INSTALL_RPATH_USE_LINK_PATH: OFF
-- [example property] NAME: example
-- [example property] POSITION_INDEPENDENT_CODE: TRUE
-- [example property] RUNTIME_OUTPUT_DIRECTORY: <blt_root>/build-blt/bin
-- [example property] SKIP_BUILD_RPATH: OFF
-- [example property] SOURCES: src/Example.cpp;src/Example.hpp
-- [example property] SOURCE_DIR: <blt_root>/tests/internal
-- [example property] TYPE: STATIC_LIBRARY
-- [t_example_smoke property] BINARY_DIR: <blt_root>/build-blt
-- [t_example_smoke property] BUILD_WITH_INSTALL_RPATH: OFF
-- [t_example_smoke property] COMPILE_DEFINITIONS: GTEST_HAS_DEATH_TEST=0
-- [t_example_smoke property] CXX_EXTENSIONS: OFF
-- [t_example_smoke property] CXX_STANDARD: 11
-- [t_example_smoke property] CXX_STANDARD_REQUIRED: ON
-- [t_example_smoke property] Fortran_MODULE_DIRECTORY: <blt_root>/build-blt/lib/fortran
-- [t_example_smoke property] IMPORTED: FALSE
-- [t_example_smoke property] INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [t_example_smoke property] INSTALL_RPATH:
-- [t_example_smoke property] INSTALL_RPATH_USE_LINK_PATH: OFF
-- [t_example_smoke property] INTERFACE_COMPILE_DEFINITIONS: GTEST_HAS_DEATH_TEST=0
-- [t_example_smoke property] INTERFACE_INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [t_example_smoke property] INTERFACE_LINK_LIBRARIES: example;gtest_main;gtest;-pthread
-- [t_example_smoke property] INTERFACE_SYSTEM_INCLUDE_DIRECTORIES: <blt_root>/thirdparty_builtin/googletest-master-2018-02-01/googletest/include
-- [t_example_smoke property] LINK_LIBRARIES: example;gtest_main;gtest;-pthread
-- [t_example_smoke property] NAME: t_example_smoke
-- [t_example_smoke property] POSITION_INDEPENDENT_CODE: TRUE
-- [t_example_smoke property] RUNTIME_OUTPUT_DIRECTORY: <blt_root>/build-blt/bin
-- [t_example_smoke property] SKIP_BUILD_RPATH: OFF
-- [t_example_smoke property] SOURCES: src/t_example_smoke.cpp
-- [t_example_smoke property] SOURCE_DIR: <blt_root>/tests/internal
-- [t_example_smoke property] TYPE: EXECUTABLE
-- [blt_header_only property] INTERFACE_SOURCES: $<BUILD_INTERFACE:<blt_root>/tests/internal/src/HeaderOnly.hpp>
-- [blt_header_only property] NAME: blt_header_only
-- [blt_header_only property] TYPE: INTERFACE_LIBRARY
```