### PR TITLE
Uncrustify changed heir --no-backup flag to not replace

### DIFF
--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -445,7 +445,7 @@ macro(blt_add_uncrustify_target)
     set(_generate_target TRUE)
 
     if(${arg_MODIFY_FILES})
-        set(MODIFY_FILES_FLAG "--no-backup")
+        set(MODIFY_FILES_FLAG --replace;--no-backup)
     else()
         set(MODIFY_FILES_FLAG "--check")
 


### PR DESCRIPTION
Uncrustify decided to be unhelpful and changed "--no-backup" to no longer replace the file it is modifying.  So it does nothing by itself (In fact if you call just no-backup it only creates a backup and does not modify the file). You now need "--replace --no-backup".  I tested this on 0.63 and 0.68.

I want my 3 hours back.