### PR TITLE
mpi: protect rpath flags

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,12 +9,15 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Changed
+- MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed as single string prefixed by ``SHELL:`` to prevent
+de-duplication of flags passed to ``target_link_options``.
+
 ## [Version 0.3.6] - Release date 2020-07-27
 
 ### Changed
 - ``CUDA_TOOLKIT_ROOT_DIR`` is now optional. If it is not specified, FindCUDA.cmake will
   attempt to set it.
-
 
 ## [Version 0.3.5] - Release date 2020-07-20
 

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -136,6 +136,15 @@ if (BLT_MPI_LINK_FLAGS)
     set(_mpi_link_flags ${BLT_MPI_LINK_FLAGS})
 endif()
 
+#
+# We use `LINK_OPTIONS` for CMake 3.13 and beyond.
+# To make sure that de-duping doesn't undermine our MPI flags
+# use a string with SHELL: prefix
+#
+if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0" )
+    string(REPLACE ";" " " _mpi_link_flags "${_mpi_link_flags}")
+    set(_mpi_link_flags "SHELL:${_mpi_link_flags}")
+endif()
 
 # Output all MPI information
 message(STATUS "BLT MPI Compile Flags:  ${_mpi_compile_flags}")


### PR DESCRIPTION
resolves #331 

[100%] Linking CXX executable ../../../tests/blt_mpi_smoke
cd /home/user/blt/BLT_NEW/blt/docs/tutorial/calc_pi/build/blt/tests/smoke && /home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/cmake-3.18.1-tdx5vwyy2wc7cafdjzyc6vmb4h2x5kx6/bin/cmake -E cmake_link_script CMakeFiles/blt_mpi_smoke.dir/link.txt --verbose=1
/usr/bin/c++      -Wall -Wextra  -Wl,-rpath -Wl,/home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/hwloc-1.11.11-fl4w6luvijw4llh7ra4d7g6tj5u4lwce/lib -Wl,-rpath -Wl,/home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/zlib-1.2.11-zkl5ufya6sj7wsnrqkcqbgnay3byre7h/lib -Wl,-rpath -Wl,/home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/openmpi-3.1.6-pzmebw34oh7bifr6pu4fjxfqeoje2o5d/lib -L/home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/hwloc-1.11.11-fl4w6luvijw4llh7ra4d7g6tj5u4lwce/lib -L/home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/zlib-1.2.11-zkl5ufya6sj7wsnrqkcqbgnay3byre7h/lib -pthread CMakeFiles/blt_mpi_smoke.dir/blt_mpi_smoke.cpp.o -o ../../../tests/blt_mpi_smoke  /home/user/spack/opt/spack/linux-ubuntu18.04-haswell/gcc-7.5.0/openmpi-3.1.6-pzmebw34oh7bifr6pu4fjxfqeoje2o5d/lib/libmpi.so 

:-)

