### PR TITLE
Benchmark cleanup and docs

### DIFF
--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -64,6 +64,8 @@ endif()
 option(ENABLE_GTEST        "Enable Google Test testing support (if ENABLE_TESTS=ON)" ${_CXX_enabled})
 option(ENABLE_GMOCK        "Enable Google Mock testing support (if ENABLE_TESTS=ON)" OFF)
 option(ENABLE_FRUIT        "Enable Fruit testing support (if ENABLE_TESTS=ON and ENABLE_FORTRAN=ON)" ON)
+option(ENABLE_GBENCHMARK   "Enable Google Benchmark support (if ENABLE_TESTS=ON)" ${ENABLE_BENCHMARKS})
+
 
 if( (NOT _CXX_enabled) AND ENABLE_GTEST )
   message( FATAL_ERROR

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@
 .. # 
 .. # SPDX-License-Identifier: (BSD-3-Clause)
 
-API documentation
+API Documentation
 =================
 
 .. toctree::

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -28,29 +28,37 @@ COMMAND
 NUM_MPI_TASKS
   Indicates this is an MPI test and how many MPI tasks to use.
 
-This macro adds the benchmark to the ``run_benchmarks`` build target.
-The underlying executable, previously added with :ref:`blt_add_executable`,
-should include necessary benchmarking library in its DEPENDS_ON list.
+This macro adds a benchmark test to the ``Benchmark`` CTest configuration
+which can be run by the ``run_benchmarks`` build target.  These tests are
+not run when you use the regular ``test`` build target.
 
-BLT provides a built-in Google Benchmark that is enabled by default if you set
-ENABLE_BENCHMARKS=ON and can be turned off with the option ENABLE_GBENCHMARK.
+This macro is just a thin wrapper around :ref:`blt_add_test` and assists 
+with building up the correct command line for running the benchmark.  For more
+information see :ref:`blt_add_test`.
+
+The underlying executable should be previously added to the build system
+with :ref:`blt_add_executable`. It should include the necessary benchmarking 
+library in its DEPENDS_ON list.
+
+Any calls to this macro should be guarded with ENABLE_BENCHMARKS unless this option
+is always on in your build project.
 
 .. note::
-  This is just a thin wrapper around :ref:`blt_add_test` that sets the CTest configuration
-  to "Benchmark" to filter these benchmarks out of the ``test`` build target. It also assists
-  with building up the correct command line.  For more info see :ref:`blt_add_test`.
+  BLT provides a built-in Google Benchmark that is enabled by default if you set
+  ENABLE_BENCHMARKS=ON and can be turned off with the option ENABLE_GBENCHMARK.
 
 .. code-block:: cmake
     :caption: **Example**
     :linenos:
 
-    blt_add_executable(NAME    component_benchmark
-                       SOURCES my_benchmark.cpp
-                       DEPENDS gbenchmark)
-    blt_add_benchmark(
-         NAME    component_benchmark
-         COMMAND component_benchmark "--benchmark_min_time=0.0 --v=3 --benchmark_format=json")
-
+    if(ENABLE_BENCHMARKS)
+      blt_add_executable(NAME    component_benchmark
+                         SOURCES my_benchmark.cpp
+                         DEPENDS gbenchmark)
+      blt_add_benchmark(
+           NAME    component_benchmark
+           COMMAND component_benchmark "--benchmark_min_time=0.0 --v=3 --benchmark_format=json")
+    endif()
 
 .. _blt_add_executable:
 
@@ -182,24 +190,28 @@ NUM_MPI_TASKS
   Indicates this is an MPI test and how many MPI tasks to use.
 
 CONFIGURATIONS
-  Set the CTest configuration for this test.  Do not specify if you want the
-  test to run every ``test`` build target.
+  Set the CTest configuration for this test.  When not specified, the test
+  will be added to the default CTest configuration.
 
-This macro adds the named test to CTest and the build target ``test``. This macro
-does not build the executable and requires a call to :ref:`blt_add_executable` first.
+This macro adds the named test to CTest, which is run by the build target ``test``. This macro
+does not build the executable and requires a prior call to :ref:`blt_add_executable`.
 
 This macro assists with building up the correct command line. It will prepend
-the RUNTIME_OUTPUT_DIRECTORY target property to the executable. If NUM_MPI_TASKS
-is given, the macro will appropiately use MPIEXEC, MPIEXEC_NUMPROC_FLAG, and 
-BLT_MPI_COMMAND_APPEND to create the MPI run line.
+the RUNTIME_OUTPUT_DIRECTORY target property to the executable.
+
+If NUM_MPI_TASKS is given or ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC is set, the macro 
+will appropiately use MPIEXEC, MPIEXEC_NUMPROC_FLAG, and BLT_MPI_COMMAND_APPEND 
+to create the MPI run line.
 
 MPIEXEC and MPIEXEC_NUMPROC_FLAG are filled in by CMake's FindMPI.cmake but can
 be overwritten in your host-config specific to your platform. BLT_MPI_COMMAND_APPEND
 is useful on machines that require extra arguments to MPIEXEC.
 
 .. note::
-  If you do not want the command line assistance, for example you already have a script
-  you wish to run as a test, then just call CMake's ``add_test()``.
+  If you do not require this macros command line assistance, you can call CMake's
+  ``add_test()`` directly. For example, you may have a script checked into your
+  repository you wish to run as a test instead of an executable you built as a part
+  of your build system.
 
 .. code-block:: cmake
     :caption: **Example**

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -52,12 +52,12 @@ is always on in your build project.
     :linenos:
 
     if(ENABLE_BENCHMARKS)
-      blt_add_executable(NAME    component_benchmark
-                         SOURCES my_benchmark.cpp
-                         DEPENDS gbenchmark)
-      blt_add_benchmark(
-           NAME    component_benchmark
-           COMMAND component_benchmark "--benchmark_min_time=0.0 --v=3 --benchmark_format=json")
+        blt_add_executable(NAME    component_benchmark
+                           SOURCES my_benchmark.cpp
+                           DEPENDS gbenchmark)
+        blt_add_benchmark(
+             NAME    component_benchmark
+             COMMAND component_benchmark "--benchmark_min_time=0.0 --v=3 --benchmark_format=json")
     endif()
 
 .. _blt_add_executable:
@@ -213,14 +213,19 @@ is useful on machines that require extra arguments to MPIEXEC.
   repository you wish to run as a test instead of an executable you built as a part
   of your build system.
 
+Any calls to this macro should be guarded with ENABLE_TESTS unless this option
+is always on in your build project.
+
 .. code-block:: cmake
     :caption: **Example**
     :linenos:
 
-    blt_add_executable(NAME    my_test
-                       SOURCES my_test.cpp)
-    blt_add_test(NAME    my_test
-                 COMMAND my_test --with-some-argument)
+    if (ENABLE_TESTS)
+        blt_add_executable(NAME    my_test
+                           SOURCES my_test.cpp)
+        blt_add_test(NAME    my_test
+                     COMMAND my_test --with-some-argument)
+    endif()
 
 
 .. _blt_register_library:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,4 +66,4 @@ Documentation
     :maxdepth: 2
 
     User Tutorial <tutorial/index>
-    API Documenation <api/index>
+    API Documentation <api/index>

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -121,33 +121,36 @@ if(ENABLE_TESTS)
 endif()
 
 if(ENABLE_BENCHMARKS)
-    if(WIN32 AND BUILD_SHARED_LIBS)
-      message(FATAL_ERROR "Benchmarks cannot be built when BUILD_SHARED_LIBS=On")
+    if(NOT ENABLE_TESTS)
+        message(FATAL_ERROR "ENABLE_BENCHMARKS requires ENABLE_TESTS to be ON")
     endif()
 
-    ## google benchmark support
-    add_subdirectory(gbenchmark-master-2017-05-19
-                     ${BLT_BUILD_DIR}/thirdparty_builtin/gbenchmark-master-2017-05-19)
+    message(STATUS "Google Benchmark Support is ${ENABLE_GBENCHMARK}")
 
-    if (UNIX AND NOT APPLE)
-      find_library(RT_LIBRARIES rt)
+    if(ENABLE_GBENCHMARK)
+        if(WIN32 AND BUILD_SHARED_LIBS)
+          message(FATAL_ERROR "Google Benchmark cannot be built when BUILD_SHARED_LIBS=ON or on Windows")
+        endif()
+
+        add_subdirectory(gbenchmark-master-2017-05-19
+                         ${BLT_BUILD_DIR}/thirdparty_builtin/gbenchmark-master-2017-05-19)
+
+        if (UNIX AND NOT APPLE)
+          find_library(RT_LIBRARIES rt)
+        endif()
+
+        blt_register_library(NAME      gbenchmark
+                             INCLUDES  ${benchmark_SOURCE_DIR}/include ${benchmark_SOURCE_DIR}
+                             LIBRARIES benchmark ${RT_LIBRARIES}
+                             TREAT_INCLUDES_AS_SYSTEM ON)
+
+        list(APPEND _blt_tpl_targets gbenchmark)
     endif()
 
-    blt_register_library(NAME gbenchmark
-                         INCLUDES ${benchmark_SOURCE_DIR}/include ${benchmark_SOURCE_DIR}
-                         LIBRARIES benchmark ${RT_LIBRARIES}
-                         TREAT_INCLUDES_AS_SYSTEM ON
-                         )
-
-    list(APPEND _blt_tpl_targets benchmark)
-
-    if(ENABLE_TESTS)
-      # This sets up a target to run the benchmarks
-      add_custom_target(run_benchmarks 
-                        COMMAND ctest -C Benchmark -VV -R benchmark
-                        WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-                        )
-    endif()
+    # This sets up a target to run the benchmarks
+    add_custom_target(run_benchmarks
+                      COMMAND ctest -C Benchmark -VV
+                      WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
 
 # Set the folder property of the blt thirdparty libraries 


### PR DESCRIPTION
This slightly cleans up benchmarking and adds a bit more documenation.

Look at blt_add_benchmark and blt_add_test documenation here:
https://llnl-blt.readthedocs.io/en/feature-white238-moredocs/api/target.html#blt-add-benchmark