### PR TITLE
Resolves toss3+clang+mpi regression

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   users strings to a list (3.13+) or list to a string (<3.13).  New property supports
   generator expressions so thats a plus.
 - Improved how all BLT MPI information is being merged together and reported to users.
+- Increased number of ranks in `blt_mpi_smoke` test to catch regression.
 
 ## 0.2.0 - Release date 2019-02-15
 

--- a/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
+++ b/host-configs/llnl-quartz-toss3-clang@4.0.0-libcxx.cmake
@@ -41,7 +41,7 @@ set(gtest_defines "-DGTEST_HAS_CXXABI_H_=0" CACHE STRING "")
 #------------------------------------------------------------------------------
 set(ENABLE_MPI ON CACHE BOOL "")
 
-set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0" CACHE PATH "")
+set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-4.0.0" CACHE PATH "")
 set(MPI_C_COMPILER       "${MPI_HOME}/bin/mpicc"   CACHE PATH "")
 set(MPI_CXX_COMPILER     "${MPI_HOME}/bin/mpicxx"  CACHE PATH "")
 set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpifort" CACHE PATH "")

--- a/host-configs/llnl-quartz-toss3-clang@6.0.0-static-analysis.cmake
+++ b/host-configs/llnl-quartz-toss3-clang@6.0.0-static-analysis.cmake
@@ -47,7 +47,7 @@ set(ENABLE_CLANGQUERY ON CACHE BOOL "")
 #------------------------------------------------------------------------------
 set(ENABLE_MPI ON CACHE BOOL "")
 
-set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-6.0.0" CACHE PATH "")
+set(MPI_HOME             "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-6.0.0" CACHE PATH "")
 set(MPI_C_COMPILER       "${MPI_HOME}/bin/mpicc"   CACHE PATH "")
 set(MPI_CXX_COMPILER     "${MPI_HOME}/bin/mpicxx"  CACHE PATH "")
 set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpifort" CACHE PATH "")

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -95,7 +95,7 @@ if (ENABLE_MPI)
 
     blt_add_test(NAME blt_mpi_smoke
                  COMMAND blt_mpi_smoke
-                 NUM_MPI_TASKS 2)
+                 NUM_MPI_TASKS 4)
 endif()
 
 ################


### PR DESCRIPTION
* Increases number of ranks in `blt_mpi_smoke` to 4. Resolves #263 
* Updates mvapich2 version from 2.2 to 2.3 in clang host-configs on LLNL's toss3.  This resolves a regression due to a recent update to mvapich2.