### PR TITLE
Fix in-source error message

### DIFF
--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -56,9 +56,10 @@ if (NOT BLT_LOADED)
     ################################
     # Fail if someone tries to config an in-source build.
     if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
-        message(FATAL_ERROR "In-source builds are not supported. Please remove "
-                            "CMakeCache.txt from the 'src' dir and configure an "
-                            "out-of-source build in another directory.")
+        message(FATAL_ERROR "In-source builds are not supported. Please remove the "
+                            "CMakeFiles directory and CMakeCache.txt from the 'src' "
+                            "dir and configure an out-of-source build in another "
+                            "directory.")
     endif()
 
     #################################


### PR DESCRIPTION
If you mistakenly run CMake in the ``src`` dir, you have to remove *both* ``CMakeLists.txt`` and ``CMakeFiles`` directory. This updates the error message to reflect that.