### PR TITLE
Bugfix for determining if blt_list_append should add the elements

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -47,10 +47,22 @@ macro(blt_list_append)
          message(FATAL_ERROR "blt_list_append() requires ELEMENTS to be specified" )
     endif()
 
+    # determine if we should add the elements to the list
+    set(_shouldAdd FALSE )
+    set(_listVar "${ARGN}")         # convert macro arguments to list variable
+    if("IF" IN_LIST _listVar)
+        set(_shouldAdd ${arg_IF})   # use IF condition, when present
+    else()
+        set(_shouldAdd TRUE)        # otherwise, always add the elements
+    endif()
+
     # append if
-    if ( (${arg_IF}) OR (NOT DEFINED arg_IF) )
+    if ( ${_shouldAdd} )
         list( APPEND ${arg_TO} ${arg_ELEMENTS} )
     endif()
+
+    unset(_shouldAdd)
+    unset(_listVar)
 
 endmacro(blt_list_append)
 

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -417,8 +417,8 @@ macro(blt_add_uncrustify_target)
             COMMAND ${UNCRUSTIFY_EXECUTABLE} --version
             OUTPUT_VARIABLE _version_str
             OUTPUT_STRIP_TRAILING_WHITESPACE )
-        string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?$" _uncrustify_version ${_version_str})
-        
+        string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?" _uncrustify_version ${_version_str})
+
         # Skip 'check' target if version is not high enough 
         if(_uncrustify_version VERSION_LESS 0.61)
             set(_generate_target FALSE)


### PR DESCRIPTION
Two bug fixes in this PR.

* The logic for determining the version of `uncrustify` was failing on my Windows machine, where the return string was `uncrustify 0.61.3-gf65394e` 
* Improves the logic in `blt_list_append` to support cases where the passed in `IF` argument corresponds to a dereferenced undefined variable.

Details for second case:
Assume that the variable `SOMELIB_FOUND` is not defined.
and we call 
```cmake 
blt_list_append(TO some_list ELEMENTS some_elems IF ${SOMELIB_FOUND})
```
The expectation is that this has the same semantics as 
```cmake
if(${SOMELIB_FOUND})
   list(APPEND some_list some_elems)
endif()
```

However, in this case, since `${SOMELIB_FOUND}` is `<UNDEFINED>`, 
`arg_IF` was also not defined. This caused `some_elems` to be incorrectly added to `some_list`.