### PR TITLE
Handle FindMPI 3.10+

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,9 +14,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   C++17 (A BLT fatal error will occur).
 - Added ability to override all MPI variables: BLT_MPI_COMPILE_FLAGS,
   BLT_MPI_INCLUDES, BLT_MPI_LIBRARIES, and BLT_MPI_LINK_FLAGS
+- blt_list_remove_duplicates(): macro for removing duplicates from a list that
+  doesn't error on empty lists.
 
 ### Changed
-
+- Handle CMake 3.10+ changing all the FindMPI output variables.
 - BLT_CXX_STD is no longer defined to "c++11" by default. If undefined, BLT will
   not try and add any C++ standard flags.
 - Handle FindMPI variable MPIEXEC changed to MPIEXEC_EXECUTABLE in CMake 3.10+.

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -68,6 +68,42 @@ endmacro(blt_list_append)
 
 
 ##------------------------------------------------------------------------------
+## blt_list_remove_duplicates( TO <list> )
+##
+## Removes duplicate elements from the given TO list.
+##
+## This macro is essentially a wrapper around CMake's `list(REMOVE_DUPLICATES ...)`
+## command but doesn't throw an error if the list is empty or not defined.
+##
+## Usage Example:
+##
+##  set(mylist A B A)
+##  blt_list_remove_duplicates( TO mylist )
+##
+##------------------------------------------------------------------------------
+macro(blt_list_remove_duplicates)
+
+    set(options)
+    set(singleValueArgs TO )
+    set(multiValueArgs )
+
+    # parse macro arguments
+    cmake_parse_arguments(arg
+        "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+     # sanity checks
+    if( NOT DEFINED arg_TO )
+        message(FATAL_ERROR "blt_list_append() requires a TO <list> argument")
+    endif()
+
+    if ( ${arg_TO} )
+        list(REMOVE_DUPLICATES ${arg_TO} )
+    endif()
+
+endmacro(blt_list_remove_duplicates)
+
+
+##------------------------------------------------------------------------------
 ## blt_add_target_definitions(TO <target> TARGET_DEFINITIONS [FOO [BAR ...]])
 ##
 ## Adds pre-processor definitions to the given target.
@@ -1140,8 +1176,8 @@ macro(blt_combine_static_libraries)
     endforeach()
     
     # Remove duplicates from the includes
-    list( REMOVE_DUPLICATES interface_include_directories )
-    list( REMOVE_DUPLICATES interface_system_include_directories )
+    blt_list_remove_duplicates(TO interface_include_directories )
+    blt_list_remove_duplicates(TO interface_system_include_directories )
 
     # Remove any system includes from the regular includes
     foreach( include_dir ${interface_system_include_directories} )
@@ -1222,7 +1258,7 @@ macro(blt_print_target_properties)
         string(REGEX REPLACE ";" "\\\\;" _property_list "${_property_list}")
         string(REGEX REPLACE "\n" ";" _property_list "${_property_list}")
         blt_filter_list(TO _property_list REGEX "^LOCATION$|^LOCATION_|_LOCATION$" OPERATION "exclude")
-        list(REMOVE_DUPLICATES _property_list)   
+        blt_list_remove_duplicates(TO _property_list)   
 
         ## For interface targets, filter against whitelist of valid properties
         get_property(_targetType TARGET ${arg_TARGET} PROPERTY TYPE)

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -7,15 +7,27 @@
 # MPI
 ################################
 
-# Handle CMake changing MPIEXEC to MPIEXEC_EXECUTABLE
+# Handle CMake changing FindMPI variables
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
     if (NOT MPIEXEC_EXECUTABLE AND MPIEXEC)
         set(MPIEXEC_EXECUTABLE ${MPIEXEC} CACHE PATH "" FORCE)
     endif()
+
+    set(_mpi_includes_suffix "INCLUDE_DIRS")
+    set(_mpi_compile_flags_suffix "COMPILE_OPTIONS")
+    set(_mpi_c_library_variable "MPI_mpi_LIBRARY")
+    set(_mpi_cxx_library_variable "MPI_mpicxx_LIBRARY")
+    set(_mpi_fortran_library_variable "MPI_mpifort_LIBRARY")
 else()
     if (MPIEXEC_EXECUTABLE AND NOT MPIEXEC)
         set(MPIEXEC ${MPIEXEC_EXECUTABLE} CACHE PATH "" FORCE)
     endif()
+
+    set(_mpi_includes_suffix "INCLUDE_PATH")
+    set(_mpi_compile_flags_suffix "COMPILE_FLAGS")
+    set(_mpi_c_library_variable "MPI_C_LIBRARIES")
+    set(_mpi_cxx_library_variable "MPI_CXX_LIBRARIES")
+    set(_mpi_fortran_library_variable "MPI_Fortran_LIBRARIES")
 endif()
 
 set(_mpi_compile_flags )
@@ -32,22 +44,25 @@ if (ENABLE_FIND_MPI)
     # Merge found MPI info and remove duplication
     #-------------------
     # Compile flags
-    list(APPEND _mpi_compile_flags ${MPI_C_COMPILE_FLAGS})
-    if (NOT "${MPI_C_COMPILE_FLAGS}" STREQUAL "${MPI_CXX_COMPILE_FLAGS}")
-        list(APPEND _mpi_compile_flags ${MPI_CXX_LINK_FLAGS})
+    list(APPEND _mpi_compile_flags ${MPI_C_${_mpi_compile_flags_suffix}})
+    if (NOT "${MPI_C_${_mpi_compile_flags_suffix}}" STREQUAL
+             "${MPI_CXX_${_mpi_compile_flags_suffix}}")
+        list(APPEND _mpi_compile_flags ${MPI_CXX_${_mpi_compile_flags_suffix}})
     endif()
     if (ENABLE_FORTRAN)
-        if (NOT "${MPI_C_COMPILE_FLAGS}" STREQUAL "${MPI_Fortran_COMPILE_FLAGS}")
-            list(APPEND _mpi_compile_flags ${MPI_CXX__COMPILE_FLAGS})
+        if (NOT "${MPI_C_${_mpi_compile_flags_suffix}}" STREQUAL
+                "${MPI_Fortran_${_mpi_compile_flags_suffix}}")
+            list(APPEND _mpi_compile_flags ${MPI_Fortran_${_mpi_compile_flags_suffix}})
         endif()
     endif()
 
     # Include paths
-    list(APPEND _mpi_includes ${MPI_C_INCLUDE_PATH} ${MPI_CXX_INCLUDE_PATH})
+    list(APPEND _mpi_includes ${MPI_C_${_mpi_includes_suffix}}
+                              ${MPI_CXX_${_mpi_includes_suffix}})
     if (ENABLE_FORTRAN)
-        list(APPEND _mpi_includes ${MPI_Fortran_INCLUDE_PATH})
+        list(APPEND _mpi_includes ${MPI_Fortran_${_mpi_includes_suffix}})
     endif()
-    list(REMOVE_DUPLICATES _mpi_includes)
+    blt_list_remove_duplicates(TO _mpi_includes)
 
     # Link flags
     set(_mpi_link_flags ${MPI_C_LINK_FLAGS})
@@ -61,12 +76,12 @@ if (ENABLE_FIND_MPI)
     endif()
 
     # Libraries
-    set(_mpi_libraries ${MPI_C_LIBRARIES}
-                       ${MPI_CXX_LIBRARIES})
+    set(_mpi_libraries ${${_mpi_c_library_variable}}
+                       ${${_mpi_cxx_library_variable}})
     if (ENABLE_FORTRAN)
-        list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
+        list(APPEND _mpi_libraries ${${_mpi_fortran_library_variable}})
     endif()
-    list(REMOVE_DUPLICATES _mpi_libraries)
+    blt_list_remove_duplicates(TO _mpi_libraries)
 endif()
 
 # Allow users to override CMake's FindMPI
@@ -122,5 +137,3 @@ blt_register_library(NAME          mpi
                      LIBRARIES     ${_mpi_libraries}
                      COMPILE_FLAGS ${_mpi_compile_flags}
                      LINK_FLAGS    ${_mpi_link_flags} )
-
-

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -7,7 +7,7 @@
 # MPI
 ################################
 
-# CMake changed the output variables that we use from Find(MPI)
+# CMake changed some of the output variables that we use from Find(MPI)
 # in 3.10+.  This toggles the variables based on the CMake version
 # the user is running.
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
@@ -17,9 +17,6 @@ if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
 
     set(_mpi_includes_suffix "INCLUDE_DIRS")
     set(_mpi_compile_flags_suffix "COMPILE_OPTIONS")
-    set(_mpi_c_library_variable "MPI_mpi_LIBRARY")
-    set(_mpi_cxx_library_variable "MPI_mpicxx_LIBRARY")
-    set(_mpi_fortran_library_variable "MPI_mpifort_LIBRARY")
 else()
     if (MPIEXEC_EXECUTABLE AND NOT MPIEXEC)
         set(MPIEXEC ${MPIEXEC_EXECUTABLE} CACHE PATH "" FORCE)
@@ -27,9 +24,6 @@ else()
 
     set(_mpi_includes_suffix "INCLUDE_PATH")
     set(_mpi_compile_flags_suffix "COMPILE_FLAGS")
-    set(_mpi_c_library_variable "MPI_C_LIBRARIES")
-    set(_mpi_cxx_library_variable "MPI_CXX_LIBRARIES")
-    set(_mpi_fortran_library_variable "MPI_Fortran_LIBRARIES")
 endif()
 
 set(_mpi_compile_flags )
@@ -78,10 +72,9 @@ if (ENABLE_FIND_MPI)
     endif()
 
     # Libraries
-    set(_mpi_libraries ${${_mpi_c_library_variable}}
-                       ${${_mpi_cxx_library_variable}})
+    set(_mpi_libraries ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
     if (ENABLE_FORTRAN)
-        list(APPEND _mpi_libraries ${${_mpi_fortran_library_variable}})
+        list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
     endif()
     blt_list_remove_duplicates(TO _mpi_libraries)
 endif()

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -7,7 +7,9 @@
 # MPI
 ################################
 
-# Handle CMake changing FindMPI variables
+# CMake changed the output variables that we use from Find(MPI)
+# in 3.10+.  This toggles the variables based on the CMake version
+# the user is running.
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
     if (NOT MPIEXEC_EXECUTABLE AND MPIEXEC)
         set(MPIEXEC_EXECUTABLE ${MPIEXEC} CACHE PATH "" FORCE)


### PR DESCRIPTION
CMake changed all of the output variable names from FindMPI.cmake.  This PR handles this and no change is required on the users end.  Yay for BLT. For example:

* MPI_C_INCLUDE_PATH to MPI_C_INCLUDE_DIRS
* MPI_C_COMPILE_FLAGS to MPI_C_COMPILE_OPTIONS

On a side note, this exposed that list(REMOVE_DUPLICATES ...) errors on an empty list.  So I added blt_list_remove_duplicates() which can.