### PR TITLE
Feature/white238/clangformat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,6 @@ The BLT project uses git's commit history to track contributions from individual
 
 Since we want everyone to feel they are getting the proper attribution for their contributions, please add your name to the list below as part of your commit.
 
-For example: 
-
-```
-# Author: John Doe @ Some Company, Inc.
-```
-
 # Contributors (In Alphabetical Order)
 
 * Izaak Beekman

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ Any questions can be sent to blt-dev@llnl.gov.
 # Attribution
 
 We want everyone to feel they are getting the proper attribution for their
-contributions.  Here are some suggestions on how to get that:
+contributions.  Github automatically tracks contribution but if you do not feel
+that is adequate. Here are some suggestions we recommend:
 
 * New files: add your name and a date to the top of the file
 * New functions or macros: add your name to the comment above it
@@ -34,5 +35,5 @@ For example:
 * Matt Larsen
 * Martin McFadden, LLNL
 * Mark Miller, LLNL
-* David Poliakoff, LLNL
+* David Poliakoff, Sandia National Laboratories
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,9 @@ Any questions can be sent to blt-dev@llnl.gov.
 
 # Attribution
 
-We want everyone to feel they are getting the proper attribution for their
-contributions.  Github automatically tracks contribution but if you do not feel
-that is adequate. Here are some suggestions we recommend:
+The BLT project uses git's commit history to track contributions from individual developers. 
 
-* New files: add your name and a date to the top of the file
-* New functions or macros: add your name to the comment above it
+Since we want everyone to feel they are getting the proper attribution for their contributions, please add your name to the list below as part of your commit.
 
 For example: 
 
@@ -32,7 +29,7 @@ For example:
 * Chip Freitag, AMD, Inc.
 * Elsa Gonsiorowski, LLNL
 * Burl Hall, LLNL
-* Matt Larsen
+* Matt Larsen, LLNL
 * Martin McFadden, LLNL
 * Mark Miller, LLNL
 * David Poliakoff, Sandia National Laboratories

--- a/README.md
+++ b/README.md
@@ -61,17 +61,21 @@ Authors
 
 Developers include:
 
- * Chris White (white238@llnl.gov)
- * Kenneth Weiss (kweiss@llnl.gov)
- * Cyrus Harrison (harrison37@llnl.gov)
- * George Zagaris (zagaris2@llnl.gov)
- * Lee Taylor (taylor16@llnl.gov)
- * Aaron Black (black27@llnl.gov)
- * David A. Beckingsale (beckingsale1@llnl.gov)
- * Richard Hornung (hornung1@llnl.gov)
- * Randolph Settgast (settgast1@llnl.gov)
+ * Chris White, LLNL
+ * Kenneth Weiss, LLNL
+ * Cyrus Harrison, LLNL
+ * George Zagaris, LLNL
+ * Lee Taylor, LLNL
+ * Aaron Black, LLNL
+ * David A. Beckingsale, LLNL
+ * Richard Hornung, LLNL
+ * Randolph Settgast, LLNL
 
