### PR TITLE
Adds tests for blt_list_append macro

### DIFF
--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -76,9 +76,9 @@ for clarity and convenience.
 
 This macro requires specifying:
 
-    * The target list to append to by passing TO <list>
-    * A condition to check by passing IF <bool>
-    * The list of elements to append by passing ELEMENTS [<element>...]
+    * The target list to append to by passing ``TO <list>``
+    * A condition to check by passing ``IF <bool>``
+    * The list of elements to append by passing ``ELEMENTS [<element>...]``
 
 Note, the argument passed to the IF option has to be a single boolean value
 and cannot be a boolean expression since CMake cannot evaluate those inline.
@@ -88,7 +88,18 @@ and cannot be a boolean expression since CMake cannot evaluate those inline.
     :linenos:
 
     set(mylist A B)
-    blt_list_append( TO mylist ELEMENTS C IF ${ENABLE_C} )
+    
+    set(ENABLE_C TRUE)
+    blt_list_append( TO mylist ELEMENTS C IF ${ENABLE_C} ) # Appends 'C'
+
+    set(ENABLE_D TRUE)
+    blt_list_append( TO mylist ELEMENTS D IF ENABLE_D ) # Appends 'D'
+
+    set(ENABLE_E FALSE)
+    blt_list_append( TO mylist ELEMENTS E IF ENABLE_E ) # Does not append 'E'
+
+    unset(_undefined)
+    blt_list_append( TO mylist ELEMENTS F IF _undefined ) # Does not append 'F'
 
 
 blt_list_remove_duplicates

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -161,6 +161,7 @@ if(ENABLE_GTEST)
     
     #------------------------------------------------------
     # Tests blt_add_target_definitions macro
+    #
     # Four variants of a test with a list of two definitions
     #------------------------------------------------------
     set(_variant_1 A=1 B)         # neither use '-D'
@@ -184,6 +185,52 @@ if(ENABLE_GTEST)
             NAME ${_testname}
             COMMAND ${_testname})
     endforeach()
+
+    #------------------------------------------------------
+    # Tests the IF clause of the blt_list_append macro
+    #
+    # We expect variables that are not defined to be omitted.
+    # For defined variables, we expect them to be added when
+    # they evaluate to TRUE, whether or not they are escaped.
+    #------------------------------------------------------
+    
+    unset(_existing_true_var)
+    unset(_existing_false_var)
+    
+    set(_existing_true_var TRUE)
+    set(_existing_false_var FALSE)
+    set(_defined_empty_var "")
+    set(_defined_nonempty_var "<evaluates-to-true-before-but-not-after-escaping>")
+    unset(_undefined_var)
+    
+    unset(_actual_list) # blt_list_append can work on an non-existant list
+    
+    # The following will be added to the list
+    blt_list_append(TO _actual_list ELEMENTS "true_literal"         IF TRUE)
+    blt_list_append(TO _actual_list ELEMENTS "true_nonescaped"      IF _existing_true_var)
+    blt_list_append(TO _actual_list ELEMENTS "true_escaped"         IF ${_existing_true_var})
+    blt_list_append(TO _actual_list ELEMENTS "nonempty_nonescaped"  IF _defined_nonempty_var)
+    set(_expected_list "true_literal" "true_nonescaped" "true_escaped" "nonempty_nonescaped")
+    set(_expected_size 4)
+    
+    # The following will not be added to the list
+    blt_list_append(TO _actual_list ELEMENTS "false_literal"        IF FALSE)
+    blt_list_append(TO _actual_list ELEMENTS "false_nonescaped"     IF _existing_false_var)
+    blt_list_append(TO _actual_list ELEMENTS "false_escaped"        IF ${_existing_false_var})
+    blt_list_append(TO _actual_list ELEMENTS "undefined_nonescaped" IF _nonexisting_var)
+    blt_list_append(TO _actual_list ELEMENTS "undefined_escaped"    IF ${_nonexisting_var})
+    blt_list_append(TO _actual_list ELEMENTS "empty_nonescaped"     IF _defined_empty_var)
+    blt_list_append(TO _actual_list ELEMENTS "empty_escaped"        IF ${_defined_empty_var})
+    blt_list_append(TO _actual_list ELEMENTS "nonempty_escaped"     IF ${_defined_nonempty_var})
+
+    # Check the results
+    list(LENGTH _actual_list _actual_size)
+    if(NOT "${_actual_list}" STREQUAL "${_expected_list}"
+       OR NOT ${_actual_size} EQUAL ${_expected_size})
+        message(FATAL_ERROR "[blt_list_append] Unexpected evaluation: "
+                            "\n\t" "Expected: '${_expected_list}'"
+                            "\n\t" "Got:      '${_actual_list}'" )
+    endif()
 
 endif() # endif ENABLE_GTEST
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -203,7 +203,7 @@ if(ENABLE_GTEST)
     set(_defined_nonempty_var "<evaluates-to-true-before-but-not-after-escaping>")
     unset(_undefined_var)
     
-    unset(_actual_list) # blt_list_append can work on an non-existant list
+    unset(_actual_list) # blt_list_append can work on an initially undefined list
     
     # The following will be added to the list
     blt_list_append(TO _actual_list ELEMENTS "true_literal"         IF TRUE)


### PR DESCRIPTION
Adds some tests for the ``blt_list_append`` macro.

The tests confirm that one does not need to escape the variable passed to the ``IF`` clause of the macro for it to successfully determine the predicate value.