### PR TITLE
prefix several BLT internal vars with _ to avoid expanding and duping…

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,12 +10,14 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Changed
-- MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed as single string prefixed by ``SHELL:`` to prevent
-de-duplication of flags passed to ``target_link_options``.
+- MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed
+  as single string prefixed by ``SHELL:`` to prevent de-duplication of flags
+  passed to ``target_link_options``.
 
 ### Fixed
 - ClangFormat checks now support multiple Python executable names
-
+- Prefixed blt_register_library() internal variables with ``_`` to avoid collision
+  with input parameters.
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -321,60 +321,60 @@ macro(blt_register_library)
 
     string(TOUPPER ${arg_NAME} uppercase_name)
 
-    set(BLT_${uppercase_name}_IS_REGISTERED_LIBRARY TRUE CACHE BOOL "" FORCE)
+    set(_BLT_${uppercase_name}_IS_REGISTERED_LIBRARY TRUE CACHE BOOL "" FORCE)
 
     if( arg_DEPENDS_ON )
-        set(BLT_${uppercase_name}_DEPENDS_ON ${arg_DEPENDS_ON} CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_DEPENDS_ON)
+        set(_BLT_${uppercase_name}_DEPENDS_ON ${arg_DEPENDS_ON} CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_DEPENDS_ON)
     endif()
 
     if( arg_INCLUDES )
-        set(BLT_${uppercase_name}_INCLUDES ${arg_INCLUDES} CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_INCLUDES)
+        set(_BLT_${uppercase_name}_INCLUDES ${arg_INCLUDES} CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_INCLUDES)
     endif()
 
     if( ${arg_OBJECT} )
-        set(BLT_${uppercase_name}_IS_OBJECT_LIBRARY TRUE CACHE BOOL "" FORCE)
+        set(_BLT_${uppercase_name}_IS_OBJECT_LIBRARY TRUE CACHE BOOL "" FORCE)
     else()
-        set(BLT_${uppercase_name}_IS_OBJECT_LIBRARY FALSE CACHE BOOL "" FORCE)
+        set(_BLT_${uppercase_name}_IS_OBJECT_LIBRARY FALSE CACHE BOOL "" FORCE)
     endif()
-    mark_as_advanced(BLT_${uppercase_name}_IS_OBJECT_LIBRARY)
+    mark_as_advanced(_BLT_${uppercase_name}_IS_OBJECT_LIBRARY)
 
     if( ${arg_TREAT_INCLUDES_AS_SYSTEM} )
-        set(BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM TRUE CACHE BOOL "" FORCE)
+        set(_BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM TRUE CACHE BOOL "" FORCE)
     else()
-        set(BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM FALSE CACHE BOOL "" FORCE)
+        set(_BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM FALSE CACHE BOOL "" FORCE)
     endif()
-    mark_as_advanced(BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM)
+    mark_as_advanced(_BLT_${uppercase_name}_TREAT_INCLUDES_AS_SYSTEM)
 
     if( ENABLE_FORTRAN AND arg_FORTRAN_MODULES )
-        set(BLT_${uppercase_name}_FORTRAN_MODULES ${arg_INCLUDES} CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_FORTRAN_MODULES)
+        set(_BLT_${uppercase_name}_FORTRAN_MODULES ${arg_INCLUDES} CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_FORTRAN_MODULES)
     endif()
 
     if( arg_LIBRARIES )
-        set(BLT_${uppercase_name}_LIBRARIES ${arg_LIBRARIES} CACHE STRING "" FORCE)
+        set(_BLT_${uppercase_name}_LIBRARIES ${arg_LIBRARIES} CACHE STRING "" FORCE)
     else()
         # This prevents cmake from falling back on adding -l<library name>
         # to the command line for BLT registered libraries which are not
         # actual CMake targets
-        set(BLT_${uppercase_name}_LIBRARIES "BLT_NO_LIBRARIES" CACHE STRING "" FORCE)
+        set(_BLT_${uppercase_name}_LIBRARIES "BLT_NO_LIBRARIES" CACHE STRING "" FORCE)
     endif()
-    mark_as_advanced(BLT_${uppercase_name}_LIBRARIES)
+    mark_as_advanced(_BLT_${uppercase_name}_LIBRARIES)
 
     if( arg_COMPILE_FLAGS )
-        set(BLT_${uppercase_name}_COMPILE_FLAGS "${arg_COMPILE_FLAGS}" CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_COMPILE_FLAGS)
+        set(_BLT_${uppercase_name}_COMPILE_FLAGS "${arg_COMPILE_FLAGS}" CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_COMPILE_FLAGS)
     endif()
 
     if( arg_LINK_FLAGS )
-        set(BLT_${uppercase_name}_LINK_FLAGS "${arg_LINK_FLAGS}" CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_LINK_FLAGS)
+        set(_BLT_${uppercase_name}_LINK_FLAGS "${arg_LINK_FLAGS}" CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_LINK_FLAGS)
     endif()
 
     if( arg_DEFINES )
