### PR TITLE
Flush out CUDA_LINK_WITH_NVCC rpath link flag

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   '-Wl,-rpath' linking flag to '-Xlinker -rpath -Xlinker' and removes ``-pthread`` from from
   MPI linking flags returned from FindMPI because it doesn't work
   (see https://gitlab.kitware.com/cmake/cmake/issues/18008).
+- In CMake 3.13+, "SHELL:" was added to blt_add_target_link_flags.  This stops CMake from de-duplicating
+  needed linker flags.
 
 ### Changed
 - Restructured the host-config directory by site and platform.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,7 +15,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - API Docs that are public!
 - Added the ability to override blt's custom target names, e.g. for code checks,
   formatting and generating documentation. The new variables are: ``BLT_CODE_CHECK_TARGET_NAME``,
- ``BLT_CODE_STYLE_TARGET_NAME``, ``BLT_DOCS_TARGET_NAME`` and  ``BLT_RUN_BENCHMARKS_TARGET_NAME``.
+  ``BLT_CODE_STYLE_TARGET_NAME``, ``BLT_DOCS_TARGET_NAME`` and  ``BLT_RUN_BENCHMARKS_TARGET_NAME``.
+- Clean up linking flags when ``CUDA_LINK_WITH_NVCC`` is ON. Added logic to automatically convert
+  '-Wl,-rpath' linking flag to '-Xlinker -rpath -Xlinker' and removes ``-pthread`` from from
+  MPI linking flags returned from FindMPI because it doesn't work
+  (see https://gitlab.kitware.com/cmake/cmake/issues/18008).
 
 ### Changed
 - Restructured the host-config directory by site and platform.

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -214,10 +214,13 @@ macro(blt_add_target_link_flags)
             # In CMake 3.13+, LINK_FLAGS was converted to LINK_OPTIONS.
             # This now supports generator expressions but expects a list
             # not a string
-            separate_arguments(_flag_list NATIVE_COMMAND "${_flags}" )
-            foreach( _flag  ${_flag_list} )
-                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS "${_flag}" )
-            endforeach()
+            # Note: "SHELL:"" causes the flags to be not de-duplicated and parsed with
+            # separate_arguments
+            if(NOT "${arg_FLAGS}" MATCHES SHELL:)
+                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS SHELL:${arg_FLAGS})
+            else()
+                set_property(TARGET ${arg_TO} APPEND PROPERTY LINK_OPTIONS ${arg_FLAGS})
+            endif()
         else()
             get_target_property(_link_flags ${arg_TO} LINK_FLAGS)
             if(NOT _link_flags)

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -52,6 +52,12 @@ else()
     endif()
 endif()
 
+# Override rpath link flags for nvcc
+if (CUDA_LINK_WITH_NVCC)
+    set(CMAKE_SHARED_LIBRARY_RUNTIME_CUDA_FLAG "-Xlinker -rpath -Xlinker " CACHE STRING "")
+    set(CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG "-Xlinker -rpath -Xlinker " CACHE STRING "")
+endif()
+
 
 ############################################################
 # Basics
@@ -70,7 +76,6 @@ endif ()
 # FindMPI can break nvcc. In that case, you should set ENABLE_FIND_MPI to Off and control
 # the link using CMAKE_CUDA_LINK_FLAGS. -Wl,-rpath, equivalent would be -Xlinker -rpath -Xlinker
 if (CUDA_LINK_WITH_NVCC)
-    set(CMAKE_SHARED_LIBRARY_RPATH_LINK_CUDA_FLAG "-Xlinker -rpath -Xlinker")
     set(CMAKE_CUDA_LINK_EXECUTABLE
     "${CMAKE_CUDA_COMPILER} <CMAKE_CUDA_LINK_FLAGS>  <FLAGS>  <LINK_FLAGS>  <OBJECTS> -o <TARGET>  <LINK_LIBRARIES>")
     # do a no-op for the device links - for some reason the device link library dependencies are only a subset of the 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -88,9 +88,13 @@ if (ENABLE_FIND_MPI)
             list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
         endif()
     endif()
-    # Convert rpath flag if linking with CUDA
+    # Fixes for linking with NVCC
     if (CUDA_LINK_WITH_NVCC)
+        # Convert rpath flag if linking with CUDA
         string(REPLACE "-Wl,-rpath," "-Xlinker -rpath -Xlinker "
+                       _mpi_link_flags "${_mpi_link_flags}")
+        # -pthread just doesn't work with nvcc                       
+        string(REPLACE "-pthread" " "
                        _mpi_link_flags "${_mpi_link_flags}")
     endif()
 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -88,6 +88,11 @@ if (ENABLE_FIND_MPI)
             list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
         endif()
     endif()
