### PR TITLE
Switch order of input file checks for Sphinx

### DIFF
--- a/cmake/SetupDocs.cmake
+++ b/cmake/SetupDocs.cmake
@@ -77,11 +77,10 @@ macro(blt_add_sphinx_target sphinx_target_name )
     # HTML output directory
     set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
 
-    # support both direct use of a conf.py file and a cmake config-d
-    # sphinx input file (conf.py.in). The cmake config-d input file is
+    # support both direct use of a conf.py file and a cmake-configured
+    # sphinx input file (conf.py.in). The cmake-configured input file is
     # preferred when both exist.
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in")
-
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in"
                        "${SPHINX_BUILD_DIR}/conf.py"
                        @ONLY)

--- a/cmake/SetupDocs.cmake
+++ b/cmake/SetupDocs.cmake
@@ -77,20 +77,11 @@ macro(blt_add_sphinx_target sphinx_target_name )
     # HTML output directory
     set(SPHINX_HTML_DIR "${CMAKE_CURRENT_BINARY_DIR}/html")
 
-    # support both direct use of a conf.py file and a cmake config-d 
-    # sphinx input file (conf.py.in)
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/conf.py")
-        add_custom_target(${sphinx_target_name}
-                          ${SPHINX_EXECUTABLE}
-                          -q -b html
-                          #-W disable warn on error for now, while our sphinx env is still in flux
-                          -d "${SPHINX_CACHE_DIR}"
-                          "${CMAKE_CURRENT_SOURCE_DIR}"
-                          "${SPHINX_HTML_DIR}"
-                          COMMENT "Building HTML documentation with Sphinx for ${sphinx_target_name} target"
-                          DEPENDS ${deps})
-    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in")
-        
+    # support both direct use of a conf.py file and a cmake config-d
+    # sphinx input file (conf.py.in). The cmake config-d input file is
+    # preferred when both exist.
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in")
+
         configure_file("${CMAKE_CURRENT_SOURCE_DIR}/conf.py.in"
                        "${SPHINX_BUILD_DIR}/conf.py"
                        @ONLY)
@@ -100,6 +91,16 @@ macro(blt_add_sphinx_target sphinx_target_name )
                           -q -b html
                           #-W disable warn on error for now, while our sphinx env is still in flux
                           -c "${SPHINX_BUILD_DIR}"
+                          -d "${SPHINX_CACHE_DIR}"
+                          "${CMAKE_CURRENT_SOURCE_DIR}"
+                          "${SPHINX_HTML_DIR}"
+                          COMMENT "Building HTML documentation with Sphinx for ${sphinx_target_name} target"
+                          DEPENDS ${deps})
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/conf.py")
+        add_custom_target(${sphinx_target_name}
+                          ${SPHINX_EXECUTABLE}
+                          -q -b html
+                          #-W disable warn on error for now, while our sphinx env is still in flux
                           -d "${SPHINX_CACHE_DIR}"
                           "${CMAKE_CURRENT_SOURCE_DIR}"
                           "${SPHINX_HTML_DIR}"


### PR DESCRIPTION
This allows us to support using both a local and ReadTheDocs build of Sphinx.

Read the docs runs both Doxygen and Sphinx in-place, while Umpire and CMake use separate build and source directories. Without this, Sphinx fails with the message:

```Exhale: the specified folder [.../Umpire/docs/doxygen/xml] does not exist.  Has Doxygen been run?```

However, the Doxygen files are (correctly) located in `${CMAKE_BINARY_DIR}/docs/doxygen/xml`. If we use a CMake-d `config.py` (`.in`) specifying the correct directory, we can work around the quirk in readthedocs when manually building them.