-Please see the [BLT Contributors Page](https://github.com/LLNL/BLT/graphs/contributors) for the full list of project contributors.
+Please see our [contributing guide](https://github.com/LLNL/blt/blob/develop/CONTRIBUTING.md) 
+for details about how to contribute to the project.
+
+The full list of project contributors can be found on the 
+[BLT Contributors Page](https://github.com/LLNL/BLT/graphs/contributors).
 
 Open-Source Projects using BLT
 ------------------------------

--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ operating systems and technologies:
       [FRUIT](https://sourceforge.net/projects/fortranxunit),
       [gbenchmark](https://github.com/google/benchmark)
  * Documentation:
-      [Doxygen](http://www.doxygen.nl/), 
+      [Doxygen](http://www.doxygen.nl/),
       [Sphinx](http://www.sphinx-doc.org)
- * Code style and health:
-      [Uncrustify](http://uncrustify.sourceforge.net), 
-      [AStyle](http://astyle.sourceforge.net), 
-      [Cppcheck](http://cppcheck.sourceforge.net),
-      [clang-query](http://clang.llvm.org/docs/LibASTMatchers.html)
+ * Code style:
+      [AStyle](http://astyle.sourceforge.net),
+      [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html),
+      [Uncrustify](http://uncrustify.sourceforge.net)
+ * Code quality
+      [clang-query](http://clang.llvm.org/docs/LibASTMatchers.html),
+      [Cppcheck](http://cppcheck.sourceforge.net)
  
 
 Getting started
@@ -132,3 +134,7 @@ PackageLicenseDeclared: BSD-3-Clause
 PackageName: gtest  
 PackageHomePage: https://github.com/google/googletest  
 PackageLicenseDeclared: BSD-3-Clause  
+
+PackageName: run-clang-format  
+PackageHomePage: https://github.com/Sarcasm/run-clang-format  
+PackageLicenseDeclared: MIT  

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -31,6 +31,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added support for Cray compilers in blt_append_custom_compiler_flag.
 - Added ability to add flags to the cppcheck command line through blt_add_code_checks()
 - Added ability for blt_add_test() to set required number of OpenMP threads via new option NUM_OMP_THREADS.
+- Added ClangFormat as an option for code styling.  This has some caveats that are noted here:
+  https://llnl-blt.readthedocs.io/en/develop/api/code_check.html
 
 ### Changed
 - Restructured the host-config directory by site and platform.

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -20,14 +20,21 @@ option(ENABLE_COVERAGE   "Enables code coverage support" OFF)
 #------------------------------------------------------------------------------
 # TPL Executable Options
 #------------------------------------------------------------------------------
+option(ENABLE_GIT          "Enables Git support" ON)
+
+# Documentation
+option(ENABLE_DOXYGEN      "Enables Doxygen support" ON)
+option(ENABLE_SPHINX       "Enables Sphinx support" ON)
+
+# Quality
 option(ENABLE_CLANGQUERY   "Enables Clang-query support" ON)
 option(ENABLE_CPPCHECK     "Enables Cppcheck support" ON)
-option(ENABLE_DOXYGEN      "Enables Doxygen support" ON)
-option(ENABLE_GIT          "Enables Git support" ON)
-option(ENABLE_SPHINX       "Enables Sphinx support" ON)
-option(ENABLE_UNCRUSTIFY   "Enables Uncrustify support" ON)
-option(ENABLE_ASTYLE       "Enables AStyle support" ON)
 option(ENABLE_VALGRIND     "Enables Valgrind support" ON)
+
+# Style
+option(ENABLE_ASTYLE       "Enables AStyle support" ON)
+option(ENABLE_CLANGFORMAT  "Enables ClangFormat support" ON)
+option(ENABLE_UNCRUSTIFY   "Enables Uncrustify support" ON)
 
 #------------------------------------------------------------------------------
 # Build Options

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -68,11 +68,12 @@ endforeach()
 
 
 ##------------------------------------------------------------------------------
-## blt_add_code_checks( PREFIX              <Base name used for created targets>
-##                      SOURCES             [source1 [source2 ...]]
-##                      UNCRUSTIFY_CFG_FILE <Path to Uncrustify config file>
-##                      ASTYLE_CFG_FILE     <Path to AStyle config file>
-##                      CPPCHECK_FLAGS      <List of flags added to Cppcheck>)
+## blt_add_code_checks( PREFIX               <Base name used for created targets>
+##                      SOURCES              [source1 [source2 ...]]
+##                      ASTYLE_CFG_FILE      <Path to AStyle config file>
+##                      CLANGFORMAT_CFG_FILE <Path to ClangFormat config file>
+##                      UNCRUSTIFY_CFG_FILE  <Path to Uncrustify config file>
+##                      CPPCHECK_FLAGS       <List of flags added to Cppcheck>)
 ##
 ## This macro adds all enabled code check targets for the given SOURCES. It
 ## filters checks based on file extensions.
@@ -81,7 +82,7 @@ endforeach()
 macro(blt_add_code_checks)
 
     set(options )
-    set(singleValueArgs PREFIX UNCRUSTIFY_CFG_FILE ASTYLE_CFG_FILE)
+    set(singleValueArgs PREFIX ASTYLE_CFG_FILE CLANGFORMAT_CFG_FILE UNCRUSTIFY_CFG_FILE)
     set(multiValueArgs SOURCES CPPCHECK_FLAGS)
 
     cmake_parse_arguments(arg
@@ -431,14 +432,14 @@ endmacro(blt_add_astyle_target)
 ##------------------------------------------------------------------------------
 ## blt_add_clangformat_target( NAME              <Created Target Name>
 ##                             MODIFY_FILES      [TRUE | FALSE (default)]
-##                             CFG_FILE          <clang-format Configuration File> 
-##                             PREPEND_FLAGS     <Additional Flags to clang-format>
-##                             APPEND_FLAGS      <Additional Flags to clang-format>
+##                             CFG_FILE          <ClangFormat Configuration File> 
+##                             PREPEND_FLAGS     <Additional Flags to ClangFormat>
+##                             APPEND_FLAGS      <Additional Flags to ClangFormat>
 ##                             COMMENT           <Additional Comment for Target Invocation>
 ##                             WORKING_DIRECTORY <Working Directory>
 ##                             SRC_FILES         [FILE1 [FILE2 ...]] )
 ##
-## Creates a new target with the given NAME for running clang-format over the given SRC_FILES.
+## Creates a new target with the given NAME for running ClangFormat over the given SRC_FILES.
 ##------------------------------------------------------------------------------
 macro(blt_add_clangformat_target)
 
@@ -486,7 +487,7 @@ macro(blt_add_clangformat_target)
                 COMMAND ${CLANGFORMAT_EXECUTABLE} ${arg_PREPEND_FLAGS}
                     -style ${arg_CFG_FILE} ${MODIFY_FILES_FLAG} ${arg_SRC_FILES} ${arg_APPEND_FLAGS}
                 WORKING_DIRECTORY ${_wd} 
-                COMMENT "${arg_COMMENT}Running clang-format source code formatting checks.")
+                COMMENT "${arg_COMMENT}Running ClangFormat source code formatting checks.")
 
         # Hook our new target into the proper dependency chain
         if(${arg_MODIFY_FILES})

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -476,18 +476,26 @@ macro(blt_add_clangformat_target)
 
     set(_generate_target TRUE)
 
-    if(${arg_MODIFY_FILES})
-        set(MODIFY_FILES_FLAG -i)
-    else()
-        set(MODIFY_FILES_FLAG --dry-run)
-    endif()
+    # Copy config file to given working directory since ClangFormat doesn't support pointing to one
+    configure_file(${arg_CFG_FILE} ${arg_WORKING_DIRECTORY}/.clang-format COPYONLY)
 
     if(_generate_target)
-        add_custom_target(${arg_NAME}
-                COMMAND ${CLANGFORMAT_EXECUTABLE} ${arg_PREPEND_FLAGS}
-                    -style ${arg_CFG_FILE} ${MODIFY_FILES_FLAG} ${arg_SRC_FILES} ${arg_APPEND_FLAGS}
-                WORKING_DIRECTORY ${_wd} 
-                COMMENT "${arg_COMMENT}Running ClangFormat source code formatting checks.")
+        # ClangFormat does not support --dry-run until version 10 which isn't on many machines.
+        # For now, use run-clang-format for dry running purposes.
+        if(${arg_MODIFY_FILES})
+            add_custom_target(${arg_NAME}
+                    COMMAND  ${CLANGFORMAT_EXECUTABLE} ${arg_PREPEND_FLAGS}
+                        --style=file -i ${arg_SRC_FILES} ${arg_APPEND_FLAGS}
+                    WORKING_DIRECTORY ${_wd} 
+                    COMMENT "${arg_COMMENT}Running ClangFormat source code formatting checks.")
+        else()
+            set(_run_clangformat "${BLT_ROOT_DIR}/cmake/run-clang-format.py" --clang-format-executable ${CLANGFORMAT_EXECUTABLE})
+            add_custom_target(${arg_NAME}
+                    COMMAND ${_run_clangformat} -j1 ${arg_SRC_FILES}
+                    WORKING_DIRECTORY ${_wd} 
+                    COMMENT "${arg_COMMENT}Running ClangFormat source code formatting checks.")
+
+        endif()
 
         # Hook our new target into the proper dependency chain
         if(${arg_MODIFY_FILES})

--- a/cmake/run-clang-format.py
+++ b/cmake/run-clang-format.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, unicode_literals
+
+"""MIT License
+
+Copyright (c) 2017 Guillaume Papin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+"""A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
+
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+"""
+
+import argparse
+import codecs
+import difflib
+import fnmatch
+import io
+import errno
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import traceback
+
+from functools import partial
+
+try:
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx'
+DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+def excludes_from_file(ignore_file):
+    excludes = []
+    try:
+        with io.open(ignore_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('#'):
+                    # ignore comments
+                    continue
+                pattern = line.rstrip()
+                if not pattern:
+                    # allow empty lines
+                    continue
+                excludes.append(pattern)
+    except EnvironmentError as e:
+        if e.errno != errno.ENOENT:
+            raise
+    return excludes;
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [
+                        x for x in dnames
+                        if
+                        not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
+                    ]
+                    fpaths = [
+                        x for x in fpaths if not fnmatch.fnmatch(x, pattern)
+                    ]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original,
+            reformatted,
+            fromfile='{}\t(original)'.format(file),
+            tofile='{}\t(reformatted)'.format(file),
+            n=3))
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super(DiffError, self).__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super(UnexpectedError, self).__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__,
+                                                  e), e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with io.open(file, 'r', encoding='utf-8') as f:
+            original = f.readlines()
+    except IOError as exc:
+        raise DiffError(str(exc))
+
+# BLT CHANGE TO ADD FORMAT FILE
+    invocation = [args.clang_format_executable, "-style=file", file]
+# END BLT CHANGES
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
+
+    try:
+        proc = subprocess.Popen(
+            invocation,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            **encoding_py3)
+    except OSError as exc:
+        raise DiffError(
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(invocation), exc
+            )
+        )
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return '\x1b[1m\x1b[31m' + s + '\x1b[0m'
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return '\x1b[1m' + s + '\x1b[0m'
+
+    def cyan(s):
+        return '\x1b[36m' + s + '\x1b[0m'
+
+    def green(s):
+        return '\x1b[32m' + s + '\x1b[0m'
+
+    def red(s):
+        return '\x1b[31m' + s + '\x1b[0m'
+
+    for line in diff_lines:
+        if line[:4] in ['--- ', '+++ ']:
+            yield bold(line)
+        elif line.startswith('@@ '):
+            yield cyan(line)
+        elif line.startswith('+'):
+            yield green(line)
+        elif line.startswith('-'):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = 'error:'
+    if use_colors:
+        error_text = bold_red(error_text)
+    print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--clang-format-executable',
+        metavar='EXECUTABLE',
+        help='path to the clang-format executable',
+        default='clang-format')
+    parser.add_argument(
+        '--extensions',
+        help='comma separated list of file extensions (default: {})'.format(
+            DEFAULT_EXTENSIONS),
+        default=DEFAULT_EXTENSIONS)
+    parser.add_argument(
+        '-r',
+        '--recursive',
+        action='store_true',
+        help='run recursively over directories')
+    parser.add_argument('files', metavar='file', nargs='+')
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help="disable output, useful for the exit code")
+    parser.add_argument(
+        '-j',
+        metavar='N',
+        type=int,
+        default=0,
+        help='run N clang-format jobs in parallel'
+        ' (default number of cpus + 1)')
+    parser.add_argument(
+        '--color',
+        default='auto',
+        choices=['auto', 'always', 'never'],
+        help='show colored diff (default: auto)')
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help='exclude paths matching the given glob-like pattern(s)'
+        ' from recursive search')
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == 'always':
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == 'auto':
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+
+    version_invocation = [args.clang_format_executable, str("--version")]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(version_invocation), e
+            ),
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+
+    retcode = ExitStatus.SUCCESS
+
+    excludes = excludes_from_file(DEFAULT_CLANG_FORMAT_IGNORE)
+    excludes.extend(args.exclude)
+
+    files = list_files(
+        args.files,
+        recursive=args.recursive,
+        exclude=excludes,
+        extensions=args.extensions.split(','))
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(
+            partial(run_clang_format_diff_wrapper, args), files)
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    return retcode
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/cmake/thirdparty/SetupThirdParty.cmake
+++ b/cmake/thirdparty/SetupThirdParty.cmake
@@ -86,11 +86,14 @@ blt_find_executable(NAME        Valgrind
 #------------------------------------
 # linting
 #------------------------------------
-blt_find_executable(NAME        Uncrustify
-                    EXECUTABLES uncrustify)
-
 blt_find_executable(NAME        AStyle
                     EXECUTABLES astyle)
+
+blt_find_executable(NAME        ClangFormat
+                    EXECUTABLES clang-format)
+
+blt_find_executable(NAME        Uncrustify
+                    EXECUTABLES uncrustify)
 
 
 #------------------------------------

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -11,11 +11,12 @@ blt_add_code_checks
 
 .. code-block:: cmake
 
-    blt_add_code_checks( PREFIX              <Base name used for created targets>
-                         SOURCES             [source1 [source2 ...]]
-                         UNCRUSTIFY_CFG_FILE <Path to Uncrustify config file>
-                         ASTYLE_CFG_FILE     <Path to AStyle config file>
-                         CPPCHECK_FLAGS      <List of flags added to Cppcheck>)
+    blt_add_code_checks( PREFIX               <Base name used for created targets>
+                         SOURCES              [source1 [source2 ...]]
+                         ASTYLE_CFG_FILE      <Path to AStyle config file>
+                         CLANGFORMAT_CFG_FILE <Path to ClangFormat config file>
+                         UNCRUSTIFY_CFG_FILE  <Path to Uncrustify config file>
+                         CPPCHECK_FLAGS       <List of flags added to Cppcheck>)
 
 This macro adds all enabled code check targets for the given SOURCES.
 
@@ -26,11 +27,14 @@ PREFIX
 SOURCES
   Source list that the code checks will be ran on
 
-UNCRUSTIFY_CFG_FILE
-  Path to Uncrustify config file
-
 ASTYLE_CFG_FILE
   Path to AStyle config file
+
+CLANGFORMAT_CFG_FILE
+  Path to ClangFormat config file
+
+UNCRUSTIFY_CFG_FILE
+  Path to Uncrustify config file
 
 CPPCHECK_FLAGS
   List of flags added to Cppcheck
@@ -39,23 +43,29 @@ Sources are filtered based on file extensions for use in these code checks.  If 
 additional file extensions defined add them to BLT_C_FILE_EXTS and BLT_Fortran_FILE_EXTS.
 Currently this macro only has code checks for C/C++ and simply filters out the Fortran files.
 
-This macro supports code formatting with either Uncrustify or AStyle (but not both at the same time)
-only if the following requirements are met:
-
-- Uncrustify
-
-  * UNCRUSTIFY_CFG_FILE is given
-  * UNCRUSTIFY_EXECUTABLE is defined and found prior to calling this macro
+This macro supports code formatting with either AStyle, ClangFormat, or Uncrustify
+(but not all at the same time) only if the following requirements are met:
 
 - AStyle
 
   * ASTYLE_CFG_FILE is given
   * ASTYLE_EXECUTABLE is defined and found prior to calling this macro
 
+- ClangFormat
+
+  * CLANGFORMAT_CFG_FILE is given
+  * CLANGFORMAT_EXECUTABLE is defined and found prior to calling this macro
+
+- Uncrustify
+
+  * UNCRUSTIFY_CFG_FILE is given
+  * UNCRUSTIFY_EXECUTABLE is defined and found prior to calling this macro
+
+
 Enabled code formatting checks produce a `check` build target that will test to see if you
 are out of compliance with your code formatting and a `style` build target that will actually
 modify your source files.  It also creates smaller child build targets that follow the pattern
-`<PREFIX>_<uncrustify|astyle>_<check|style>`.
+`<PREFIX>_<astyle|clangformat|uncrustify>_<check|style>`.
 
 This macro supports the following static analysis tools with their requirements:
 
@@ -152,56 +162,6 @@ SRC_FILES
 Cppcheck is a static analysis tool for C/C++ code. More information about
 Cppcheck can be found `here <http://cppcheck.sourceforge.net/>`_.
 
-blt_add_uncrustify_target
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: cmake
-
-    blt_add_uncrustify_target( NAME              <Created Target Name>
-                               MODIFY_FILES      [TRUE | FALSE (default)]
-                               CFG_FILE          <Uncrustify Configuration File> 
-                               PREPEND_FLAGS     <Additional Flags to Uncrustify>
-                               APPEND_FLAGS      <Additional Flags to Uncrustify>
-                               COMMENT           <Additional Comment for Target Invocation>
-                               WORKING_DIRECTORY <Working Directory>
-                               SRC_FILES         [source1 [source2 ...]] )
-
-Creates a new build target for running Uncrustify
-
-NAME
-  Name of created build target
-
-MODIFY_FILES
-  Modify the files in place. Defaults to FALSE.
-
-CFG_FILE
-  Path to Uncrustify config file
-
-PREPEND_FLAGS
-  Additional flags added to the front of the Uncrustify flags
-
-APPEND_FLAGS
- Additional flags added to the end of the Uncrustify flags
-
-COMMENT
-  Comment prepended to the build target output
-
-WORKING_DIRECTORY
-  Directory in which the Uncrustify command is run. Defaults to where macro is called.
-
-SRC_FILES
-  Source list that Uncrustify will be ran on
-
-Uncrustify is a Source Code Beautifier for C/C++ code. More information about
-Uncrustify can be found `here <http://uncrustify.sourceforge.net/>`_.
-
-When MODIFY_FILES is set to TRUE, modifies the files in place and adds the created build
-target to the parent `style` build target.  Otherwise the files are not modified and the
-created target is added to the parent `check` build target. This target will notify you
-which files do not conform to your style guide.
-.. Note::
-  Setting MODIFY_FILES to FALSE is only supported in Uncrustify v0.61 or greater.
-
 
 blt_add_astyle_target
 ~~~~~~~~~~~~~~~~~~~~~
@@ -252,3 +212,103 @@ created target is added to the parent `check` build target. This target will not
 which files do not conform to your style guide.
 .. Note::
   Setting MODIFY_FILES to FALSE is only supported in AStyle v2.05 or greater.
+
+
+blt_add_clangformat_target
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cmake
+
+    blt_add_clangformat_target( NAME              <Created Target Name>
+                                MODIFY_FILES      [TRUE | FALSE (default)]
+                                CFG_FILE          <ClangFormat Configuration File> 
+                                PREPEND_FLAGS     <Additional Flags to ClangFormat>
+                                APPEND_FLAGS      <Additional Flags to ClangFormat>
+                                COMMENT           <Additional Comment for Target Invocation>
+                                WORKING_DIRECTORY <Working Directory>
+                                SRC_FILES         [FILE1 [FILE2 ...]] )
+
+Creates a new build target for running ClangFormat
+
+NAME
+  Name of created build target
+
+MODIFY_FILES
+  Modify the files in place. Defaults to FALSE.
+
+CFG_FILE
+  Path to ClangFormat config file
+
+PREPEND_FLAGS
+  Additional flags added to the front of the ClangFormat flags
+
+APPEND_FLAGS
+ Additional flags added to the end of the ClangFormat flags
+
+COMMENT
+  Comment prepended to the build target output
+
+WORKING_DIRECTORY
+  Directory in which the ClangFormat command is run. Defaults to where macro is called.
+
+SRC_FILES
+  Source list that ClangFormat will be ran on
+
+ClangFormat is a Source Code Beautifier for C/C++ code. More information about
+ClangFormat can be found `here <https://clang.llvm.org/docs/ClangFormat.html>`_.
+
+When MODIFY_FILES is set to TRUE, modifies the files in place and adds the created build
+target to the parent `style` build target.  Otherwise the files are not modified and the
+created target is added to the parent `check` build target. This target will notify you
+which files do not conform to your style guide.
+
+
+blt_add_uncrustify_target
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cmake
+
+    blt_add_uncrustify_target( NAME              <Created Target Name>
+                               MODIFY_FILES      [TRUE | FALSE (default)]
+                               CFG_FILE          <Uncrustify Configuration File> 
+                               PREPEND_FLAGS     <Additional Flags to Uncrustify>
+                               APPEND_FLAGS      <Additional Flags to Uncrustify>
+                               COMMENT           <Additional Comment for Target Invocation>
+                               WORKING_DIRECTORY <Working Directory>
+                               SRC_FILES         [source1 [source2 ...]] )
+
+Creates a new build target for running Uncrustify
+
+NAME
+  Name of created build target
+
+MODIFY_FILES
+  Modify the files in place. Defaults to FALSE.
+
+CFG_FILE
+  Path to Uncrustify config file
+
+PREPEND_FLAGS
+  Additional flags added to the front of the Uncrustify flags
+
+APPEND_FLAGS
+ Additional flags added to the end of the Uncrustify flags
+
+COMMENT
+  Comment prepended to the build target output
+
+WORKING_DIRECTORY
+  Directory in which the Uncrustify command is run. Defaults to where macro is called.
+
+SRC_FILES
+  Source list that Uncrustify will be ran on
+
+Uncrustify is a Source Code Beautifier for C/C++ code. More information about
+Uncrustify can be found `here <http://uncrustify.sourceforge.net/>`_.
+
+When MODIFY_FILES is set to TRUE, modifies the files in place and adds the created build
+target to the parent `style` build target.  Otherwise the files are not modified and the
+created target is added to the parent `check` build target. This target will notify you
+which files do not conform to your style guide.
+.. Note::
+  Setting MODIFY_FILES to FALSE is only supported in Uncrustify v0.61 or greater.

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -39,6 +39,10 @@ UNCRUSTIFY_CFG_FILE
 CPPCHECK_FLAGS
   List of flags added to Cppcheck
 
+The purpose of this macro is to enable all code checks in the default manner.  It runs
+all code checks from the working directory `CMAKE_BINARY_DIR`.  If you need more specific
+functionality you will need to call the individual code check macros yourself.
+
 Sources are filtered based on file extensions for use in these code checks.  If you need
 additional file extensions defined add them to BLT_C_FILE_EXTS and BLT_Fortran_FILE_EXTS.
 Currently this macro only has code checks for C/C++ and simply filters out the Fortran files.
@@ -268,12 +272,16 @@ which files do not conform to your style guide.
 .. note::
   ClangFormat does not support a command line option for config files.  To work around this,
   we copy the given config file to the given working directory. We recommend using the build
-  directory.
+  directory `${PROJECT_BINARY_DIR}`. Also if someone is directly including your CMake project
+  in theirs, you may conflict with theirs.  We recommend guarding your code checks against this
+  with the following check `if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")`.
 
 .. note::
   ClangFormat does not support a command line option for check (--dry-run) until version 10.
   This version is not widely used or available at this time. To work around this, we use an 
-  included script called run-clang-format.py that does not use PREPEND_FLAGS or APPEND_FLAGS.
+  included script called run-clang-format.py that does not use PREPEND_FLAGS or APPEND_FLAGS
+  in the `check` build target because the script does not support command line flags passed
+  to `clang-format`. This script is not used in the `style` build target.
 
 blt_add_uncrustify_target
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -61,6 +61,9 @@ This macro supports code formatting with either AStyle, ClangFormat, or Uncrusti
   * UNCRUSTIFY_CFG_FILE is given
   * UNCRUSTIFY_EXECUTABLE is defined and found prior to calling this macro
 
+.. note::
+  ClangFormat does not support a command line option for config files.  To work around this,
+  we copy the given config file to the build directory where this macro runs from.
 
 Enabled code formatting checks produce a `check` build target that will test to see if you
 are out of compliance with your code formatting and a `style` build target that will actually
@@ -262,6 +265,15 @@ target to the parent `style` build target.  Otherwise the files are not modified
 created target is added to the parent `check` build target. This target will notify you
 which files do not conform to your style guide.
 
+.. note::
+  ClangFormat does not support a command line option for config files.  To work around this,
+  we copy the given config file to the given working directory. We recommend using the build
+  directory.
+
+.. note::
+  ClangFormat does not support a command line option for check (--dry-run) until version 10.
+  This version is not widely used or available at this time. To work around this, we use an 
+  included script called run-clang-format.py that does not use PREPEND_FLAGS or APPEND_FLAGS.
 
 blt_add_uncrustify_target
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -266,9 +266,9 @@ if(ENABLE_CLANGQUERY)
 endif()
 
 #------------------------------------------------------------------------------
-# Format the testing code using AStyle
+# Format the testing code using ClangFormat
 #------------------------------------------------------------------------------
-if(ASTYLE_FOUND)
+if(CLANGFORMAT_FOUND)
 
   set(smoke_tests_srcs
     ../smoke/blt_cuda_mpi_smoke.cpp
@@ -327,15 +327,20 @@ if(ASTYLE_FOUND)
     src/test_cuda_device_call_from_kernel/Parent.hpp
   )
 
-  blt_add_code_checks(
-      PREFIX          smoke_tests
-      SOURCES         ${smoke_tests_srcs}
-      ASTYLE_CFG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/astyle.cfg )
+  set(_cfg_file "${BLT_ROOT_DIR}/thirdparty_builtin/benchmark-1.5.0/.clang-format")
+  if(NOT EXISTS "${_cfg_file}")
+      message(FATAL_ERROR "Could not find ClangFormat style file: ${_cfg_file}")
+  endif()
 
   blt_add_code_checks(
-      PREFIX          internal_tests
-      SOURCES         ${internal_tests_srcs}
-      ASTYLE_CFG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/astyle.cfg )
+      PREFIX               smoke_tests
+      SOURCES              ${smoke_tests_srcs}
+      CLANGFORMAT_CFG_FILE ${_cfg_file} )
+
+  blt_add_code_checks(
+      PREFIX               internal_tests
+      SOURCES              ${internal_tests_srcs}
+      CLANGFORMAT_CFG_FILE ${_cfg_file} )
 
       
 endif()

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -327,20 +327,14 @@ if(CLANGFORMAT_FOUND)
     src/test_cuda_device_call_from_kernel/Parent.hpp
   )
 
-  set(_cfg_file "${BLT_ROOT_DIR}/thirdparty_builtin/benchmark-1.5.0/.clang-format")
-  if(NOT EXISTS "${_cfg_file}")
-      message(FATAL_ERROR "Could not find ClangFormat style file: ${_cfg_file}")
-  endif()
+  blt_add_code_checks(
+      PREFIX          smoke_tests
+      SOURCES         ${smoke_tests_srcs}
+      ASTYLE_CFG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/astyle.cfg )
 
   blt_add_code_checks(
-      PREFIX               smoke_tests
-      SOURCES              ${smoke_tests_srcs}
-      CLANGFORMAT_CFG_FILE ${_cfg_file} )
-
-  blt_add_code_checks(
-      PREFIX               internal_tests
-      SOURCES              ${internal_tests_srcs}
-      CLANGFORMAT_CFG_FILE ${_cfg_file} )
-
+      PREFIX          internal_tests
+      SOURCES         ${internal_tests_srcs}
+      ASTYLE_CFG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/astyle.cfg )
       
 endif()


### PR DESCRIPTION
Adds ClangFormat support.

ClangFormat has a couple short-comings I had to work around and I documented.
 * No support for --dry-run until version 10, which doesn't seem to be many places yet.  I grabbed a widely used script online that helps with this
 * No support for a command line option to use a specific config file.  I copied it to the working directory during the cmake phase.