### PR TITLE
throw an error if cuda is enabled AND CMAKE_CUDA_HOST_COMPILER is not set

### DIFF
--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -46,8 +46,20 @@
 set (CMAKE_MODULE_PATH "${BLT_ROOT_DIR}/cmake/thirdparty;${CMAKE_MODULE_PATH}")
 
 
+
+
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.9.0" )
+
+  get_property(LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+
   if ( NOT CMAKE_CUDA_HOST_COMPILER )
+  
+    if("CUDA" IN_LIST LANGUAGES )
+      message( FATAL_ERROR 
+               "CUDA Enabled prior to setting CMAKE_CUDA_HOST_COMPILER. Please set \
+                CMAKE_CUDA_HOST_COMPILER prior to ENABLE_LANGUAGE(CUDA) or PROJECT(.. LANGUAGES CUDA) ")
+    endif()    
+  
     if ( CMAKE_CXX_COMPILER )
       set ( CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE STRING "" FORCE)
     else ()


### PR DESCRIPTION
If cuda was enabled via the ```project( myproj LANGUAGES CUDA )``` and ```CMAKE_CUDA_HOST_COMPILER``` is not set, then ```-ccbin=host/compiler``` will not be set. Throwing an error if this is the case.