### PR TITLE
Add support for clang-tidy static analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ operating systems and technologies:
       [Uncrustify](http://uncrustify.sourceforge.net)
  * Code quality
       [clang-query](http://clang.llvm.org/docs/LibASTMatchers.html),
+      [clang-tidy](https://clang.llvm.org/extra/clang-tidy),
       [Cppcheck](http://cppcheck.sourceforge.net)
  
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added variable BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE to allow removing
   implicit link directories added to CUDA executables by CMake. See the following example host-config:
   host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17.cmake
+- Added support for clang-tidy static analysis check
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -28,6 +28,7 @@ option(ENABLE_SPHINX       "Enables Sphinx support" ON)
 
 # Quality
 option(ENABLE_CLANGQUERY   "Enables Clang-query support" ON)
+option(ENABLE_CLANGTIDY    "Enables clang-tidy support" ON)
 option(ENABLE_CPPCHECK     "Enables Cppcheck support" ON)
 option(ENABLE_VALGRIND     "Enables Valgrind support" ON)
 
@@ -142,4 +143,3 @@ mark_as_advanced(
     BLT_CODE_STYLE_TARGET_NAME
     BLT_DOCS_TARGET_NAME
     BLT_RUN_BENCHMARKS_TARGET_NAME )
-

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -55,11 +55,23 @@ if(CLANGQUERY_FOUND)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_query_check)
 endif()
 
+if(CLANGTIDY_FOUND)
+    # note: interactive_clang_tidy_check 
+    # is for the use of code developers who
+    # want to check specific attributes of
+    # specific targets, and does not make 
+    # sense as a dependency of check
+    add_custom_target(clang_tidy_check)
+    add_custom_target(interactive_clang-tidy_check)
+    add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_check)
+endif()
+
 # Code check targets should only be run on demand
 foreach(target 
         check uncrustify_check astyle_check clangformat_check cppcheck_check
         style uncrustify_style astyle_style clangformat_style
-        clang_query_check interactive_clang_query_check)
+        clang_query_check interactive_clang_query_check
+        clang_tidy_check interactive_clang_tidy_check)
     if(TARGET ${target})
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
@@ -203,6 +215,14 @@ macro(blt_add_code_checks)
                                     SRC_FILES         ${_c_sources})
     endif()
 
+    if (CLANGTIDY_FOUND)
+        set(_clang_tidy_target_name ${arg_PREFIX}_clang_tidy_check)
+        blt_error_if_target_exists(${_clang_tidy_target_name} ${_error_msg})
+        blt_add_clang_tidy_target( NAME              ${_clang_tidy_target_name}
+                                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                                    SRC_FILES         ${_c_sources})
+    endif()
+
 endmacro(blt_add_code_checks)
 
 ##-----------------------------------------------------------------------------
@@ -278,6 +298,75 @@ macro(blt_add_clang_query_target)
         set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
     endif()
 endmacro(blt_add_clang_query_target)
