### PR TITLE
Add NVIDIA SDK path to the CUDA link flags

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,13 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added blt_assert_exists() utility macro.
+- Additional link flags for CUDA may now be specified by setting 
+  ``CMAKE_CUDA_LINK_FLAGS`` when configuring CMake either in a host-config 
+  or at the command-line.
+
+### Changed
+- ``CUDA_TOOLKIT_ROOT_DIR`` must now be set in order to use CUDA. If it is not
+  specified, BLT will produce an error message.
 
 ## [Version 0.3.0] - Release date 2020-01-08
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ strategy:
       Compiler_ImageName: 'axom/tpls:gcc-7'
       C_COMPILER: '/usr/bin/gcc'
       CXX_COMPILER: '/usr/bin/g++'
+      CMAKE_BIN_DIR: '/home/axom/axom_tpls/gcc-7.3.0/cmake-3.9.6/bin'
       MPI_DIR: '/home/axom/axom_tpls/gcc-7.3.0/mpich-3.2.1'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
@@ -22,6 +23,7 @@ strategy:
       Compiler_ImageName: 'axom/tpls:gcc-8'
       C_COMPILER: '/usr/bin/gcc'
       CXX_COMPILER: '/usr/bin/g++'
+      CMAKE_BIN_DIR: '/home/axom/axom_tpls/gcc-8.1.0/cmake-3.9.6/bin'
       MPI_DIR: '/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
@@ -31,6 +33,7 @@ strategy:
       Compiler_ImageName: 'axom/tpls:clang-4'
       C_COMPILER: '/usr/bin/clang'
       CXX_COMPILER: '/usr/bin/clang++'
+      CMAKE_BIN_DIR: '/home/axom/axom_tpls/clang-4.0.0/cmake-3.10.1/bin'
       MPI_DIR: '/home/axom/axom_tpls/clang-4.0.0/mpich-3.0.4'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
@@ -40,6 +43,7 @@ strategy:
       Compiler_ImageName: 'axom/tpls:clang-6'
       C_COMPILER: '/usr/bin/clang'
       CXX_COMPILER: '/usr/bin/clang++'
+      CMAKE_BIN_DIR: '/home/axom/axom_tpls/clang-6.0.0/cmake-3.10.1/bin'
       MPI_DIR: '/home/axom/axom_tpls/clang-6.0.0/mpich-3.0.4'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
@@ -79,7 +83,7 @@ steps:
 
 # Linux
 - script:  |
-    docker run $(DOCKER_FLAGS) cmake $(CMAKE_FLAGS) ../tests/internal
+    docker run $(DOCKER_FLAGS) $(CMAKE_BIN_DIR)/cmake $(CMAKE_FLAGS) ../tests/internal
   condition: eq( variables['Agent.OS'], 'Linux')
   displayName: 'Linux CMake'
 - script:  |
@@ -87,7 +91,7 @@ steps:
   condition: eq( variables['Agent.OS'], 'Linux')
   displayName: 'Linux Build'
 - script:  |
-    docker run $(DOCKER_FLAGS) ctest -T Test --output-on-failure -V
+    docker run $(DOCKER_FLAGS) $(CMAKE_BIN_DIR)/ctest -T Test --output-on-failure -V
   condition: eq( variables['Agent.OS'], 'Linux')
   displayName: 'Linux Test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ strategy:
       C_COMPILER: '/usr/bin/gcc'
       CXX_COMPILER: '/usr/bin/g++'
       CMAKE_BIN_DIR: '/home/axom/axom_tpls/gcc-8.1.0/cmake-3.10.1/bin'
-      MPI_DIR: '/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1'
+      MPI_DIR: '/home/axom/axom_tpls/gcc-8.1.0/mpich-3.3.2'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
       TEST_TARGET: 'linux_gcc8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ strategy:
       Compiler_ImageName: 'axom/tpls:gcc-8'
       C_COMPILER: '/usr/bin/gcc'
       CXX_COMPILER: '/usr/bin/g++'
-      CMAKE_BIN_DIR: '/home/axom/axom_tpls/gcc-8.1.0/cmake-3.9.6/bin'
+      CMAKE_BIN_DIR: '/home/axom/axom_tpls/gcc-8.1.0/cmake-3.10.1/bin'
       MPI_DIR: '/home/axom/axom_tpls/gcc-8.1.0/mpich-3.2.1'
       MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -7,6 +7,15 @@
 # Sanity Checks
 ################################
 
+# Ensure CUDA_TOOLKIT_ROOT_DIR is specified, since it is needed 
+# by the call to find_package(CUDA) below.
+if (NOT DEFINED CUDA_TOOLKIT_ROOT_DIR)
+   message( FATAL_ERROR
+        "Please specify CUDA_TOOLKIT_ROOT_DIR to use CUDA" )
+endif()
+
+blt_assert_exists( DIRECTORIES ${CUDA_TOOLKIT_ROOT_DIR} )
+
 # Rare case of two flags being incompatible
 if (DEFINED CMAKE_SKIP_BUILD_RPATH AND DEFINED CUDA_LINK_WITH_NVCC)
     if (NOT CMAKE_SKIP_BUILD_RPATH AND CUDA_LINK_WITH_NVCC)
@@ -88,7 +97,16 @@ endif()
 
 find_package(CUDA REQUIRED)
 
+# Append the path to the NVIDIA SDK to the link flags
+if ( IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/lib64" )
+    list(APPEND CMAKE_CUDA_LINK_FLAGS "-L${CUDA_TOOLKIT_ROOT_DIR}/lib64" )
+endif()
+if ( IS_DIRECTORY "${CUDA_TOOLKIT_ROOT_DIR}/lib}" )
+    list(APPEND CMAKE_CUDA_LINK_FLAGS "-L${CUDA_TOOLKIT_ROOT_DIR}/lib" )
+endif()
+
 message(STATUS "CUDA Version:       ${CUDA_VERSION_STRING}")
+message(STATUS "CUDA Toolkit Root Dir: ${CUDA_TOOLKIT_ROOT_DIR}")
 message(STATUS "CUDA Compiler:      ${CMAKE_CUDA_COMPILER}")
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.9.0" )
     message(STATUS "CUDA Host Compiler: ${CMAKE_CUDA_HOST_COMPILER}")
@@ -125,7 +143,9 @@ endif()
 blt_register_library(NAME cuda
                      COMPILE_FLAGS ${_cuda_compile_flags}
                      INCLUDES ${CUDA_INCLUDE_DIRS}
-                     LIBRARIES ${CUDA_LIBRARIES})
+                     LIBRARIES ${CUDA_LIBRARIES}
+                     LINK_FLAGS "${CMAKE_CUDA_LINK_FLAGS}"
+                     )
 
 # same as 'cuda' but we don't flag your source files as
 # CUDA language.  This causes your source files to use 


### PR DESCRIPTION
# Summary

This commit adds the path to the NVDIA SDK libraries to the
CMAKE_CUDA_LINK_FLAGS. Moreover, it ensures that these
link flags are specified to the registered CUDA library that
is used with BLT.

This allows applications to link additional libraries that are supplied
with the NVIDIA SDK by listing them in the list of dependencies,
e.g., nvToolsExt, cublas, etc. In addition, CMAKE_CUDA_LINK_FLAGS
may also be specified in a host-config or at the command line and
those will now be correctly propagated and associated with
BLT's registered CUDA library.