### PR TITLE
Add ability to override MPI variables

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 ### Added
 - Added support for C++17. Note: Neither XL or CMake's CUDA_STANDARD does not support
   C++17 (A BLT fatal error will occur).
+- Added ability to override all MPI variables: BLT_MPI_COMPILE_FLAGS,
+  BLT_MPI_INCLUDES, BLT_MPI_LIBRARIES, and BLT_MPI_LINK_FLAGS
 
 ### Changed
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,9 +42,9 @@ install:
   # Install CMake 3.9
   ############################################################################
   #- ps: Start-FileDownload 'https://cmake.org/files/v3.9/cmake-3.9.6-win64-x64.msi'
-  - ps: Start-FileDownload 'http://portal.nersc.gov/project/visit/cmake/cmake-3.9.6-win64-x64.msi'
-  - cmake-3.9.6-win64-x64.msi /passive
-  - set PATH=C:\Program Files\CMake\bin;%PATH%
+  #- ps: Start-FileDownload 'http://portal.nersc.gov/project/visit/cmake/cmake-3.9.6-win64-x64.msi'
+  #- cmake-3.9.6-win64-x64.msi /passive
+  #- set PATH=C:\Program Files\CMake\bin;%PATH%
   - cmake --version
   
 before_build:

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -18,10 +18,12 @@ else()
     endif()
 endif()
 
-set(_mpi_compile_flags)
-set(_mpi_includes)
-set(_mpi_libraries)
-set(_mpi_link_flags)
+set(_mpi_compile_flags )
+set(_mpi_includes )
+set(_mpi_libraries )
+set(_mpi_link_flags )
+
+message(STATUS "Enable FindMPI:  ${ENABLE_FIND_MPI}")
 
 if (ENABLE_FIND_MPI)
     find_package(MPI REQUIRED)
@@ -67,8 +69,24 @@ if (ENABLE_FIND_MPI)
     list(REMOVE_DUPLICATES _mpi_libraries)
 endif()
 
+# Allow users to override CMake's FindMPI
+if (BLT_MPI_COMPILE_FLAGS)
+    set(_mpi_compile_flags ${BLT_MPI_COMPILE_FLAGS})
+endif()
+if (BLT_MPI_INCLUDES)
+    set(_mpi_includes ${BLT_MPI_INCLUDES})
+endif()
+if (BLT_MPI_LIBRARIES)
+    set(_mpi_libraries ${BLT_MPI_LIBRARIES})
+endif()
+if (BLT_MPI_LINK_FLAGS)
+    set(_mpi_link_flags ${BLT_MPI_LINK_FLAGS})
+endif()
+
+
+# Output all MPI information
 message(STATUS "BLT MPI Compile Flags:  ${_mpi_compile_flags}")
-message(STATUS "BLT MPI Include Paths:   ${_mpi_includes}")
+message(STATUS "BLT MPI Include Paths:  ${_mpi_includes}")
 message(STATUS "BLT MPI Libraries:      ${_mpi_libraries}")
 message(STATUS "BLT MPI Link Flags:     ${_mpi_link_flags}")
 
@@ -84,7 +102,7 @@ if (ENABLE_FORTRAN)
     # Determine if we should use fortran mpif.h header or fortran mpi module
     find_path(mpif_path
         NAMES "mpif.h"
-        PATHS ${MPI_Fortran_INCLUDE_PATH}
+        PATHS ${_mpi_includes}
         NO_DEFAULT_PATH
         )
     

--- a/docs/creating_documentation.rst
+++ b/docs/creating_documentation.rst
@@ -1,44 +1,7 @@
-.. ###############################################################################
-.. # Copyright (c) 2017, Lawrence Livermore National Security, LLC.
-.. #
-.. # Produced at the Lawrence Livermore National Laboratory
-.. #
-.. # LLNL-CODE-725085
-.. #
-.. # All rights reserved.
-.. #
-.. # This file is part of BLT.
-.. #
-.. # For additional details, please also read BLT/LICENSE.
-.. #
-.. # Redistribution and use in source and binary forms, with or without
-.. # modification, are permitted provided that the following conditions are met:
-.. #
-.. # * Redistributions of source code must retain the above copyright notice,
-.. #   this list of conditions and the disclaimer below.
-.. #
-.. # * Redistributions in binary form must reproduce the above copyright notice,
-.. #   this list of conditions and the disclaimer (as noted below) in the
-.. #   documentation and/or other materials provided with the distribution.
-.. #
-.. # * Neither the name of the LLNS/LLNL nor the names of its contributors may
-.. #   be used to endorse or promote products derived from this software without
-.. #   specific prior written permission.
-.. #
-.. # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-.. # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-.. # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-.. # ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE LIVERMORE NATIONAL SECURITY,
-.. # LLC, THE U.S. DEPARTMENT OF ENERGY OR CONTRIBUTORS BE LIABLE FOR ANY
-.. # DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-.. # DAMAGES  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-.. # OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-.. # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-.. # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-.. # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-.. # POSSIBILITY OF SUCH DAMAGE.
-.. #
-.. ###############################################################################
+.. # Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+.. # other BLT Project Developers. See the top-level COPYRIGHT file for details
+.. # 
+.. # SPDX-License-Identifier: (BSD-3-Clause)
 
 Creating Documentation
 ======================

