### PR TITLE
Fix clang-cuda support

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -200,6 +200,10 @@ endmacro(blt_set_target_folder)
 ## blt_add_target_link_flags (TO <target> FLAGS [FOO [BAR ...]])
 ##
 ## Adds linker flags to a target by appending to the target's existing flags.
+##
+## The flags argument contains a ;-list of linker flags to add to the target.
+## This list is converted to a string internally and any ; characters will be
+## removed.
 ##------------------------------------------------------------------------------
 macro(blt_add_target_link_flags)
 
@@ -219,8 +223,10 @@ macro(blt_add_target_link_flags)
         endif()
         # append new flag
         set(_LINK_FLAGS "${arg_FLAGS} ${_LINK_FLAGS}")
+        # Convert _LINK_FLAGS from a CMake ;-list to a string
+        string (REPLACE ";" " " _LINK_FLAGS_STR "${_LINK_FLAGS}")
         set_target_properties(${arg_TO}
-                              PROPERTIES LINK_FLAGS ${_LINK_FLAGS} )
+                              PROPERTIES LINK_FLAGS "${_LINK_FLAGS_STR}")
     endif()
 
 endmacro(blt_add_target_link_flags)

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -56,7 +56,10 @@ endif()
 ############################################################
 # Basics
 ############################################################
-enable_language(CUDA)
+# language check fails when using clang-cuda
+if (NOT ENABLE_CLANG_CUDA)
+  enable_language(CUDA)
+endif ()
 
 
 ############################################################
@@ -104,7 +107,7 @@ endif()
 
 set(_cuda_compile_flags " ")
 if (ENABLE_CLANG_CUDA)
-    set (_cuda_compile_flags "-x cuda --cuda-gpu-arch=${BLT_CLANG_CUDA_ARCH} --cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
+    set (_cuda_compile_flags "-x;cuda;--cuda-gpu-arch=${BLT_CLANG_CUDA_ARCH};--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
     message(STATUS "Clang CUDA Enabled. CUDA compile flags added: ${_cuda_compile_flags}")    
 endif()
 

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -107,7 +107,7 @@ endif()
 
 set(_cuda_compile_flags " ")
 if (ENABLE_CLANG_CUDA)
-    set (_cuda_compile_flags "-x;cuda;--cuda-gpu-arch=${BLT_CLANG_CUDA_ARCH};--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}")
+    set (_cuda_compile_flags -x cuda --cuda-gpu-arch=${BLT_CLANG_CUDA_ARCH} --cuda-path=${CUDA_TOOLKIT_ROOT_DIR})
     message(STATUS "Clang CUDA Enabled. CUDA compile flags added: ${_cuda_compile_flags}")    
 endif()
 


### PR DESCRIPTION
This PR guards the `enable_language(CUDA)` statement when CLANG_CUDA is enabled. This is required because nvcc cannot use newer versions of clang, so CMake's built in checks fail. 

It also updates the flags registered for `cuda` to be a list rather than a string.