### PR TITLE
fixed blt_add_target_link_flags for cmake >= 3.13

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -270,9 +270,9 @@ macro(blt_add_target_link_flags)
             # In CMake 3.13+, LINK_FLAGS was converted to LINK_OPTIONS.
             # This now supports generator expressions but expects a list
             # not a string
-            string(REPLACE " " ";" _flag_list ${arg_FLAGS})
+            separate_arguments(_flag_list NATIVE_COMMAND "${arg_FLAGS}" )
             foreach( _flag  ${_flag_list} )
-                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS ${_flag})
+                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS "${_flag}" )
             endforeach()
         else()
             get_target_property(_link_flags ${arg_TO} LINK_FLAGS)

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -270,7 +270,10 @@ macro(blt_add_target_link_flags)
             # In CMake 3.13+, LINK_FLAGS was converted to LINK_OPTIONS.
             # This now supports generator expressions but expects a list
             # not a string
-            set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS ${arg_FLAGS})
+            string(REPLACE " " ";" _flag_list ${arg_FLAGS})
+            foreach( _flag  ${_flag_list} )
+                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS ${_flag})
+            endforeach()
         else()
             get_target_property(_link_flags ${arg_TO} LINK_FLAGS)
             if(NOT _link_flags)


### PR DESCRIPTION
changed blt_add_target_link_flags to convert input flags to list, and loop over list

resolves #266 