--- a/docs/creating_execs_and_libs.rst
+++ b/docs/creating_execs_and_libs.rst
@@ -8,14 +8,15 @@
 Creating Libraries and Executables
 ==================================
 
-In the previous section, we learned the basics about how to create a CMake project with BLT, 
-how to configure the project and how to build and test BLT's built-in third party libraries.  
+In the previous section, we learned the basics about how to create a CMake
+project with BLT, how to configure the project and how to build and test BLT's built-in third party libraries.  
 
 We now move on to creating libraries and executables
 using two of BLT's core macros: ``blt_add_library`` and ``blt_add_executable``.
 
-We begin with a simple executable that calculates pi by numerical integration (``example_1``).  
-We will then extract that code into a library, which we link into a new executable (``example_2``).
+We begin with a simple executable that calculates pi by numerical integration
+(``example_1``). We will then extract that code into a library, which we link
+into a new executable (``example_2``).
 
 
 Example 1: Basic executable
@@ -26,14 +27,17 @@ like ``blank_project`` in the previous section, we can start using BLT's macros.
 Creating an executable is as simple as calling the following macro:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt
+   :start-after: _blt_tutorial_example_executable_start
+   :end-before:  _blt_tutorial_example_executable_end
    :language: cmake
-   :lines: 28-29
 
-This tells CMake to create an executable named ``example_1`` with one source file (``example_1.cpp``).
+This tells CMake to create an executable named ``example_1`` with one source file
+(``example_1.cpp``).
 
-You can create this project yourself or you can run the already provided ``tutorial/calc_pi`` project.
-For ease of use, we have combined many examples into this one CMake project.  After running
-the following commands, you will create the executable ``<build dir>/bin/example_1``:
+You can create this project yourself or you can run the already provided
+``tutorial/calc_pi`` project. For ease of use, we have combined many examples
+into this one CMake project.  After running the following commands, you will
+create the executable ``<build dir>/bin/example_1``:
 
 .. code-block:: bash
 
@@ -45,56 +49,61 @@ the following commands, you will create the executable ``<build dir>/bin/example
 
 .. admonition:: blt_add_executable
    :class: hint
-   
-   This is one of the core macros that enables BLT to simplify our CMake-based project.
-   It unifies many CMake calls into one easy to use macro.  
-   ``blt_add_executable`` creates a CMake executable target with the 
-   given sources, sets the output directory to ``<build dir>/bin`` (unless overridden with the
-   macro parameter ``OUTPUT_DIR``) and handles internal and external dependencies in a greatly
-   simplified manner.  There will be more on that in the following section.
+   This is one of the core macros that enables BLT to simplify our CMake-based
+   project. It unifies many CMake calls into one easy to use macro.
+   ``blt_add_executable`` creates a CMake executable target with the
+   given sources, sets the output directory to ``<build dir>/bin``
+   (unless overridden with the macro parameter ``OUTPUT_DIR``) and handles
+   internal and external dependencies in a greatly simplified manner. There
+   will be more on that in the following section.
 
 
 Example 2: One library, one executable
 --------------------------------------
 
-This example is a bit more exciting.  This time we are creating a library that calculates
-pi and then linking that library into an executable.
+This example is a bit more exciting.  This time we are creating a library
+that calculates pi and then linking that library into an executable.
 
 First, we create the library with the following BLT code:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt
+   :start-after: _blt_tutorial_calcpi_library_start
+   :end-before:  _blt_tutorial_calcpi_library_end
    :language: cmake
-   :lines: 34-36
 
-Just like before, this creates a CMake library target that will get built to ``<build dir>/lib/libcalc_pi.a``.
+Just like before, this creates a CMake library target that will get built to
+``<build dir>/lib/libcalc_pi.a``.
 
