### PR TITLE
Bugfix/gtest cxxabi

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -107,8 +107,14 @@ endmacro(blt_list_append)
 ## The supplied target must be added via add_executable() or add_library() or
 ## with the corresponding blt_add_executable() and blt_add_library() macros.
 ##
-## Note, the list of target definitions *SHOULD NOT* include the "-D" flag. This
-## flag is added internally by cmake.
+## Note, the target definitions can either include or omit the "-D" characters. 
+## E.g. the following are all valid ways to add two compile definitions 
+## (A=1 and B) to target 'foo'
+##
+##   blt_add_target_definitions(TO foo TARGET_DEFINITIONS A=1 B)
+##   blt_add_target_definitions(TO foo TARGET_DEFINITIONS -DA=1 -DB)
+##   blt_add_target_definitions(TO foo TARGET_DEFINITIONS "A=1;-DB")
+##   blt_add_target_definitions(TO foo TARGET_DEFINITIONS " " -DA=1;B")
 ##------------------------------------------------------------------------------
 macro(blt_add_target_definitions)
 
@@ -120,16 +126,24 @@ macro(blt_add_target_definitions)
     cmake_parse_arguments(arg
         "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    get_target_property(defs ${arg_TO} COMPILE_DEFINITIONS)
-    if (defs MATCHES "NOTFOUND")
-        set(defs "")
+    ## check that the passed in parameter TO is actually a target
+    if(NOT TARGET ${arg_TO})
+        message(FATAL_ERROR "Target ${arg_TO} passed to blt_add_target_definitions is not a valid cmake target")    
     endif()
 
-    foreach (def ${defs} ${arg_TARGET_DEFINITIONS})
-        list(APPEND deflist ${def})
-    endforeach()
+    ## only add the flag if it is not empty
+    string(STRIP "${arg_TARGET_DEFINITIONS}" _strippedDefs)
+    if(NOT "${_strippedDefs}" STREQUAL "")
+        get_property(_targetType TARGET ${arg_TO} PROPERTY TYPE)
+        if(${_targetType} STREQUAL "INTERFACE_LIBRARY")
+            target_compile_definitions(${arg_TO} INTERFACE ${_strippedDefs})
+        else()
+            target_compile_definitions(${arg_TO} PUBLIC ${_strippedDefs})
+        endif()        
+    endif()
 
-    set_target_properties(${arg_TO} PROPERTIES COMPILE_DEFINITIONS "${deflist}")
+    unset(_targetType)
+    unset(_strippedFlags)
 
 endmacro(blt_add_target_definitions)
 

--- a/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
+++ b/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
@@ -1,0 +1,50 @@
+###########################################################
+# Example host-config file for the quartz cluster at LLNL
+###########################################################
+#
+# This file provides CMake with paths / details for:
+#  C,C++, & Fortran compilers + MPI
+# 
+###########################################################
+
+###########################################################
+# clang-4.0.0 / gfortran@4.9.3 compilers
+# Uses clang's 'libc++' instead of 'libstdc++'
+###########################################################
+
+set(CLANG_HOME "/usr/tce/packages/clang/clang-4.0.0")
+set(GNU_HOME "/usr/tce/packages/gcc/gcc-4.9.3")
+
+# c compiler
+set(CMAKE_C_COMPILER "${CLANG_HOME}/bin/clang" CACHE PATH "")
+
+# cpp compiler
+set(CMAKE_CXX_COMPILER "${CLANG_HOME}/bin/clang++" CACHE PATH "")
+
+# fortran support
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+
+# fortran compiler
+set(CMAKE_Fortran_COMPILER "${GNU_HOME}/bin/gfortran" CACHE PATH "")
+
+###########################################################
+# Extra flags
+###########################################################
+
+# Use clang's libc++ instead of libstdc++
+set(BLT_CXX_FLAGS "-stdlib=libc++" CACHE STRING "")
+set(gtest_defines "-DGTEST_HAS_CXXABI_H_=0" CACHE STRING "")
+
+###########################################################
+# MPI Support
+###########################################################
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0" CACHE PATH "")
+set(MPI_C_COMPILER       "${MPI_HOME}/bin/mpicc"   CACHE PATH "")
+set(MPI_CXX_COMPILER     "${MPI_HOME}/bin/mpicxx"  CACHE PATH "")
+set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpifort" CACHE PATH "")
+
+set(MPIEXEC              "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
+

--- a/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
+++ b/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
@@ -1,16 +1,26 @@
-###########################################################
+###############################################################################
+# Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-725085
+#
+# All rights reserved.
+#
+# This file is part of BLT.
+#
+# For additional details, please also read BLT/LICENSE.
+#
+#------------------------------------------------------------------------------
 # Example host-config file for the quartz cluster at LLNL
-###########################################################
+#------------------------------------------------------------------------------
 #
 # This file provides CMake with paths / details for:
 #  C,C++, & Fortran compilers + MPI
-# 
-###########################################################
-
-###########################################################
+#------------------------------------------------------------------------------
 # clang-4.0.0 / gfortran@4.9.3 compilers
 # Uses clang's 'libc++' instead of 'libstdc++'
-###########################################################
+###############################################################################
 
 set(CLANG_HOME "/usr/tce/packages/clang/clang-4.0.0")
 set(GNU_HOME "/usr/tce/packages/gcc/gcc-4.9.3")
@@ -27,17 +37,17 @@ set(ENABLE_FORTRAN ON CACHE BOOL "")
 # fortran compiler
 set(CMAKE_Fortran_COMPILER "${GNU_HOME}/bin/gfortran" CACHE PATH "")
 
-###########################################################
+#------------------------------------------------------------------------------
 # Extra flags
-###########################################################
+#------------------------------------------------------------------------------
 
 # Use clang's libc++ instead of libstdc++
 set(BLT_CXX_FLAGS "-stdlib=libc++" CACHE STRING "")
 set(gtest_defines "-DGTEST_HAS_CXXABI_H_=0" CACHE STRING "")
 
-###########################################################
+#------------------------------------------------------------------------------
 # MPI Support
-###########################################################
+#------------------------------------------------------------------------------
 set(ENABLE_MPI ON CACHE BOOL "")
 
 set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0" CACHE PATH "")

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -183,6 +183,32 @@ if(ENABLE_GTEST)
     if (ENABLE_CUDA)
         add_subdirectory(src/test_cuda_device_call_from_kernel)
     endif()
+    
+    ########################################################
+    # Tests blt_add_target_definitions macro
+    # Four variants of a test with a list of two definitions
+    ########################################################
+    set(_variant_1 A=1 B)         # neither use '-D'
+    set(_variant_2 -DA=1 -DB)     # both uses '-D'
+    set(_variant_3 "A=1;-DB")     # list passed in as string
+    set(_variant_4 " " "-DA=1;B") # list can contain empty strings
+    foreach(i RANGE 1 4)
+        set(_casename "_variant_${i}")
+        set(_testname "t_example_compile_definitions_test${_casename}")
+
+        blt_add_executable( 
+            NAME ${_testname}
+            SOURCES src/t_example_compile_definitions.cpp 
+            DEPENDS_ON gtest)
+
+        blt_add_target_definitions(
+            TO ${_testname}
+            TARGET_DEFINITIONS ${${_casename}})
+
+        blt_add_test( 
+            NAME ${_testname}
+            COMMAND ${_testname})
+    endforeach()
 
 endif() # endif ENABLE_GTEST
 

--- a/tests/internal/src/t_example_compile_definitions.cpp
+++ b/tests/internal/src/t_example_compile_definitions.cpp
@@ -1,0 +1,37 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-725085
+//
+// All rights reserved.
+//
+// This file is part of BLT.
+//
+// For additional details, please also read BLT/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+#include "gtest/gtest.h"
+
+//------------------------------------------------------------------------------
+
+// Simple test that expects symbol A to be defined as a non-zero number
+TEST(blt_compile_definitions,check_A_defined)
+{
+#if A
+    SUCCEED();
+#else
+    FAIL() << "Compiler define A was not defined as a non-zero number";
+#endif
+}
+
+// Simple test that expects symbol B to be defined
+TEST(blt_compile_definitions,check_B_defined)
+{
+#ifdef B
+    SUCCEED();
+#else
+    FAIL() << "Compiler define B was not defined";
+#endif
+}

--- a/tests/internal/src/t_example_compile_definitions.cpp
+++ b/tests/internal/src/t_example_compile_definitions.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2018, Lawrence Livermore National Security, LLC.
 //
 // Produced at the Lawrence Livermore National Laboratory
 //

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+# Copyright (c) 2017-2018, Lawrence Livermore National Security, LLC.
 #
 # Produced at the Lawrence Livermore National Laboratory
 #

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -45,17 +45,18 @@ set(_blt_tpl_targets) # tracks names of enabled tpl targets
 if(ENABLE_TESTS)
     include(CTest)
 
+    # Note: Users can pass extra compiler flags to gtest 
+    #       with the 'gtest_extra_flags' variable and extra 
+    #       compile definitions with the 'gtest_defines' variable.
+
     if(WIN32 AND BUILD_SHARED_LIBS)
-        add_definitions(-DGTEST_CREATE_SHARED_LIBRARY=1)
         list(APPEND gtest_defines "-DGTEST_LINKED_AS_SHARED_LIBRARY=1")
     endif()
 
     # Explicitly enable/disable death tests
     if(ENABLE_GTEST_DEATH_TESTS)
-        add_definitions(-DGTEST_HAS_DEATH_TEST=1)
         list(APPEND gtest_defines "-DGTEST_HAS_DEATH_TEST=1")
     else()
-        add_definitions(-DGTEST_HAS_DEATH_TEST=0)
         list(APPEND gtest_defines "-DGTEST_HAS_DEATH_TEST=0")
     endif()
 
@@ -84,7 +85,7 @@ if(ENABLE_TESTS)
     
     #
     # Guard of googletest w/ ENABLE_GTEST
-    # In BTL ENABLE_GTEST is also required when using ENABLE_GMOCK
+    # In BLT, ENABLE_GTEST is also required when using ENABLE_GMOCK
     #
     
     if(ENABLE_GTEST)
@@ -120,6 +121,8 @@ if(ENABLE_TESTS)
                              DEFINES  ${gtest_defines}
                              TREAT_INCLUDES_AS_SYSTEM ON
                              )
+                             
+        blt_add_target_definitions(TO gtest TARGET_DEFINITIONS ${gtest_defines})
 
         list(APPEND _blt_tpl_targets gtest gtest_main)
 

--- a/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h
+++ b/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h
@@ -982,10 +982,12 @@ using ::std::tuple_size;
 #endif
 
 // _LIBCPP_VERSION is defined by the libc++ library from the LLVM project.
-#if defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER))
-# define GTEST_HAS_CXXABI_H_ 1
-#else
-# define GTEST_HAS_CXXABI_H_ 0
+#if !defined(GTEST_HAS_CXXABI_H_)
+# if defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER))
+#  define GTEST_HAS_CXXABI_H_ 1
+# else
+#  define GTEST_HAS_CXXABI_H_ 0
+# endif
 #endif
 
 // A function level attribute to disable checking for use of uninitialized

--- a/thirdparty_builtin/patches/gtest-2018-02-01-override-GTEST_HAS_CXXABI_H_.patch
+++ b/thirdparty_builtin/patches/gtest-2018-02-01-override-GTEST_HAS_CXXABI_H_.patch
@@ -1,0 +1,38 @@
+From ead9f65a6a79177ed81da566e5e7bab8da976d14 Mon Sep 17 00:00:00 2001
+From: Kenneth Weiss <weiss27@llnl.gov>
+Date: Tue, 30 Oct 2018 14:34:46 -0700
+Subject: [PATCH] Patch for gtest: Adds guard around definition of
+ GTEST_HAS_CXXABI_H_
+
+Don't modify value if it is already defined.
+
+This change is already in gtest's master branch.
+See: https://github.com/google/googletest/blob/cf9d6344d28020b70c634c898fe798c862148668/googletest/include/gtest/internal/gtest-port.h#L1005-L1011
+---
+ .../googletest/include/gtest/internal/gtest-port.h             | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h b/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h
+index 1c4e1ba..f250efa 100755
+--- a/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h
++++ b/thirdparty_builtin/googletest-master-2018-02-01/googletest/include/gtest/internal/gtest-port.h
+@@ -982,10 +982,12 @@ using ::std::tuple_size;
+ #endif
+ 
+ // _LIBCPP_VERSION is defined by the libc++ library from the LLVM project.
+-#if defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER))
+-# define GTEST_HAS_CXXABI_H_ 1
+-#else
+-# define GTEST_HAS_CXXABI_H_ 0
++#if !defined(GTEST_HAS_CXXABI_H_)
++# if defined(__GLIBCXX__) || (defined(_LIBCPP_VERSION) && !defined(_MSC_VER))
++#  define GTEST_HAS_CXXABI_H_ 1
++# else
++#  define GTEST_HAS_CXXABI_H_ 0
++# endif
+ #endif
+ 
+ // A function level attribute to disable checking for use of uninitialized
+-- 
+2.8.3
+


### PR DESCRIPTION
* Patches gtest to allow users to override GTEST_HAS_CXXABI_H_
* Improves blt_add_target_definitions macro (partially fulfilling #181), with unit test
* Adds host-config for clang@4 using clang's ``libc++`` instead of ``libstdc++``