### PR TITLE
finding openmp on mac requires uppercase

### DIFF
--- a/cmake/thirdparty/SetupOpenMP.cmake
+++ b/cmake/thirdparty/SetupOpenMP.cmake
@@ -8,7 +8,7 @@
 # (OpenMP support is provided by the compiler)
 #################################################
 
-find_package(OpenMP REQUIRED)
+find_package(OPENMP REQUIRED)
 
 # avoid generator expressions if possible, as generator expressions can be 
 # passed as flags to downstream projects that might not be using the same


### PR DESCRIPTION
OpenMP is randomly found/not found unless OpenMP is all uppercase on my mac.
cmake 3.15.3, clang 9, libomp 8.0.1 on two machines, one finds it the other not. if in uppercase, both find it.

fix found there: 
https://stackoverflow.com/a/53823820

have not tested on linux wether the uppercase version works.
