### PR TITLE
Fix Issue 221 - Incorrect test for cuda_runtime.

### DIFF
--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -232,7 +232,7 @@ macro(blt_setup_cuda_target)
     endif()
     list(FIND arg_DEPENDS_ON "cuda_runtime" _cuda_runtime_index)
     set(_depends_on_cuda_runtime FALSE)
-    if(${_cuda_index} GREATER -1)
+    if(${_cuda_runtime_index} GREATER -1)
         set(_depends_on_cuda_runtime TRUE)
     endif()
 


### PR DESCRIPTION
In line 235 of BLTPrivateMacros.cmake in the definition of the
blt_setup_cuda_target macro, _cuda_index was being used in the test
for cuda_runtime instead of _cuda_runtime_index.  So targets depending
on cuda_runtime where not properly set up. In particular, executables
depending on cuda_runtime which wanted to link with nvcc would get link
error because the wer being linked with the host compiler instead of
nvcc.

Changing the test to use _cuda_runtime_index fixes the link errors
for the LEOS project.

Change test to use _cuda_runtime_index.  This fixed the link