### PR TITLE
New option: enable changing /MD to /MT

### DIFF
--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -6,6 +6,8 @@
 # Sets up configuration options for BLT
 #------------------------------------------------------------------------------
 
+include(CMakeDependentOption)
+
 #------------------------------------------------------------------------------
 # Build Targets
 #------------------------------------------------------------------------------
@@ -82,7 +84,12 @@ endif()
 #------------------------------------------------------------------------------
 option(ENABLE_ALL_WARNINGS         "Enables all compiler warnings on all build targets" ON)
 option(ENABLE_WARNINGS_AS_ERRORS   "Enables treating compiler warnings as errors on all build targets" OFF)
-option(ENABLE_MSVC_STATIC_MD_TO_MT "For static linking with MS Visual Studio, enables changing /MD to /MT" ON)
+cmake_dependent_option(BLT_ENABLE_MSVC_STATIC_MD_TO_MT
+                                   "When linking statically with MS Visual Studio, enables changing /MD to /MT"
+                                   ON
+                                   "NOT BUILD_SHARED_LIBS"
+                                   OFF)
+mark_as_advanced(BLT_ENABLE_MSVC_STATIC_MD_TO_MT)
 
 #------------------------------------------------------------------------------
 # Generator Options

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -80,8 +80,9 @@ endif()
 #------------------------------------------------------------------------------
 # Compiler Options
 #------------------------------------------------------------------------------
-option(ENABLE_ALL_WARNINGS       "Enables all compiler warnings on all build targets" ON)
-option(ENABLE_WARNINGS_AS_ERRORS "Enables treating compiler warnings as errors on all build targets" OFF)
+option(ENABLE_ALL_WARNINGS         "Enables all compiler warnings on all build targets" ON)
+option(ENABLE_WARNINGS_AS_ERRORS   "Enables treating compiler warnings as errors on all build targets" OFF)
+option(ENABLE_MSVC_STATIC_MD_TO_MT "For static linking with MS Visual Studio, enables changing /MD to /MT" ON)
 
 #------------------------------------------------------------------------------
 # Generator Options

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -338,16 +338,21 @@ blt_append_custom_compiler_flag(
 #
 
 if ( COMPILER_FAMILY_IS_MSVC AND NOT BUILD_SHARED_LIBS )
-  foreach(_lang C CXX)
-    foreach(_build
-            FLAGS FLAGS_DEBUG FLAGS_RELEASE
-            FLAGS_MINSIZEREL FLAGS_RELWITHDEBINFO)
-        set(_flag CMAKE_${_lang}_${_build})
-        if(${_flag} MATCHES "/MD")
-            string(REGEX REPLACE "/MD" "/MT" ${_flag} "${${_flag}}")
-        endif()
+  if ( ENABLE_MSVC_STATIC_MD_TO_MT )
+    foreach(_lang C CXX)
+      foreach(_build
+              FLAGS FLAGS_DEBUG FLAGS_RELEASE
+              FLAGS_MINSIZEREL FLAGS_RELWITHDEBINFO)
+          set(_flag CMAKE_${_lang}_${_build})
+          if(${_flag} MATCHES "/MD")
+              string(REGEX REPLACE "/MD" "/MT" ${_flag} "${${_flag}}")
+          endif()
+      endforeach()
     endforeach()
-  endforeach()
+  elseif (ENABLE_GTEST)
+    message(FATAL_ERROR
+      "For static linking with MS Visual Studio using GTEST, you must enable changing /MD to /MT.")
+  endif()
 endif()
 
 set(langFlags "CMAKE_C_FLAGS" "CMAKE_CXX_FLAGS")


### PR DESCRIPTION
When building with MS Visual Studio, the /MD command line option links in the dynamic C runtime and /MT links the static runtime.  At the link step, every binary must have used the same runtime link flag or link errors will result.  Some libraries' build systems insist on one flag or the other: CMake only uses /MD, HDF5 strongly prefers /MD for both dynamic and static builds, while GTest changes all occurences of /MD to /MT for static builds.

This commit establishes ENABLE_MSVC_STATIC_MD_TO_MT, defaulting to ON.  This flag has effect only if building static binaries using MS Visual Studio.  If the option is OFF, BLT will leave all /MD flags generated by CMake alone and throw an error if GTest is enabled for a static build under MSVC.  If ON, BLT will change each occurence of /MD in the compiler flags to /MT to match (and enable) GTest.