-        set(BLT_${uppercase_name}_DEFINES ${arg_DEFINES} CACHE STRING "" FORCE)
-        mark_as_advanced(BLT_${uppercase_name}_DEFINES)
+        set(_BLT_${uppercase_name}_DEFINES ${arg_DEFINES} CACHE STRING "" FORCE)
+        mark_as_advanced(_BLT_${uppercase_name}_DEFINES)
     endif()
 
 endmacro(blt_register_library)
@@ -1099,7 +1099,7 @@ macro(blt_print_target_properties)
 
     set(_is_blt_registered_target FALSE)
     string(TOUPPER ${arg_TARGET} _target_upper)
-    if(BLT_${_target_upper}_IS_REGISTERED_LIBRARY)
+    if(_BLT_${_target_upper}_IS_REGISTERED_LIBRARY)
         set(_is_blt_registered_target TRUE)
         message (STATUS "[${arg_TARGET} property] '${arg_TARGET}' is a blt_registered target")
     endif()
@@ -1141,11 +1141,11 @@ macro(blt_print_target_properties)
         unset(_propval)
     endif()
 
-    ## Additionally, output variables generated via blt_register_target of the form "BLT_<target>_*"
+    ## Additionally, output variables generated via blt_register_target of the form "_BLT_<target>_*"
     if(_is_blt_registered_target)
-        set(_target_prefix "BLT_${_target_upper}_")
+        set(_target_prefix "_BLT_${_target_upper}_")
 
-        ## Filter to get variables of the form BLT_<target>_ and print
+        ## Filter to get variables of the form _BLT_<target>_ and print
         get_cmake_property(_variable_names VARIABLES)
         foreach (prop ${_variable_names})
             if(prop MATCHES "^${_target_prefix}")

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -271,8 +271,8 @@ macro(blt_setup_target)
         foreach( dependency ${_expanded_DEPENDS_ON} )
             string(TOUPPER ${dependency} uppercase_dependency )
 
-            if ( DEFINED BLT_${uppercase_dependency}_DEPENDS_ON )
-                foreach(new_dependency ${BLT_${uppercase_dependency}_DEPENDS_ON})
+            if ( DEFINED _BLT_${uppercase_dependency}_DEPENDS_ON )
+                foreach(new_dependency ${_BLT_${uppercase_dependency}_DEPENDS_ON})
                     if (NOT ${new_dependency} IN_LIST _expanded_DEPENDS_ON)
                         list(APPEND _expanded_DEPENDS_ON ${new_dependency})
                     endif()
@@ -285,29 +285,29 @@ macro(blt_setup_target)
     foreach( dependency ${_expanded_DEPENDS_ON} )
         string(TOUPPER ${dependency} uppercase_dependency )
 
-        if ( NOT arg_OBJECT AND BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
+        if ( NOT arg_OBJECT AND _BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
             target_sources(${arg_NAME} PRIVATE $<TARGET_OBJECTS:${dependency}>)
         endif()
 
-        if ( DEFINED BLT_${uppercase_dependency}_INCLUDES )
-            if ( BLT_${uppercase_dependency}_TREAT_INCLUDES_AS_SYSTEM )
+        if ( DEFINED _BLT_${uppercase_dependency}_INCLUDES )
+            if ( _BLT_${uppercase_dependency}_TREAT_INCLUDES_AS_SYSTEM )
                 target_include_directories( ${arg_NAME} SYSTEM PUBLIC
-                    ${BLT_${uppercase_dependency}_INCLUDES} )
+                    ${_BLT_${uppercase_dependency}_INCLUDES} )
             else()
                 target_include_directories( ${arg_NAME} PUBLIC
-                    ${BLT_${uppercase_dependency}_INCLUDES} )
+                    ${_BLT_${uppercase_dependency}_INCLUDES} )
             endif()
         endif()
 
-        if ( DEFINED BLT_${uppercase_dependency}_FORTRAN_MODULES )
+        if ( DEFINED _BLT_${uppercase_dependency}_FORTRAN_MODULES )
             target_include_directories( ${arg_NAME} PUBLIC
-                ${BLT_${uppercase_dependency}_FORTRAN_MODULES} )
+                ${_BLT_${uppercase_dependency}_FORTRAN_MODULES} )
         endif()
 
         if ( arg_OBJECT )
             # Object libraries need to inherit info from their CMake targets listed
             # in their LIBRARIES