-Next, we create an executable named ``example_2`` and link in the previously created library target:
+Next, we create an executable named ``example_2`` and link in the previously
+created library target:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt
+   :start-after: _blt_tutorial_calcpi_example2_start
+   :end-before:  _blt_tutorial_calcpi_example2_end
    :language: cmake
-   :lines: 39-41
 
-The ``DEPENDS_ON`` parameter properly links the previously defined library into this executable without any
-more work or CMake function calls.
+The ``DEPENDS_ON`` parameter properly links the previously defined library
+into this executable without any more work or CMake function calls.
 
 
 .. admonition:: blt_add_library
    :class: hint
 
-   This is another core BLT macro.  It creates a CMake library target and associates the
-   given sources and headers along with handling dependencies the same way as ``blt_add_executable``
-   does.  It also provides a few commonly used build options, such as overriding the output name of the
-   library and the output directory.  It defaults to building a static library unless you override it with
+   This is another core BLT macro. It creates a CMake library target and associates
+   the given sources and headers along with handling dependencies the same way as
+   ``blt_add_executable`` does. It also provides a few commonly used build options,
+   such as overriding the output name of the library and the output directory. 
+   It defaults to building a static library unless you override it with
    ``SHARED`` or with the global CMake option ``BUILD_SHARED_LIBS``.
 
 Object Libraries
 ----------------
 
-BLT has simplified the use of CMake object libraries through the ``blt_add_library`` macro.
-Object libraries are a collection of object files that are not linked or archived into
-a library.  They are used in other libraries or executables through the ``DEPENDS_ON``
-argument.  This is generally useful for combining smaller libraries into a larger library
-without the linker removing unused symbols in the larger library.
+BLT has simplified the use of CMake object libraries through the 
+``blt_add_library`` macro. Object libraries are a collection of object files
+that are not linked or archived into a library. They are used in other libraries
+or executables through the ``DEPENDS_ON`` macro argument. This is generally
+useful for combining smaller libraries into a larger library without the linker removing unused symbols in the larger library.
 
 .. code-block:: cmake
 
@@ -106,3 +115,8 @@ without the linker removing unused symbols in the larger library.
     blt_add_exectuble(NAME       helloWorld
                       SOURCES    main.cpp
                       DEPENDS_ON myObjectLibrary)
+
+.. note::
+  Due to record keeping on BLT's part to make object libraries as easy to use
+  as possible, you need to define object libraries before you use them
+  if you need their inheritable information to be correct.

--- a/docs/external_dependencies.rst
+++ b/docs/external_dependencies.rst
@@ -51,12 +51,15 @@ You have already seen one use of ``DEPENDS_ON`` for a BLT
 registered dependency in test_1:  ``gtest``
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt 
+   :start-after: _blt_tutorial_calcpi_test1_executable_start
+   :end-before:  _blt_tutorial_calcpi_test1_executable_end
    :language: cmake
-   :lines: 46-51
 
 
-``gtest`` is the name for the google test dependency in BLT registered via ``blt_register_library``.
-Even though google test is built-in and uses CMake, ``blt_register_library`` allows us to easily set defines needed by all dependent targets.
+``gtest`` is the name for the Google Test dependency in BLT registered via 
+``blt_register_library``. Even though Google Test is built-in and uses CMake,
+``blt_register_library`` allows us to easily set defines needed by all dependent
+targets.
 
 
 MPI Example
@@ -69,33 +72,46 @@ which uses MPI to parallelize the calculation over the integration intervals.
 To enable MPI, we set ``ENABLE_MPI``, ``MPI_C_COMPILER``, and ``MPI_CXX_COMPILER`` in our host config file. Here is a snippet with these settings for LLNL's Surface Cluster:
 
 .. literalinclude:: ../host-configs/llnl-surface-chaos_5_x86_64_ib-gcc@4.9.3.cmake
+   :start-after: _blt_tutorial_surface_mpi_config_start
+   :end-before:  _blt_tutorial_surface_mpi_config_end
    :language: cmake
-   :lines: 25-33
 
 
 Here, you can see how ``calc_pi_mpi`` and ``test_2`` use ``DEPENDS_ON``:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt 
+   :start-after: _blt_tutorial_calcpi_test2_executable_start
+   :end-before:  _blt_tutorial_calcpi_test2_executable_end
    :language: cmake
-   :lines: 59-74
 
 
 For MPI unit tests, you also need to specify the number of MPI Tasks
 to launch. We use the ``NUM_MPI_TASKS`` argument to ``blt_add_test`` macro.
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt 
+   :start-after: _blt_tutorial_calcpi_test2_test_start
+   :end-before:  _blt_tutorial_calcpi_test2_test_end
    :language: cmake
