### PR TITLE
fix linking issue in hip 3.5

### DIFF
--- a/tests/smoke/blt_hip_smoke.cpp
+++ b/tests/smoke/blt_hip_smoke.cpp
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include "hip/hip_runtime.h"
 
-__device__ const char *STR = "HELLO WORLD!";
+__device__ const char STR[] = "HELLO WORLD!";
 const char STR_LENGTH = 12;
 
 __global__ void hello()


### PR DESCRIPTION
This fixes the rest of #366 so that the smoke test links with hip 3.5.  I'm going to feed this bug up to AMD as well, since this change should not be necessary.

The `STR_LENGTH` should also be constexpr, or at least __host__ __device__, since the current version is only valid because of over-eager constant propagation by the hip compiler, but I'm leaving that alone for now.