### PR TITLE
Fix a typo in SetupMPI.cmake

### DIFF
--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -65,7 +65,7 @@ if (ENABLE_FIND_MPI)
 
     if (ENABLE_FORTRAN)
         set(_f_flag ${MPI_Fortran_${_mpi_compile_flags_suffix}})
-        if (_f_flag AND NOT "${c_flg}" STREQUAL "${_f_flag}")
+        if (_f_flag AND NOT "${_c_flag}" STREQUAL "${_f_flag}")
             list(APPEND _mpi_compile_flags ${_f_flag})
         endif()
     endif()


### PR DESCRIPTION
Hi,

This tiny typo was resulting in broken CUDA+MPI compilation on my system (e.g. `blt_cuda_mpi_smoke`), because `-pthread` flag was being added to targets without `-Xcompiler` wrapping.

This PR just fixes the typo, and resolves the problem in my particular case - Fortran flags end up being equal to C ones and are happily ignored.

However I think there are a couple more related issues with `SetupMPI.cmake`, if I understand correctly:
1. `mpifort` flags are added to MPI flags without CUDA wrapping. Had they not been identical to `mpicc` flags in my case, I would still have a problem with `-pthread` on `nvcc` command line.
2. More generally, is it correct that flags from different languages are all mashed together into one list? Could it be the case that `mpifort` has some Fortran-specific flag which then gets onto command line of a C/C++ compiler and causes an error? This is more of a hypothetical question as I have not seen examples of that.

If code owners agree with any of the points above, I can try to provide a fix within this PR. For example:
1. This should be a trivial fix similar to the generator expression wrapping of C/C++ flags. 
2. This is a bit trickier, but in theory we could wrap each flag from each language into its own generator expression conditioned on that language only. So `mpicc` flags would only be seen when compiling C source, etc. This needs to be combined with `-Xcompiler` wrapping for CUDA, so the solution is not going to look nice...