### PR TITLE
BUGFIX: fix behavior of blt_list_append w/out IF

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -48,7 +48,7 @@ macro(blt_list_append)
     endif()
 
     # append if
-    if ( ${arg_IF} )
+    if ( (${arg_IF}) OR (NOT DEFINED arg_IF) )
         list( APPEND ${arg_TO} ${arg_ELEMENTS} )
     endif()
 


### PR DESCRIPTION
The blt_list_append macro was not appending to the
list when an "IF" condition was not specified. "IF"
is an optional argument and the default behavior
when "IF" is not specified should be to append
to the list. Fixed that.

This commit fixes #247.