+    # Convert rpath flag if linking with CUDA
+    if (CUDA_LINK_WITH_NVCC)
+        string(REPLACE "-Wl,-rpath," "-Xlinker -rpath -Xlinker "
+                       _mpi_link_flags "${_mpi_link_flags}")
+    endif()
 
     # Libraries
     set(_mpi_libraries ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})

--- a/docs/api/target_properties.rst
+++ b/docs/api/target_properties.rst
@@ -69,6 +69,9 @@ Adds linker flags to a target by appending to the target's existing flags.
 
 The FLAGS argument expects a ; delimited list of linker flags to add to the target.
 
+If `CUDA_LINK_WITH_NVCC` is set to ON, this macro will automatically convert
+"-Wl,-rpath," to "-Xlinker -rpath -Xlinker ".
+
 Note: In CMake versions prior to 3.13, this list is converted to a string internally
 and any ; characters will be removed.
 

--- a/docs/api/target_properties.rst
+++ b/docs/api/target_properties.rst
@@ -67,13 +67,21 @@ blt_add_target_link_flags
 
 Adds linker flags to a target by appending to the target's existing flags.
 
-The FLAGS argument expects a ; delimited list of linker flags to add to the target.
+TO
+  Name of CMake target
+
+FLAGS
+  ; delimited list of linker flags
 
 If `CUDA_LINK_WITH_NVCC` is set to ON, this macro will automatically convert
 "-Wl,-rpath," to "-Xlinker -rpath -Xlinker ".
 
 Note: In CMake versions prior to 3.13, this list is converted to a string internally
 and any ; characters will be removed.
+
+Note: In CMake versions 3.13 and above, this list is prepended with "SHELL:" which stops
+CMake from de-duplicating flags.  This is especially bad when linking with NVCC when 
+you have groups of flags like "-Xlinker -rpath -Xlinker <directory>".
 
 
 blt_print_target_properties

--- a/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_link_with_nvcc.cmake
+++ b/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_link_with_nvcc.cmake
@@ -41,7 +41,6 @@ set(MPI_CXX_COMPILER       "${MPI_HOME}/bin/mpicxx"  CACHE PATH "")
 set(MPIEXEC                "${MPI_HOME}/bin/mpirun"  CACHE PATH "")
 set(MPIEXEC_NUMPROC_FLAG   "-np"     CACHE PATH "")
 set(BLT_MPI_COMMAND_APPEND "mpibind" CACHE PATH "")
-set(BLT_MPI_LINK_FLAGS     "-Xlinker -rpath -Xlinker ${MPI_HOME}/lib" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # OpenMP support
@@ -52,7 +51,6 @@ set(ENABLE_OPENMP ON CACHE BOOL "")
 set(OMP_HOME ${CLANG_HOME}/ibm/omprtl)
 set(BLT_OPENMP_LINK_FLAGS "-Xlinker -rpath -Xlinker ${OMP_HOME}/lib -L${OMP_HOME}/lib -lomp -lomptarget-nvptx" CACHE STRING "")
 
-
 #------------------------------------------------------------------------------
 # CUDA support
 #------------------------------------------------------------------------------
@@ -60,16 +58,14 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-9.2.148" CACHE PATH "")
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
-set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE PATH "")
+set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER} CACHE PATH "")
 
 set (_cuda_arch "sm_60")
 set (CMAKE_CUDA_FLAGS "-restrict -arch ${_cuda_arch} -std=c++11 --expt-extended-lambda -G" CACHE STRING "" )
 
 set (CUDA_SEPARABLE_COMPILATION ON CACHE BOOL "" )
 set (CUDA_LINK_WITH_NVCC ON CACHE BOOL "")
-# set the link flags manually since nvcc will link (and not have the wrappers knowledge)
-# on ray - can figure out your equivalant flags by doing mpicc -vvvv
-set (CMAKE_CUDA_LINK_FLAGS "-Xlinker -rpath -Xlinker ${MPI_HOME}/lib -Xlinker -rpath -Xlinker ${CLANG_HOME}/ibm/lib:/usr/tce/packages/gcc/gcc-4.9.3/lib64 -L${MPI_HOME}/lib/ -lmpi_ibm" CACHE STRING "")
+
 
 
 # nvcc does not like gtest's 'pthreads' flag


### PR DESCRIPTION
This removes the need to hard-code rpath flags when linking with CUDA.  Doing this PR, I ran into a bug that looks internal to newer CMake versions. They remove the second -Xlinker in the needed flag "-Xlinker -rpath -Xlinker".  I am going to try to attempt to create a small non-BLT test case. To be clear this PR neither fixes or introduces this bug.

Also I realized that CUDA_LINK_WITH_NVCC is a BLT specific flag and should be prefixed but I'll do that in another PR.