-   :lines: 71-73
 
 
-
-As mentioned in :ref:`UnitTesting`, google test provides a default ``main()`` driver
-that will execute all unit tests defined in the source. To test MPI code we need to create a main that initializes and finalizes MPI in addition to google test. ``test_2.cpp`` provides an example driver for MPI with google test.
-
+As mentioned in :ref:`UnitTesting`, google test provides a default ``main()``
+driver that will execute all unit tests defined in the source. To test MPI code,
+we need to create a main that initializes and finalizes MPI in addition to Google
+Test. ``test_2.cpp`` provides an example driver for MPI with Google Test.
 
 .. literalinclude:: tutorial/calc_pi/test_2.cpp
+   :start-after: _blt_tutorial_calcpi_test2_main_start
+   :end-before:  _blt_tutorial_calcpi_test2_main_end
    :language: cpp
-   :lines: 40-54
+
+.. note::
+  While we have tried to ensure that BLT chooses the correct setup information
+  for MPI, but there are several niche cases where the default behavior is
+  insufficient. We have provided several available override variables:
+  BLT_MPI_COMPILE_FLAGS, BLT_MPI_INCLUDES, BLT_MPI_LIBRARIES, and BLT_MPI_LINK_FLAGS.
+  BLT also has the variable ENABLE_FIND_MPI which turns off all CMake's FindMPI
+  logic and then uses the MPI wrapper directly when you provide them as the default
+  compilers.
 
 
 CUDA Example
@@ -104,19 +120,26 @@ CUDA Example
 Finally, ``test_3`` builds and tests the ``calc_pi_cuda`` library,
 which uses CUDA to parallelize the calculation over the integration intervals.
 
-To enable CUDA, we set ``ENABLE_CUDA``, ``CMAKE_CUDA_COMPILER``, and ``CUDA_TOOLKIT_ROOT_DIR`` in our host config file.  Also before enabling the CUDA language in CMake, you need to set ``CMAKE_CUDA_HOST_COMPILER`` in CMake 3.9+ or ``CUDA_HOST_COMPILER`` in previous versions.  If you do not call ``enable_language(CUDA)``, BLT will set the appropriate host compiler variable for you and enable the CUDA language.
+To enable CUDA, we set ``ENABLE_CUDA``, ``CMAKE_CUDA_COMPILER``, and
+``CUDA_TOOLKIT_ROOT_DIR`` in our host config file.  Also before enabling the
+CUDA language in CMake, you need to set ``CMAKE_CUDA_HOST_COMPILER`` in CMake 3.9+
+or ``CUDA_HOST_COMPILER`` in previous versions.  If you do not call 
+``enable_language(CUDA)``, BLT will set the appropriate host compiler variable
+for you and enable the CUDA language.
 
 Here is a snippet with these settings for LLNL's Surface Cluster:
 
 .. literalinclude:: ../host-configs/llnl-surface-chaos_5_x86_64_ib-gcc@4.9.3.cmake
+   :start-after: _blt_tutorial_surface_cuda_config_start
+   :end-before:  _blt_tutorial_surface_cuda_config_end
    :language: cmake
-   :lines: 39-44
 
 Here, you can see how ``calc_pi_cuda`` and ``test_3`` use ``DEPENDS_ON``:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt 
+   :start-after: _blt_tutorial_calcpi_cuda_start
+   :end-before:  _blt_tutorial_calcpi_cuda_end
    :language: cmake
-   :lines: 82-100
 
 The ``cuda`` dependency for ``calc_pi_cuda``  is a little special, 
 along with adding the normal CUDA library and headers to your library or executable,
@@ -271,5 +294,3 @@ And here is how to build and test the code on Ray:
   100% tests passed, 0 tests failed out of 7
   
   Total Test time (real) =   2.47 sec  
-
-

--- a/docs/external_dependencies.rst
+++ b/docs/external_dependencies.rst
@@ -106,7 +106,7 @@ Test. ``test_2.cpp`` provides an example driver for MPI with Google Test.
 
 .. note::
   While we have tried to ensure that BLT chooses the correct setup information
-  for MPI, but there are several niche cases where the default behavior is
+  for MPI, there are several niche cases where the default behavior is
   insufficient. We have provided several available override variables:
   BLT_MPI_COMPILE_FLAGS, BLT_MPI_INCLUDES, BLT_MPI_LIBRARIES, and BLT_MPI_LINK_FLAGS.
   BLT also has the variable ENABLE_FIND_MPI which turns off all CMake's FindMPI

