### PR TITLE
Just punt on generator expressions

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,10 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Improved how all BLT MPI information is being merged together and reported to users.
 - Increased number of ranks in `blt_mpi_smoke` test to catch regression.
 
+### Fixed
+- Do not attempt to split sources on generator expression
+
+
 ## 0.2.0 - Release date 2019-02-15
 
 ### Added

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,9 +29,14 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   generator expressions so thats a plus.
 - Improved how all BLT MPI information is being merged together and reported to users.
 - Increased number of ranks in `blt_mpi_smoke` test to catch regression.
+- blt_split_source_list_by_language now supports non-BLT object libraries and errors
+  out when any other generator expression is given in source list.  This is to avoid
+  very bad side effects of not being able to set source properties on anything
+  inside the generator expression.  This is because BLT cannot evaluate them.
 
 ### Fixed
-- Do not attempt to split sources on generator expression
+- Error out with better message when empty file extensions is hit in
+  blt_split_source_list_by_language.
 
 
 ## 0.2.0 - Release date 2019-02-15

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -463,6 +463,12 @@ macro(blt_split_source_list_by_language)
 
     # Generate source lists based on language
     foreach(_file ${arg_SOURCES})
+        # Assume the user knows what they are doing if using a
+        # generator expressions because BLT can't evaluate them
+        if(${_file } MATCHES "^$<")
+            continue()
+        endif()
+
         get_filename_component(_ext ${_file} EXT)
         string(TOLOWER ${_ext} _ext_lower)
 

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -465,7 +465,7 @@ macro(blt_split_source_list_by_language)
     foreach(_file ${arg_SOURCES})
         # Assume the user knows what they are doing if using a
         # generator expressions because BLT can't evaluate them
-        if(${_file } MATCHES "^$<")
+        if(${_file} MATCHES "^$<")
             continue()
         endif()
 


### PR DESCRIPTION
Resolves #275 

There isn't anything we can do other than ignore these.  If a user gives a generator expressions we should just ignore it when it comes to setting properties on source files.  CMake does not provide a way to evaluate generator expressions.