### PR TITLE
Fix duplicate MPI link flag

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed
 - Fixed some warnings in CMake 3.14+
+- Duplication of MPI link flags in CMake 3.14+ when Fortran was enabled.
 
 ## [Version 0.2.5] - Release date 2019-06-13
 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -84,8 +84,9 @@ if (ENABLE_FIND_MPI)
         list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
     endif()
     if (ENABLE_FORTRAN)
-        if (NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}")
-            list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
+        if ((NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}") AND
+            (NOT "${MPI_CXX_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}"))
+            list(APPEND _mpi_link_flags ${MPI_Fortran_LINK_FLAGS})
         endif()
     endif()
     # Fixes for linking with NVCC


### PR DESCRIPTION
The link flags were duplicating if you enabled Fortran and in CMake 3.14.5.  Also there was clearly a typo that no one was affected by.  This is a pretty obscure bug because most of the time these flags are the same between languages but for some reason in 3.14.5, MPI_C_LINK_FLAGS was empty while the other two were filled and that caused me to add it twice.