--- a/docs/setup_blt.rst
+++ b/docs/setup_blt.rst
@@ -7,14 +7,16 @@ Setup BLT in your CMake Project
 =================================
 
 BLT is easy to include in your CMake project whether it is an existing project or
-you are starting from scratch. You simply pull it into your project using a CMake ``include()`` command.
+you are starting from scratch. You simply pull it into your project using a CMake
+``include()`` command.
 
 .. code-block:: cmake
 
     include(path/to/blt/SetupBLT.cmake)
 
 You can include the BLT source in your repository or pass the location 
-of BLT at CMake configure time through the optional ``BLT_SOURCE_DIR`` CMake variable. 
+of BLT at CMake configure time through the optional ``BLT_SOURCE_DIR``
+CMake variable. 
 
 There are two standard choices for including the BLT source in your repository:
 
@@ -66,12 +68,14 @@ However if your project is likely to be used by other projects.  The following
 is recommended:
 
 .. literalinclude:: tutorial/blank_project/CMakeLists.txt
+   :start-after: _blt_tutorial_include_blt_start
+   :end-before:  _blt_tutorial_include_blt_end
    :language: cmake
-   :lines: 14-32
 
 This is a robust way of setting up BLT and supports an optional external BLT source
 directory. This allows the use of a common BLT across large projects. There are some
-helpful error messages for if the BLT submodule is missing and the commands to solve it. 
+helpful error messages for if the BLT submodule is missing and the commands to solve
+it. 
 
 .. note::
   Throughout this tutorial, we pass the path to BLT using ``BLT_SOURCE_DIR`` since 
@@ -105,8 +109,8 @@ If you are using BLT outside of your project pass the location of BLT as follows
 Example: blank_project
 ----------------------
 
-The ``blank_project`` example is provided to show you some of BLT's built-in features.
-It demonstrates the bare minimum required for testing purposes.
+The ``blank_project`` example is provided to show you some of BLT's built-in
+features. It demonstrates the bare minimum required for testing purposes.
 
 Here is the entire CMakeLists.txt file for ``blank_project``:
 
@@ -182,16 +186,18 @@ If everything went correctly, you should have the following output:
 
     Total Test time (real) =   0.10 sec
 
-Note that the default options for ``blank_project`` only include a single test ``blt_gtest_smoke``.
-As we will see later on, BLT includes additional smoke tests that are activated when BLT is configured 
-with other options enabled, like Fortran, MPI, OpenMP and Cuda. 
+Note that the default options for ``blank_project`` only include a single test
+``blt_gtest_smoke``. As we will see later on, BLT includes additional smoke
+tests that are activated when BLT is configured with other options enabled,
+like Fortran, MPI, OpenMP, and Cuda. 
 
 Host-configs
 ------------
 
 To capture (and revision control) build options, third party library paths, etc.,
-we recommend using CMake's initial-cache file mechanism. 
-This feature allows you to pass a file to CMake that provides variables to bootstrap the configuration process. 
+we recommend using CMake's initial-cache file mechanism. This feature allows you
+to pass a file to CMake that provides variables to bootstrap the configuration
+process. 
 
 You can pass initial-cache files to cmake via the ``-C`` command line option.
 
@@ -200,20 +206,22 @@ You can pass initial-cache files to cmake via the ``-C`` command line option.
     cmake -C config_file.cmake
 
 
-We call these initial-cache files ``host-config`` files since we typically create a file for each platform
-or specific hosts, if necessary. 
+We call these initial-cache files ``host-config`` files since we typically create
+a file for each platform or specific hosts, if necessary. 
 
-
-These files use standard CMake commands. CMake ``set()`` commands need to specify ``CACHE`` as follows:
+These files use standard CMake commands. CMake ``set()`` commands need to specify
+``CACHE`` as follows:
 
 .. code-block:: cmake
 
     set(CMAKE_VARIABLE_NAME {VALUE} CACHE PATH "")
 
-Here is a snippet from a host-config file that specifies compiler details for using gcc 4.9.3 on LLNL's surface cluster. 
+Here is a snippet from a host-config file that specifies compiler details for
+using gcc 4.9.3 on LLNL's surface cluster. 
 
 .. literalinclude:: ../host-configs/llnl-surface-chaos_5_x86_64_ib-gcc@4.9.3.cmake
+   :start-after: _blt_tutorial_surface_compiler_config_start
+   :end-before:  _blt_tutorial_surface_compiler_config_end
    :language: cmake
-   :lines: 9-23
 
 

