### PR TITLE
Let blt_add_target_link_flags accept a list

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -200,6 +200,8 @@ endmacro(blt_set_target_folder)
 ## blt_add_target_link_flags (TO <target> FLAGS [FOO [BAR ...]])
 ##
 ## Adds linker flags to a target by appending to the target's existing flags.
+##
+## The flags argument contains a list of linker flags to add to the target.
 ##------------------------------------------------------------------------------
 macro(blt_add_target_link_flags)
 
@@ -219,8 +221,10 @@ macro(blt_add_target_link_flags)
         endif()
         # append new flag
         set(_LINK_FLAGS "${arg_FLAGS} ${_LINK_FLAGS}")
+        # LINK_FLAGS property _must_ be a string
+        string (REPLACE ";" " " _LINK_FLAGS_STR "${_LINK_FLAGS}")
         set_target_properties(${arg_TO}
-                              PROPERTIES LINK_FLAGS ${_LINK_FLAGS} )
+                              PROPERTIES LINK_FLAGS "${_LINK_FLAGS_STR}")
     endif()
 
 endmacro(blt_add_target_link_flags)

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -221,7 +221,7 @@ macro(blt_add_target_link_flags)
         endif()
         # append new flag
         set(_LINK_FLAGS "${arg_FLAGS} ${_LINK_FLAGS}")
-        # LINK_FLAGS property _must_ be a string
+        # Convert _LINK_FLAGS from a CMake ;-list to a string
         string (REPLACE ";" " " _LINK_FLAGS_STR "${_LINK_FLAGS}")
         set_target_properties(${arg_TO}
                               PROPERTIES LINK_FLAGS "${_LINK_FLAGS_STR}")

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -201,7 +201,9 @@ endmacro(blt_set_target_folder)
 ##
 ## Adds linker flags to a target by appending to the target's existing flags.
 ##
-## The flags argument contains a list of linker flags to add to the target.
+## The flags argument contains a ;-list of linker flags to add to the target.
+## This list is converted to a string internally and any ; characters will be
+## removed.
 ##------------------------------------------------------------------------------
 macro(blt_add_target_link_flags)
 


### PR DESCRIPTION
This is an extension of the issues we observed in #234.

Without this PR, `blt_add_target_link_flags` and `blt_add_target_compile_flags` accept their `FLAGS` argument in two different forms. This makes both macros take a list.

Internally, CMake still requires the `LINK_OPTIONS` property be a string, so we parse the flags and remove ";" before adding them.