### PR TITLE
Using generators so that OpenMP can be passed to nvcc compilers.

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -55,8 +55,11 @@ if(ENABLE_OPENMP)
     
     # register openmp with blt
     blt_register_library(NAME openmp
-                         COMPILE_FLAGS ${OpenMP_CXX_FLAGS} 
-                         LINK_FLAGS    ${OpenMP_CXX_FLAGS} )
+                         COMPILE_FLAGS
+                         $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
+                         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
+                         LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                         )
 endif()
 
 #####################################################

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -54,12 +54,19 @@ if(ENABLE_OPENMP)
     message(STATUS "OpenMP CXX Flags: ${OpenMP_CXX_FLAGS}")
     
     # register openmp with blt
-    blt_register_library(NAME openmp
-                         COMPILE_FLAGS
-                         $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
-                         $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
-                         LINK_FLAGS ${OpenMP_CXX_FLAGS}
-                         )
+    if(ENABLE_CUDA)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
+                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    else()
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    endif()
 endif()
 
 #####################################################

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -54,11 +54,26 @@ if(ENABLE_OPENMP)
     message(STATUS "OpenMP CXX Flags: ${OpenMP_CXX_FLAGS}")
     
     # register openmp with blt
-    if(ENABLE_CUDA)
+    if(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA AND ENABLE_FORTRAN)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<AND:$<NOT:$<COMPILE_LANGUAGE:CUDA>>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:${OpenMP_CXX_FLAGS}> 
+                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
+                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA)
         blt_register_library(NAME openmp
                              COMPILE_FLAGS
                              $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
                              $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_FORTRAN)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:${OpenMP_CXX_FLAGS}>
+                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
                              LINK_FLAGS ${OpenMP_CXX_FLAGS}
                              )
     else()

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -44,46 +44,6 @@
 # Setup compiler options
 ############################
 
-#################################################
-# OpenMP
-# (OpenMP support is provided by the compiler)
-#################################################
-message(STATUS "OpenMP Support is ${ENABLE_OPENMP}")
-if(ENABLE_OPENMP)
-    find_package(OpenMP REQUIRED)
-    message(STATUS "OpenMP CXX Flags: ${OpenMP_CXX_FLAGS}")
-    
-    # register openmp with blt
-    if(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA AND ENABLE_FORTRAN)
-        blt_register_library(NAME openmp
-                             COMPILE_FLAGS
-                             $<$<AND:$<NOT:$<COMPILE_LANGUAGE:CUDA>>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:${OpenMP_CXX_FLAGS}> 
-                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
-                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
-                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
-                             )
-    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA)
-        blt_register_library(NAME openmp
-                             COMPILE_FLAGS
-                             $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
-                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
-                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
-                             )
-    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_FORTRAN)
-        blt_register_library(NAME openmp
-                             COMPILE_FLAGS
-                             $<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:${OpenMP_CXX_FLAGS}>
-                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
-                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
-                             )
-    else()
-        blt_register_library(NAME openmp
-                             COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
-                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
-                             )
-    endif()
-endif()
-
 #####################################################
 # Set some variables to simplify determining compiler
 # Compiler string list from: 
@@ -143,6 +103,45 @@ else()
 endif()
 
 
+#################################################
+# OpenMP
+# (OpenMP support is provided by the compiler)
+#################################################
+message(STATUS "OpenMP Support is ${ENABLE_OPENMP}")
+if(ENABLE_OPENMP)
+    find_package(OpenMP REQUIRED)
+    message(STATUS "OpenMP CXX Flags: ${OpenMP_CXX_FLAGS}")
+    
+    # register openmp with blt
+    if(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA AND ENABLE_FORTRAN)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<AND:$<NOT:$<COMPILE_LANGUAGE:CUDA>>,$<NOT:$<COMPILE_LANGUAGE:CUDA>>>:${OpenMP_CXX_FLAGS}> 
+                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}>
+                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_CUDA)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${OpenMP_CXX_FLAGS}> 
+                             $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${OpenMP_CXX_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    elseif(NOT COMPILER_FAMILY_IS_MSVC AND ENABLE_FORTRAN)
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS
+                             $<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:${OpenMP_CXX_FLAGS}>
+                             $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}> 
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    else()
+        blt_register_library(NAME openmp
+                             COMPILE_FLAGS ${OpenMP_CXX_FLAGS}
+                             LINK_FLAGS ${OpenMP_CXX_FLAGS}
+                             )
+    endif()
+endif()
 
 
 ################################################


### PR DESCRIPTION
With a small change to the openMP flags in BLT, I'm able to use openMP can cuda at the same.  This change will unfortunately break compatibility with Visual Studio builds, but I'm not sure that OpenMP+CUDA was working for that case anyway.

