### PR TITLE
Update SetupMPI.cmake

### DIFF
--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -81,9 +81,9 @@ if (ENABLE_FIND_MPI)
     # Make nvcc work with MPI when compiling RAJA MPI+CUDA nvcc.
     # It fixes nvcc compilation for options like -pthread.
     if (ENABLE_CUDA)
-        if (NOT "${_mpi_compile_flags}" STREQUAL "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
-            set (_mpi_compile_flags "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
-        endif()
+        set (_mpi_compile_flags 
+             "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>"
+             "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_mpi_compile_flags}>")
     endif()
 endif()
 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -78,7 +78,7 @@ if (ENABLE_FIND_MPI)
     endif()
     blt_list_remove_duplicates(TO _mpi_libraries)
     
-    # Make nvcc work with MPI when compiling RAJA MPI+CUDA nvcc.
+    # Make nvcc work with MPI when compiling MPI+CUDA nvcc.
     # It fixes nvcc compilation for options like -pthread.
     if (ENABLE_CUDA)
         set (_mpi_compile_flags 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -80,7 +80,7 @@ if (ENABLE_FIND_MPI)
     
     # Make nvcc work with MPI when compiling RAJA MPI+CUDA nvcc.
     # It fixes nvcc compilation for options like -pthread.
-    if (RAJA_LOADED AND ENABLE_CUDA)
+    if (ENABLE_CUDA)
         if (NOT "${_mpi_compile_flags}" STREQUAL "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
             set (_mpi_compile_flags "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
         endif()

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -77,6 +77,14 @@ if (ENABLE_FIND_MPI)
         list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
     endif()
     blt_list_remove_duplicates(TO _mpi_libraries)
+    
+    # Make nvcc work with MPI when compiling RAJA MPI+CUDA nvcc.
+    # It fixes nvcc compilation for options like -pthread.
+    if (RAJA_LOADED AND ENABLE_CUDA)
+        if (NOT "${_mpi_compile_flags}" STREQUAL "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
+            set (_mpi_compile_flags "$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_mpi_compile_flags}>")
+        endif()
+    endif()
 endif()
 
 # Allow users to override CMake's FindMPI


### PR DESCRIPTION
With this fix MPI+CUDA RAJA compilation works on a machine with CMAKE 3.10.2, multicore and not multiprocessor, using MPI pthreads.