### PR TITLE
Sets the BLT_CXX_STD to  'c++11' in llnl-ray host-config

### DIFF
--- a/host-configs/llnl-ray-blue_os-clang-coral@2018.05.23.cmake
+++ b/host-configs/llnl-ray-blue_os-clang-coral@2018.05.23.cmake
@@ -21,6 +21,8 @@ set(CMAKE_CXX_COMPILER "${COMPILER_HOME}/bin/clang++" CACHE PATH "")
 
 set(ENABLE_FORTRAN OFF CACHE BOOL "")
 
+set(BLT_CXX_STD "c++11" CACHE STRING "")
+
 #------------------------------------------------------------------------------
 # MPI Support
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This is needed for lambda support in the cuda tests.