+
+##-----------------------------------------------------------------------------
+## blt_add_clang_tidy_target( NAME              <Created Target Name>
+##                            WORKING_DIRECTORY <Working Directory>
+##                            COMMENT           <Additional Comment for Target Invocation>
+##                            CHECKS            <If specified, requires a specific set of checks>
+##                            SRC_FILES         [FILE1 [FILE2 ...]] )
+##
+## Creates a new target with the given NAME for running clang=tidy over the given SRC_FILES
+##-----------------------------------------------------------------------------
+macro(blt_add_clang_tidy_target)
+    if(CLANGTIDY_FOUND)
+
+        ## parse the arguments to the macro
+        set(options)
+        set(singleValueArgs NAME COMMENT WORKING_DIRECTORY)
+        set(multiValueArgs SRC_FILES CHECKS)
+
+        cmake_parse_arguments(arg
+            "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+        # Check required parameters
+        if(NOT DEFINED arg_NAME)
+             message(FATAL_ERROR "blt_add_clang_tidy_target requires a NAME parameter")
+        endif()
+
+        if(NOT DEFINED arg_SRC_FILES)
+            message(FATAL_ERROR "blt_add_clang_tidy_target requires a SRC_FILES parameter")
+        endif()
+
+        if(DEFINED arg_WORKING_DIRECTORY)
+            set(_wd ${arg_WORKING_DIRECTORY})
+        else()
+            set(_wd ${CMAKE_CURRENT_SOURCE_DIR})
+        endif()
+   
+        set(interactive_tidy_target_name interactive_tidy_${arg_NAME})
+        set(CLANG_TIDY_HELPER_SCRIPT ${BLT_ROOT_DIR}/cmake/run-clang-tidy.py)
+        set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_SCRIPT} -clang-tidy-binary=${CLANGTIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR})
+
+        if(DEFINED arg_CHECKS)
+            STRING(REGEX REPLACE " " ":" CHECK_ARG_STRING ${arg_CHECKS})
+            add_custom_target(${arg_NAME}
+              COMMAND ${CLANG_TIDY_HELPER_COMMAND} -checks=${CHECK_ARG_STRING} ${arg_SRC_FILES}
+                    WORKING_DIRECTORY ${_wd}
+                    COMMENT "${arg_COMMENT}Running specified clang-tidy source code static analysis checks.")
+        else() #DEFINED CHECKERS
+            add_custom_target(${arg_NAME}
+              COMMAND ${CLANG_TIDY_HELPER_COMMAND} -checks=* ${arg_SRC_FILES}
+                    WORKING_DIRECTORY ${_wd}
+                    COMMENT "${arg_COMMENT}Running default clang-tidy source code static analysis checks.")
+        endif()
+
+        add_custom_target(${interactive_tidy_target_name}
+          COMMAND ${CLANG_TIDY_HELPER_COMMAND} -i ${arg_SRC_FILES}
+                WORKING_DIRECTORY ${_wd}
+                COMMENT "${arg_COMMENT}Running clang-tidy source code static analysis checks.")
+
+        # hook our new target into the proper dependency chain
+        add_dependencies(clang_tidy_check ${arg_NAME})
+        add_dependencies(interactive_clang-tidy_check ${interactive_tidy_target_name})
+
+        # Code check targets should only be run on demand
+        set_property(TARGET ${interactive_tidy_target_name} PROPERTY EXCLUDE_FROM_ALL TRUE)
+        set_property(TARGET ${interactive_tidy_target_name} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+        set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_ALL TRUE)
+        set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+    endif()
+endmacro(blt_add_clang_tidy_target)
 
 
 ##-----------------------------------------------------------------------------

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -304,6 +304,7 @@ endmacro(blt_add_clang_query_target)
 ##                            WORKING_DIRECTORY <Working Directory>
 ##                            COMMENT           <Additional Comment for Target Invocation>
 ##                            CHECKS            <If specified, requires a specific set of checks>
+##                            FIX               <If true, apply fixes>
 ##                            SRC_FILES         [FILE1 [FILE2 ...]] )
 ##
 ## Creates a new target with the given NAME for running clang=tidy over the given SRC_FILES
@@ -313,7 +314,7 @@ macro(blt_add_clang_tidy_target)
 
         ## parse the arguments to the macro
         set(options)
-        set(singleValueArgs NAME COMMENT WORKING_DIRECTORY)
+        set(singleValueArgs NAME COMMENT WORKING_DIRECTORY FIX)
         set(multiValueArgs SRC_FILES CHECKS)
 
         cmake_parse_arguments(arg
@@ -338,6 +339,10 @@ macro(blt_add_clang_tidy_target)
         set(CLANG_TIDY_HELPER_SCRIPT ${BLT_ROOT_DIR}/cmake/run-clang-tidy.py)
         set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_SCRIPT} -clang-tidy-binary=${CLANGTIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR})
 
