### PR TITLE
Cuda Separable Compilation 

### DIFF
--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -231,6 +231,12 @@ macro(blt_setup_cuda_source_properties)
                                  PROPERTIES
                                  LANGUAGE CUDA)
 
+    if (CUDA_SEPARABLE_COMPILATION)
+        set_source_files_properties( ${_cuda_sources}
+                                     PROPERTIES
+                                     CUDA_SEPARABLE_COMPILATION ON)
+    endif()
+
     #
     # for debugging, or if we add verbose BLT output
     #


### PR DESCRIPTION
When attempting to compile Comb for cuda I ran into an issue with cuda separable compilation on rzmanta.
Only one of my source files was actually being compiled with cuda separable compilation enabled.
I saw that BLT sets the CUDA_SEPARABLE_COMPILATION property on the build target but not the sources.
When I added the CUDA_SEPARABLE_COMPILATION property on each of the source files cmake enabled cuda separable compilation on each of the source files.