-            foreach( _library ${BLT_${uppercase_dependency}_LIBRARIES} )
+            foreach( _library ${_BLT_${uppercase_dependency}_LIBRARIES} )
                 if(TARGET ${_library})
                     blt_inherit_target_info(TO     ${arg_NAME}
                                             FROM   ${_library}
@@ -316,7 +316,7 @@ macro(blt_setup_target)
             endforeach()
         endif()
 
-        if ( arg_OBJECT OR BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
+        if ( arg_OBJECT OR _BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
             # We want object libraries to inherit the vital info but not call
             # target_link_libraries() otherwise you have to install the object
             # files associated with the object library which noone wants.
@@ -325,32 +325,32 @@ macro(blt_setup_target)
                                         FROM   ${dependency}
                                         OBJECT ${arg_OBJECT})
             endif()
-        elseif (DEFINED BLT_${uppercase_dependency}_LIBRARIES)
+        elseif (DEFINED _BLT_${uppercase_dependency}_LIBRARIES)
             # This prevents cmake from adding -l<library name> to the
             # command line for BLT registered libraries which are not
             # actual CMake targets
-            if(NOT "${BLT_${uppercase_dependency}_LIBRARIES}"
+            if(NOT "${_BLT_${uppercase_dependency}_LIBRARIES}"
                     STREQUAL "BLT_NO_LIBRARIES" )
                 target_link_libraries( ${arg_NAME} PUBLIC
-                    ${BLT_${uppercase_dependency}_LIBRARIES} )
+                    ${_BLT_${uppercase_dependency}_LIBRARIES} )
             endif()
         else()
             target_link_libraries( ${arg_NAME} PUBLIC ${dependency} )
         endif()
 
-        if ( DEFINED BLT_${uppercase_dependency}_DEFINES )
+        if ( DEFINED _BLT_${uppercase_dependency}_DEFINES )
             target_compile_definitions( ${arg_NAME} PUBLIC
-                ${BLT_${uppercase_dependency}_DEFINES} )
+                ${_BLT_${uppercase_dependency}_DEFINES} )
         endif()
 
-        if ( DEFINED BLT_${uppercase_dependency}_COMPILE_FLAGS )
+        if ( DEFINED _BLT_${uppercase_dependency}_COMPILE_FLAGS )
             blt_add_target_compile_flags(TO ${arg_NAME}
-                                         FLAGS ${BLT_${uppercase_dependency}_COMPILE_FLAGS} )
+                                         FLAGS ${_BLT_${uppercase_dependency}_COMPILE_FLAGS} )
         endif()
 
-        if ( NOT arg_OBJECT AND DEFINED BLT_${uppercase_dependency}_LINK_FLAGS )
+        if ( NOT arg_OBJECT AND DEFINED _BLT_${uppercase_dependency}_LINK_FLAGS )
             blt_add_target_link_flags(TO ${arg_NAME}
-                                      FLAGS ${BLT_${uppercase_dependency}_LINK_FLAGS} )
+                                      FLAGS ${_BLT_${uppercase_dependency}_LINK_FLAGS} )
         endif()
 
     endforeach()

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -188,7 +188,7 @@ Normal libraries are libraries that have sources that are compiled and linked in
 library and have headers that go along with them (unless it's a Fortran library).
 
 Header-only libraries are useful when you do not want the library separately compiled or 
-are using C++ templates that require the library's user to instatiate them. These libraries
+are using C++ templates that require the library's user to instantiate them. These libraries
 have headers but no sources. To create a header-only library (CMake calls them INTERFACE libraries),
 simply list all headers under the HEADER argument and do not specify SOURCES (because there aren't any).
 
@@ -262,7 +262,7 @@ This macro assists with building up the correct command line. It will prepend
 the RUNTIME_OUTPUT_DIRECTORY target property to the executable.
 
 If NUM_MPI_TASKS is given or ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC is set, the macro 
-will appropiately use MPIEXEC, MPIEXEC_NUMPROC_FLAG, and BLT_MPI_COMMAND_APPEND 
+will appropriately use MPIEXEC, MPIEXEC_NUMPROC_FLAG, and BLT_MPI_COMMAND_APPEND 
 to create the MPI run line.
 
 MPIEXEC and MPIEXEC_NUMPROC_FLAG are filled in by CMake's FindMPI.cmake but can
@@ -329,13 +329,16 @@ Note: The OBJECT parameter is for internal BLT support for object libraries
 and is not for users.  Object libraries are created using blt_add_library().
 
 Internally created variables (NAME = "foo"):
-    | BLT_FOO_IS_REGISTERED_LIBRARY
-    | BLT_FOO_IS_OBJECT_LIBRARY
-    | BLT_FOO_DEPENDS_ON
-    | BLT_FOO_INCLUDES
-    | BLT_FOO_TREAT_INCLUDES_AS_SYSTEM
-    | BLT_FOO_FORTRAN_MODULES
-    | BLT_FOO_LIBRARIES
-    | BLT_FOO_COMPILE_FLAGS
-    | BLT_FOO_LINK_FLAGS
-    | BLT_FOO_DEFINES
+    | _BLT_FOO_IS_REGISTERED_LIBRARY
+    | _BLT_FOO_IS_OBJECT_LIBRARY
+    | _BLT_FOO_DEPENDS_ON
+    | _BLT_FOO_INCLUDES
+    | _BLT_FOO_TREAT_INCLUDES_AS_SYSTEM
+    | _BLT_FOO_FORTRAN_MODULES
+    | _BLT_FOO_LIBRARIES
+    | _BLT_FOO_COMPILE_FLAGS
+    | _BLT_FOO_LINK_FLAGS
+    | _BLT_FOO_DEFINES
+
+Internal variable names are prefixed with ``_`` to avoid collision with input parameters.
+


### PR DESCRIPTION
… var contents on re-configure

resolves #390 