+        if(arg_FIX)
+            set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_COMMAND} -fix)
+        endif()
+
         if(DEFINED arg_CHECKS)
             STRING(REGEX REPLACE " " ":" CHECK_ARG_STRING ${arg_CHECKS})
             add_custom_target(${arg_NAME}
@@ -346,7 +351,7 @@ macro(blt_add_clang_tidy_target)
                     COMMENT "${arg_COMMENT}Running specified clang-tidy source code static analysis checks.")
         else() #DEFINED CHECKERS
             add_custom_target(${arg_NAME}
-              COMMAND ${CLANG_TIDY_HELPER_COMMAND} -checks=* ${arg_SRC_FILES}
+              COMMAND ${CLANG_TIDY_HELPER_COMMAND} ${arg_SRC_FILES}
                     WORKING_DIRECTORY ${_wd}
                     COMMENT "${arg_COMMENT}Running default clang-tidy source code static analysis checks.")
         endif()

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -56,13 +56,7 @@ if(CLANGQUERY_FOUND)
 endif()
 
 if(CLANGTIDY_FOUND)
-    # note: interactive_clang_tidy_check 
-    # is for the use of code developers who
-    # want to check specific attributes of
-    # specific targets, and does not make 
-    # sense as a dependency of check
     add_custom_target(clang_tidy_check)
-    add_custom_target(interactive_clang-tidy_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_check)
 endif()
 
@@ -70,8 +64,7 @@ endif()
 foreach(target 
         check uncrustify_check astyle_check clangformat_check cppcheck_check
         style uncrustify_style astyle_style clangformat_style
-        clang_query_check interactive_clang_query_check
-        clang_tidy_check interactive_clang_tidy_check)
+        clang_query_check interactive_clang_query_check clang_tidy_check)
     if(TARGET ${target})
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
@@ -335,7 +328,6 @@ macro(blt_add_clang_tidy_target)
             set(_wd ${CMAKE_CURRENT_SOURCE_DIR})
         endif()
    
-        set(interactive_tidy_target_name interactive_tidy_${arg_NAME})
         set(CLANG_TIDY_HELPER_SCRIPT ${BLT_ROOT_DIR}/cmake/run-clang-tidy.py)
         set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_SCRIPT} -clang-tidy-binary=${CLANGTIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR})
 
@@ -356,18 +348,10 @@ macro(blt_add_clang_tidy_target)
                     COMMENT "${arg_COMMENT}Running default clang-tidy source code static analysis checks.")
         endif()
 
-        add_custom_target(${interactive_tidy_target_name}
-          COMMAND ${CLANG_TIDY_HELPER_COMMAND} -i ${arg_SRC_FILES}
-                WORKING_DIRECTORY ${_wd}
-                COMMENT "${arg_COMMENT}Running clang-tidy source code static analysis checks.")
-
         # hook our new target into the proper dependency chain
         add_dependencies(clang_tidy_check ${arg_NAME})
-        add_dependencies(interactive_clang-tidy_check ${interactive_tidy_target_name})
 
         # Code check targets should only be run on demand
-        set_property(TARGET ${interactive_tidy_target_name} PROPERTY EXCLUDE_FROM_ALL TRUE)
-        set_property(TARGET ${interactive_tidy_target_name} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
         set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_ALL TRUE)
         set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
     endif()

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -300,7 +300,7 @@ endmacro(blt_add_clang_query_target)
 ##                            FIX               <If true, apply fixes>
 ##                            SRC_FILES         [FILE1 [FILE2 ...]] )
 ##
-## Creates a new target with the given NAME for running clang=tidy over the given SRC_FILES
+## Creates a new target with the given NAME for running clang-tidy over the given SRC_FILES
 ##-----------------------------------------------------------------------------
 macro(blt_add_clang_tidy_target)
     if(CLANGTIDY_FOUND)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -296,7 +296,7 @@ endmacro(blt_add_clang_query_target)
 ## blt_add_clang_tidy_target( NAME              <Created Target Name>
 ##                            WORKING_DIRECTORY <Working Directory>
 ##                            COMMENT           <Additional Comment for Target Invocation>