--- a/docs/tutorial/blank_project/CMakeLists.txt
+++ b/docs/tutorial/blank_project/CMakeLists.txt
@@ -11,6 +11,7 @@ project( blank )
 ###############################################################################
 # Setup BLT
 ###############################################################################
+# _blt_tutorial_include_blt_start
 if (DEFINED BLT_SOURCE_DIR)
     # Support having a shared BLT outside of the repository if given a BLT_SOURCE_DIR
     if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
@@ -21,7 +22,7 @@ else()
     set(BLT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/cmake/blt" CACHE PATH "")
     if (NOT EXISTS ${BLT_SOURCE_DIR}/SetupBLT.cmake)
         message(FATAL_ERROR
-            "The BLT is not present. "
+            "The BLT git submodule is not present. "
             "Either run the following two commands in your git repository: \n"
             "    git submodule init\n"
             "    git submodule update\n"
@@ -30,4 +31,4 @@ else()
 endif()
 
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
-
+# _blt_tutorial_include_blt_end

--- a/docs/tutorial/calc_pi/CMakeLists.txt
+++ b/docs/tutorial/calc_pi/CMakeLists.txt
@@ -1,5 +1,4 @@
 ###############################################################################
-# ****** WARNING - CHANGES IN THIS FILE NEED TO BE REFLECTED IN SPHINX DOCS
 # BLT Tutorial Example: Calc Pi.
 #
 ###############################################################################
@@ -21,33 +20,43 @@ include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 ###############################################################################
 # Example 1: Creating a simple executable.
 ###############################################################################
-blt_add_executable( NAME example_1
+# _blt_tutorial_example_executable_start
+blt_add_executable( NAME    example_1
                     SOURCES example_1.cpp )
+# _blt_tutorial_example_executable_end
 
 ###############################################################################
 # Example 2: Creating a library and an executable using our library.
 ###############################################################################
+# _blt_tutorial_calcpi_library_start
 blt_add_library( NAME    calc_pi
                  HEADERS calc_pi.hpp calc_pi_exports.h
                  SOURCES calc_pi.cpp )
+# _blt_tutorial_calcpi_library_end
 
 if(WIN32 AND BUILD_SHARED_LIBS)
     target_compile_definitions(calc_pi PUBLIC WIN32_SHARED_LIBS)
 endif()
 
+# _blt_tutorial_calcpi_example2_start 
 blt_add_executable( NAME       example_2
                     SOURCES    example_2.cpp 
                     DEPENDS_ON calc_pi)
+# _blt_tutorial_calcpi_example2_end
 
 ###############################################################################
 # Test 1: Creating an executable using gtest, using the executable via ctest.
 ###############################################################################
-blt_add_executable( NAME      test_1
+# _blt_tutorial_calcpi_test1_executable_start
+blt_add_executable( NAME       test_1
                     SOURCES    test_1.cpp 
                     DEPENDS_ON calc_pi gtest)
+# _blt_tutorial_calcpi_test1_executable_end
 
+# _blt_tutorial_calcpi_test1_test_start
 blt_add_test( NAME    test_1 
               COMMAND test_1)
+# _blt_tutorial_calcpi_test1_test_start
 
 ###############################################################################
 #
@@ -56,7 +65,7 @@ blt_add_test( NAME    test_1
 #
 ###############################################################################
 if(MPI_FOUND)
-
+# _blt_tutorial_calcpi_test2_executable_start
     blt_add_library( NAME       calc_pi_mpi
                      HEADERS    calc_pi_mpi.hpp calc_pi_mpi_exports.h
                      SOURCES    calc_pi_mpi.cpp 
@@ -66,13 +75,16 @@ if(MPI_FOUND)
         target_compile_definitions(calc_pi_mpi PUBLIC WIN32_SHARED_LIBS)
     endif()
 
-    blt_add_executable( NAME test_2
-                        SOURCES test_2.cpp 
+    blt_add_executable( NAME       test_2
+                        SOURCES    test_2.cpp 
                         DEPENDS_ON calc_pi calc_pi_mpi gtest)
+# _blt_tutorial_calcpi_test2_executable_end
 
-    blt_add_test( NAME test_2 
-                  COMMAND test_2
+# _blt_tutorial_calcpi_test2_test_start
+    blt_add_test( NAME          test_2 
+                  COMMAND       test_2
                   NUM_MPI_TASKS 2) # number of mpi tasks to use
+# _blt_tutorial_calcpi_test2_test_end
 endif()
 
 ###############################################################################
@@ -82,7 +94,7 @@ endif()
 #
 ###############################################################################
 if(CUDA_FOUND)
-
+# _blt_tutorial_calcpi_cuda_start
     # avoid warnings about sm_20 deprecated
     set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-arch=sm_30)
 	
@@ -103,6 +115,7 @@ if(CUDA_FOUND)
 
     blt_add_test( NAME    test_3
                   COMMAND test_3)
+# _blt_tutorial_calcpi_cuda_end
 endif()
 
 

--- a/docs/tutorial/calc_pi/test_1.cpp
+++ b/docs/tutorial/calc_pi/test_1.cpp
@@ -8,6 +8,7 @@
 // https://www.mcs.anl.gov/research/projects/mpi/usingmpi/examples-usingmpi/simplempi/cpi_c.html
 ///////////////////////////////////////////////////////////////////////////////
 
+// _blt_tutorial_calpi_test1_start
 #include <gtest/gtest.h>
 
 #include "calc_pi.hpp"
@@ -17,4 +18,4 @@ TEST(calc_pi, serial_example)
     double PI_REF = 3.141592653589793238462643;
     ASSERT_NEAR(calc_pi(1000),PI_REF,1e-6);
 }
-
+// _blt_tutorial_calpi_test1_end

--- a/docs/tutorial/calc_pi/test_2.cpp
+++ b/docs/tutorial/calc_pi/test_2.cpp
@@ -36,7 +36,7 @@ TEST(calc_pi_mpi, compare_mpi_serial)
     ASSERT_NEAR(calc_pi(1000),calc_pi_mpi(1000),1e-12);
 }
 
-
+// _blt_tutorial_calcpi_test2_main_start
 // main driver that allows using mpi w/ google test
 int main(int argc, char * argv[])
 {
@@ -52,4 +52,4 @@ int main(int argc, char * argv[])
 
     return result;
 }
-
+//_blt_tutorial_calcpi_test2_main_end

--- a/docs/unit_testing.rst
+++ b/docs/unit_testing.rst
@@ -9,24 +9,27 @@ Unit Testing
 ============
 
 BLT has a built-in copy of the 
-`Google Test framework (gtest) <https://github.com/google/googletest>`_ for C and C++ unit tests and the 
-`Fortran Unit Test Framework (FRUIT) <https://sourceforge.net/projects/fortranxunit/>`_ for Fortran unit tests. 
+`Google Test framework (gtest) <https://github.com/google/googletest>`_ for C
+and C++ unit tests and the 
+`Fortran Unit Test Framework (FRUIT) <https://sourceforge.net/projects/fortranxunit/>`_
+for Fortran unit tests.
 
+Each Google Test or FRUIT file may contain multiple tests and is compiled into
+its own executable that can be run directly or as a ``make`` target. 
 
-Each gtest or FRUIT file may contain multiple tests and is compiled into its own executable 
-that can be run directly or as a ``make`` target. 
-
-In this section, we give a brief overview of GTest and discuss how to add unit tests using the ``blt_add_test`` macro.
+In this section, we give a brief overview of GTest and discuss how to add unit
+tests using the ``blt_add_test`` macro.
 
 
 Configuring tests within BLT
 ----------------------------
 
-Unit testing in BLT is controlled by the ``ENABLE_TESTS`` cmake option and is on by default. 
+Unit testing in BLT is controlled by the ``ENABLE_TESTS`` cmake option and is on
+by default. 
 
 For additional configuration granularity, BLT provides configuration options 
-for the individual built-in unit testing libraries.  The following additional options are available
-when ``ENABLE_TESTS`` is on:
+for the individual built-in unit testing libraries.  The following additional
+options are available when ``ENABLE_TESTS`` is on:
 
 ``ENABLE_GTEST``
   Option to enable gtest (default: ``ON``).
@@ -81,9 +84,10 @@ pre-/post-processing operations. A ``main()`` routine provided in a test
 file should be placed at the end of the file in which it resides.
 
 
-Note that Google test is initialized before ``MPI_Init()`` is called. 
+Note that Google Test is initialized before ``MPI_Init()`` is called. 
 
-Other Google Test features, such as *fixtures* and *mock* objects (gmock) may be used as well. 
+Other Google Test features, such as *fixtures* and *mock* objects (gmock) may
+be used as well. 
 
 See the `Google Test Primer <https://github.com/google/googletest/blob/master/googletest/docs/Primer.md>`_ 
 for a discussion of Google Test concepts, how to use them, and a listing of 
@@ -159,8 +163,9 @@ Adding a BLT unit test
 ----------------------
 
 After writing a unit test, we add it to the project's build system 
-by first generating an executable for the test using the ``blt_add_executable()`` macro.
-We then register the test using the ``blt_add_test()`` macro.
+by first generating an executable for the test using the
+``blt_add_executable()`` macro. We then register the test using the
+``blt_add_test()`` macro.
 
 .. admonition:: blt_add_test
    :class: hint
@@ -182,22 +187,25 @@ and compares the result to :math:`\pi`, within a given tolerance (``1e-6``).
 Here is the test code:
 
 .. literalinclude:: tutorial/calc_pi/test_1.cpp
+   :start-after: _blt_tutorial_calpi_test1_start
+   :end-before:  _blt_tutorial_calpi_test1_end
    :language: cpp
-   :lines: 11-19
 
 To add this test to the build system, we first generate a test executable:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt
+   :start-after: _blt_tutorial_calcpi_test1_executable_start
+   :end-before:  _blt_tutorial_calcpi_test1_executable_end
    :language: cmake
-   :lines: 46-48
 
 Note that this test executable depends on two targets: ``calc_pi`` and ``gtest``.
 
 We then register this executable as a test:
 
 .. literalinclude:: tutorial/calc_pi/CMakeLists.txt
+   :start-after: _blt_tutorial_calcpi_test1_test_start
+   :end-before:  _blt_tutorial_calcpi_test1_test_end
    :language: cmake
-   :lines: 50-51
 
 .. Hide these for now until we bring into an example
 .. .. note::
@@ -229,7 +237,8 @@ you are modifying or adding code and need to understand how unit test details
 are working, for example.
 
 .. note:: 
-    You can pass arguments to ctest via the ``TEST_ARGS`` parameter, e.g. ``make test TEST_ARGS="..."``
+    You can pass arguments to ctest via the ``TEST_ARGS`` parameter, e.g.
+    ``make test TEST_ARGS="..."``
     Useful arguments include:
     
     -R

--- a/host-configs/llnl-surface-chaos_5_x86_64_ib-gcc@4.9.3.cmake
+++ b/host-configs/llnl-surface-chaos_5_x86_64_ib-gcc@4.9.3.cmake
@@ -14,22 +14,19 @@
 ###########################################################
 # gcc@4.9.3 compilers
 ###########################################################
-
-# c compiler
-set(CMAKE_C_COMPILER "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
-
-# cpp compiler
+# _blt_tutorial_surface_compiler_config_start
+set(CMAKE_C_COMPILER   "/usr/apps/gnu/4.9.3/bin/gcc" CACHE PATH "")
 set(CMAKE_CXX_COMPILER "/usr/apps/gnu/4.9.3/bin/g++" CACHE PATH "")
 
-# fortran support
+# Fortran support
 set(ENABLE_FORTRAN ON CACHE BOOL "")
-
-# fortran compiler
 set(CMAKE_Fortran_COMPILER "/usr/apps/gnu/4.9.3/bin/gfortran" CACHE PATH "")
+# _blt_tutorial_surface_compiler_config_end
 
 ###########################################################
 # MPI Support
 ###########################################################
+# _blt_tutorial_surface_mpi_config_start
 set(ENABLE_MPI ON CACHE BOOL "")
 
 set(MPI_C_COMPILER "/usr/local/tools/mvapich2-gnu-2.0/bin/mpicc" CACHE PATH "")
@@ -37,14 +34,17 @@ set(MPI_C_COMPILER "/usr/local/tools/mvapich2-gnu-2.0/bin/mpicc" CACHE PATH "")
 set(MPI_CXX_COMPILER "/usr/local/tools/mvapich2-gnu-2.0/bin/mpicc" CACHE PATH "")
 
 set(MPI_Fortran_COMPILER "/usr/local/tools/mvapich2-gnu-2.0/bin/mpif90" CACHE PATH "")
+# _blt_tutorial_surface_mpi_config_end
 
 ###########################################################
 # CUDA support
 ###########################################################
+# _blt_tutorial_surface_cuda_config_start
 set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CUDA_TOOLKIT_ROOT_DIR "/opt/cudatoolkit-8.0" CACHE PATH "")
 set(CMAKE_CUDA_COMPILER "/opt/cudatoolkit-8.0/bin/nvcc" CACHE PATH "")
 set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE PATH "")
 set(CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "")
+# _blt_tutorial_surface_cuda_config_start
 


### PR DESCRIPTION
Provides a way to override default MPI behavior in a clean way.
Also converts any code snippets in the tutorial from line numbers (always breaking) to tags. #262 