-##                            CHECKS            <If specified, requires a specific set of checks>
+##                            CHECKS            <If specified, enables a specific set of checks>
 ##                            FIX               <If true, apply fixes>
 ##                            SRC_FILES         [FILE1 [FILE2 ...]] )
 ##

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -336,7 +336,7 @@ macro(blt_add_clang_tidy_target)
         endif()
 
         if(DEFINED arg_CHECKS)
-            STRING(REGEX REPLACE " " ":" CHECK_ARG_STRING ${arg_CHECKS})
+            STRING(REGEX REPLACE " " "," CHECK_ARG_STRING ${arg_CHECKS})
             add_custom_target(${arg_NAME}
               COMMAND ${CLANG_TIDY_HELPER_COMMAND} -checks=${CHECK_ARG_STRING} ${arg_SRC_FILES}
                     WORKING_DIRECTORY ${_wd}

--- a/cmake/run-clang-tidy.py
+++ b/cmake/run-clang-tidy.py
@@ -1,0 +1,350 @@
+#!/bin/sh
+
+# This file is bilingual. The following shell code finds our preferred python.
+# Following line is a shell no-op, and starts a multi-line Python comment.
+# See https://stackoverflow.com/a/47886254
+""":"
+# prefer python3, then python, then python2
+for cmd in python3 python python2; do
+   command -v > /dev/null $cmd && exec $cmd $0 "$@"
+done
+echo "==> Error: run-clang-format could not find a python interpreter!" >&2
+exit 1
+":"""
+# Line above is a shell no-op, and ends a python multi-line comment.
+# The code above runs this file with our preferred python interpreter.
+
+#===- run-clang-tidy.py - Parallel clang-tidy runner --------*- python -*--===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===-----------------------------------------------------------------------===#
+# FIXME: Integrate with clang-tidy-diff.py
+
+from __future__ import print_function
+
+"""
+Parallel clang-tidy runner
+==========================
+
+Runs clang-tidy over all files in a compilation database. Requires clang-tidy
+and clang-apply-replacements in $PATH.
+
+Example invocations.
+- Run clang-tidy on all files in the current working directory with a default
+  set of checks and show warnings in the cpp files and all project headers.
+    run-clang-tidy.py $PWD
+
+- Fix all header guards.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard
+
+- Fix all header guards included from clang-tidy and header guards
+  for clang-tidy headers.
+    run-clang-tidy.py -fix -checks=-*,llvm-header-guard extra/clang-tidy \
+                      -header-filter=extra/clang-tidy
+
+Compilation database setup:
+http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html
+"""
+
+import argparse
+import glob
+import json
+import multiprocessing
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import traceback
+
+try:
+  import yaml
+except ImportError:
+  yaml = None
+
+is_py2 = sys.version[0] == '2'
+
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
+
+
+def find_compilation_database(path):
+  """Adjusts the directory until a compilation database is found."""
+  result = './'
+  while not os.path.isfile(os.path.join(result, path)):
+    if os.path.realpath(result) == '/':
+      print('Error: could not find compilation database.')
+      sys.exit(1)
+    result += '../'
+  return os.path.realpath(result)
+
+
+def make_absolute(f, directory):
+  if os.path.isabs(f):
+    return f
+  return os.path.normpath(os.path.join(directory, f))
+
+
+def get_tidy_invocation(f, clang_tidy_binary, checks, tmpdir, build_path,
+                        header_filter, allow_enabling_alpha_checkers,
+                        extra_arg, extra_arg_before, quiet, config):
+  """Gets a command line for clang-tidy."""
+  start = [clang_tidy_binary]
+  if allow_enabling_alpha_checkers:
+    start.append('-allow-enabling-analyzer-alpha-checkers')
+  if header_filter is not None:
+    start.append('-header-filter=' + header_filter)
+  if checks:
+    start.append('-checks=' + checks)
+  if tmpdir is not None:
+    start.append('-export-fixes')
+    # Get a temporary file. We immediately close the handle so clang-tidy can
+    # overwrite it.
+    (handle, name) = tempfile.mkstemp(suffix='.yaml', dir=tmpdir)
+    os.close(handle)
+    start.append(name)
+  for arg in extra_arg:
+      start.append('-extra-arg=%s' % arg)
+  for arg in extra_arg_before:
+      start.append('-extra-arg-before=%s' % arg)
+  start.append('-p=' + build_path)
+  if quiet:
+      start.append('-quiet')
+  if config:
+      start.append('-config=' + config)
+  start.append(f)
+  return start
+
+
+def merge_replacement_files(tmpdir, mergefile):
+  """Merge all replacement files in a directory into a single file"""
+  # The fixes suggested by clang-tidy >= 4.0.0 are given under
+  # the top level key 'Diagnostics' in the output yaml files
+  mergekey = "Diagnostics"
+  merged=[]
+  for replacefile in glob.iglob(os.path.join(tmpdir, '*.yaml')):
+    content = yaml.safe_load(open(replacefile, 'r'))
+    if not content:
+      continue # Skip empty files.
+    merged.extend(content.get(mergekey, []))
+
+  if merged:
+    # MainSourceFile: The key is required by the definition inside
+    # include/clang/Tooling/ReplacementsYaml.h, but the value
+    # is actually never used inside clang-apply-replacements,
+    # so we set it to '' here.
+    output = {'MainSourceFile': '', mergekey: merged}
+    with open(mergefile, 'w') as out:
+      yaml.safe_dump(output, out)
+  else:
+    # Empty the file:
+    open(mergefile, 'w').close()
+
+
+def check_clang_apply_replacements_binary(args):
+  """Checks if invoking supplied clang-apply-replacements binary works."""
+  try:
+    subprocess.check_call([args.clang_apply_replacements_binary, '--version'])
+  except:
+    print('Unable to run clang-apply-replacements. Is clang-apply-replacements '
+          'binary correctly specified?', file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
+
+
+def apply_fixes(args, tmpdir):
+  """Calls clang-apply-fixes on a given directory."""
+  invocation = [args.clang_apply_replacements_binary]
+  if args.format:
+    invocation.append('-format')
+  if args.style:
+    invocation.append('-style=' + args.style)
+  invocation.append(tmpdir)
+  subprocess.call(invocation)
+
+
+def run_tidy(args, tmpdir, build_path, queue, lock, failed_files):
+  """Takes filenames out of queue and runs clang-tidy on them."""
+  while True:
+    name = queue.get()
+    invocation = get_tidy_invocation(name, args.clang_tidy_binary, args.checks,
+                                     tmpdir, build_path, args.header_filter,
+                                     args.allow_enabling_alpha_checkers,
+                                     args.extra_arg, args.extra_arg_before,
+                                     args.quiet, args.config)
+
+    proc = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    output, err = proc.communicate()
+    if proc.returncode != 0:
+      failed_files.append(name)
+    with lock:
+      sys.stdout.write(' '.join(invocation) + '\n' + output.decode('utf-8'))
+      if len(err) > 0:
+        sys.stdout.flush()
+        sys.stderr.write(err.decode('utf-8'))
+    queue.task_done()
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Runs clang-tidy over all files '
+                                   'in a compilation database. Requires '
+                                   'clang-tidy and clang-apply-replacements in '
+                                   '$PATH.')
+  parser.add_argument('-allow-enabling-alpha-checkers',
+                      action='store_true', help='allow alpha checkers from '
+                                                'clang-analyzer.')
+  parser.add_argument('-clang-tidy-binary', metavar='PATH',
+                      default='clang-tidy',
+                      help='path to clang-tidy binary')
+  parser.add_argument('-clang-apply-replacements-binary', metavar='PATH',
+                      default='clang-apply-replacements',
+                      help='path to clang-apply-replacements binary')
+  parser.add_argument('-checks', default=None,
+                      help='checks filter, when not specified, use clang-tidy '
+                      'default')
+  parser.add_argument('-config', default=None,
+                      help='Specifies a configuration in YAML/JSON format: '
+                      '  -config="{Checks: \'*\', '
+                      '                       CheckOptions: [{key: x, '
+                      '                                       value: y}]}" '
+                      'When the value is empty, clang-tidy will '
+                      'attempt to find a file named .clang-tidy for '
+                      'each source file in its parent directories.')
+  parser.add_argument('-header-filter', default=None,
+                      help='regular expression matching the names of the '
+                      'headers to output diagnostics from. Diagnostics from '
+                      'the main file of each translation unit are always '
+                      'displayed.')
+  if yaml:
+    parser.add_argument('-export-fixes', metavar='filename', dest='export_fixes',
+                        help='Create a yaml file to store suggested fixes in, '
+                        'which can be applied with clang-apply-replacements.')
+  parser.add_argument('-j', type=int, default=0,
+                      help='number of tidy instances to be run in parallel.')
+  parser.add_argument('files', nargs='*', default=['.*'],
+                      help='files to be processed (regex on path)')
+  parser.add_argument('-fix', action='store_true', help='apply fix-its')
+  parser.add_argument('-format', action='store_true', help='Reformat code '
+                      'after applying fixes')
+  parser.add_argument('-style', default='file', help='The style of reformat '
+                      'code after applying fixes')
+  parser.add_argument('-p', dest='build_path',
+                      help='Path used to read a compile command database.')
+  parser.add_argument('-extra-arg', dest='extra_arg',
+                      action='append', default=[],
+                      help='Additional argument to append to the compiler '
+                      'command line.')
+  parser.add_argument('-extra-arg-before', dest='extra_arg_before',
+                      action='append', default=[],
+                      help='Additional argument to prepend to the compiler '
+                      'command line.')
+  parser.add_argument('-quiet', action='store_true',
+                      help='Run clang-tidy in quiet mode')
+  args = parser.parse_args()
+
+  db_path = 'compile_commands.json'
+
+  if args.build_path is not None:
+    build_path = args.build_path
+  else:
+    # Find our database
+    build_path = find_compilation_database(db_path)
+
+  try:
+    invocation = [args.clang_tidy_binary, '-list-checks']
+    if args.allow_enabling_alpha_checkers:
+      invocation.append('-allow-enabling-analyzer-alpha-checkers')
+    invocation.append('-p=' + build_path)
+    if args.checks:
+      invocation.append('-checks=' + args.checks)
+    invocation.append('-')
+    if args.quiet:
+      # Even with -quiet we still want to check if we can call clang-tidy.
+      with open(os.devnull, 'w') as dev_null:
+        subprocess.check_call(invocation, stdout=dev_null)
+    else:
+      subprocess.check_call(invocation)
+  except:
+    print("Unable to run clang-tidy.", file=sys.stderr)
+    sys.exit(1)
+
+  # Load the database and extract all files.
+  database = json.load(open(os.path.join(build_path, db_path)))
+  files = [make_absolute(entry['file'], entry['directory'])
+           for entry in database]
+
+  max_task = args.j
+  if max_task == 0:
+    max_task = multiprocessing.cpu_count()
+
+  tmpdir = None
+  if args.fix or (yaml and args.export_fixes):
+    check_clang_apply_replacements_binary(args)
+    tmpdir = tempfile.mkdtemp()
+
+  # Build up a big regexy filter from all command line arguments.
+  file_name_re = re.compile('|'.join(args.files))
+
+  return_code = 0
+  try:
+    # Spin up a bunch of tidy-launching threads.
+    task_queue = queue.Queue(max_task)
+    # List of files with a non-zero return code.
+    failed_files = []
+    lock = threading.Lock()
+    for _ in range(max_task):
+      t = threading.Thread(target=run_tidy,
+                           args=(args, tmpdir, build_path, task_queue, lock, failed_files))
+      t.daemon = True
+      t.start()
+
+    # Fill the queue with files.
+    for name in files:
+      if file_name_re.search(name):
+        task_queue.put(name)
+
+    # Wait for all threads to be done.
+    task_queue.join()
+    if len(failed_files):
+      return_code = 1
+
+  except KeyboardInterrupt:
+    # This is a sad hack. Unfortunately subprocess goes
+    # bonkers with ctrl-c and we start forking merrily.
+    print('\nCtrl-C detected, goodbye.')
+    if tmpdir:
+      shutil.rmtree(tmpdir)
+    os.kill(0, 9)
+
+  if yaml and args.export_fixes:
+    print('Writing fixes to ' + args.export_fixes + ' ...')
+    try:
+      merge_replacement_files(tmpdir, args.export_fixes)
+    except:
+      print('Error exporting fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code=1
+
+  if args.fix:
+    print('Applying fixes ...')
+    try:
+      apply_fixes(args, tmpdir)
+    except:
+      print('Error applying fixes.\n', file=sys.stderr)
+      traceback.print_exc()
+      return_code = 1
+
+  if tmpdir:
+    shutil.rmtree(tmpdir)
+  sys.exit(return_code)
+
+
+if __name__ == '__main__':
+  main()

--- a/cmake/thirdparty/SetupThirdParty.cmake
+++ b/cmake/thirdparty/SetupThirdParty.cmake
@@ -104,9 +104,12 @@ blt_find_executable(NAME        Cppcheck
 
 
 #------------------------------------
-# Static analysis via clang-query
+# Static analysis via clang-query and clang-tidy
 #------------------------------------
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja")
     blt_find_executable(NAME        ClangQuery
                         EXECUTABLES clang-query)
+
+    blt_find_executable(NAME        ClangTidy
+                        EXECUTABLES clang-tidy)
 endif()

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -91,8 +91,12 @@ This macro supports the following static analysis tools with their requirements:
 
   * CLANGQUERY_EXECUTABLE is defined and found prior to calling this macro
 
+- clang-tidy
+
+  * CLANGTIDY_EXECUTABLE is defined and found prior to calling this macro
+
 These are added as children to the `check` build target and produce child build targets
-that follow the pattern `<PREFIX>_<cppcheck|clangquery>_check`.
+that follow the pattern `<PREFIX>_<cppcheck|clangquery|clang_tidy>_check`.
 
 blt_add_clang_query_target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,6 +178,46 @@ SRC_FILES
 
 Cppcheck is a static analysis tool for C/C++ code. More information about
 Cppcheck can be found `here <http://cppcheck.sourceforge.net/>`_.
+
+
+blt_add_clang_tidy_target
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cmake
+
+    blt_add_clang_tidy_target( NAME              <Created Target Name>
+                               WORKING_DIRECTORY <Working Directory>
+                               COMMENT           <Additional Comment for Target Invocation>
+                               CHECKS            <If specified, enables a specific set of checks>
+                               FIX               <TRUE | FALSE (default)>
+                               SRC_FILES         [source1 [source2 ...]] )
+
+Creates a new build target for running clang-tidy.
+
+NAME
+  Name of created build target
+
+WORKING_DIRECTORY
+  Directory in which the clang-tidy command is run. Defaults to where macro is called.
+
+COMMENT
+  Comment prepended to the build target output
+
+CHECKS
+  list of checks to be run on the selected source files, available checks are listed
+  `here <https://clang.llvm.org/extra/clang-tidy/checks/list.html>`_.
+
+FIX
+  Applies fixes for checks (a subset of clang-tidy checks specify how they should be resolved)
+
+SRC_FILES
+  Source list that clang-tidy will be ran on
+
+Clang-tidy is a tool used for diagnosing and fixing typical programming errors. It is useful for enforcing
+coding standards and rules on your source code.  Clang-tidy is documented `here <https://clang.llvm.org/extra/clang-tidy/index.html>`_.
+
+CHECKS are the static analysis "rules" to specifically run on the target. 
+If no checks are specified, clang-tidy will run the default available static analysis checks.
 
 
 blt_add_astyle_target

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -96,7 +96,7 @@ This macro supports the following static analysis tools with their requirements:
   * CLANGTIDY_EXECUTABLE is defined and found prior to calling this macro
 
 These are added as children to the `check` build target and produce child build targets
-that follow the pattern `<PREFIX>_<cppcheck|clangquery|clang_tidy>_check`.
+that follow the pattern `<PREFIX>_<cppcheck|clang_query|clang_tidy>_check`.
 
 blt_add_clang_query_target
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/host-configs/llnl/toss_3_x86_64_ib/clang@6.0.0-static-analysis.cmake
+++ b/host-configs/llnl/toss_3_x86_64_ib/clang@6.0.0-static-analysis.cmake
@@ -42,6 +42,9 @@ set(gtest_defines "-DGTEST_HAS_CXXABI_H_=0" CACHE STRING "")
 set(ClangQuery_DIR ${CLANG_HOME}/bin)
 set(ENABLE_CLANGQUERY ON CACHE BOOL "")
 
+set(ClangTidy_DIR ${CLANG_HOME}/bin)
+set(ENABLE_CLANGTIDY ON CACHE BOOL "")
+
 #------------------------------------------------------------------------------
 # MPI Support
 #------------------------------------------------------------------------------
@@ -54,4 +57,3 @@ set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpifort" CACHE PATH "")
 
 set(MPIEXEC              "/usr/bin/srun" CACHE PATH "")
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE PATH "")
-

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -261,7 +261,7 @@ endforeach()
 
 add_subdirectory(src/object_library_test)
 
-if(ENABLE_CLANGQUERY)
+if(ENABLE_CLANGQUERY OR ENABLE_CLANGTIDY)
   add_subdirectory(src/static_analysis)
 endif()
 

--- a/tests/internal/src/static_analysis/CMakeLists.txt
+++ b/tests/internal/src/static_analysis/CMakeLists.txt
@@ -18,3 +18,9 @@ blt_add_code_checks(PREFIX all
 blt_add_clang_query_target(NAME filtered CHECKERS "if-stmt"
   SRC_FILES well_analyzed_source.cpp)
 
+blt_add_executable( NAME subtle_error
+                    SOURCES subtle_error_source.cpp
+)
+blt_add_clang_tidy_target(NAME check_for_subtle_error 
+                          CHECKS "clang-analyzer-*"
+                          SRC_FILES subtle_error_source.cpp)

--- a/tests/internal/src/static_analysis/subtle_error_source.cpp
+++ b/tests/internal/src/static_analysis/subtle_error_source.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other BLT Project Developers. See the top-level COPYRIGHT file for details
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * This file contains a subtle C++ error that results in a runtime crash.
+ * 
+ * The "subtle_error" target ("make subtle_error") should behave incorrectly when run.
+ * 
+ * The "check_for_subtle_error" target ("make check_for_subtle_error")
+ * will run the clang-tidy static analyzer and report the error via stdout.
+ * 
+ * See https://clang.llvm.org/extra/clang-tidy/checks/list.html
+ * for the full list of available checks
+ */
+
+#include <iostream>
+
+int main()
+{
+  int array[1] = {5};
+  int first_element = array[1];
+  std::cout << first_element << "\n";
+}


### PR DESCRIPTION
In addition to adding a new macro for creating a clang-tidy target, this PR pulls in the LLVM project Python wrapper script (same approach as was used for clang-format).