### PR TITLE
Add BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE variable

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added support for clang-tidy static analysis check
 - Added ability to change the output name of an executable via the OUTPUT_NAME
   parameter of blt_add_executable
+- Added variable BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE that will be used to filter
+  implicit link directories for all languages
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed
@@ -29,6 +31,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Turn off system includes for registered libraries when using the PGI compiler
 - Removed unneeded INTERFACE system includes added by googletest that was causing problems
   in PGI builds (BLT was adding them already to the register library calls)
+- Removed variable BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE, functionality now
+  provided for all languages using BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE variable
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -418,3 +418,22 @@ endif()
 foreach(flagVar ${langFlags}  "CMAKE_EXE_LINKER_FLAGS" )
     message(STATUS "${flagVar} flags are:  ${${flagVar}}")
 endforeach()
+
+##################################
+# Remove implicit link directories
+##################################
+if(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE)
+    message(STATUS "Removing implicit link directories: ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE}")
+    list(REMOVE_ITEM CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
+    message(STATUS "Updated CXX implicit Link Directories: ${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES}")
+    list(REMOVE_ITEM CMAKE_C_IMPLICIT_LINK_DIRECTORIES ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
+    message(STATUS "Updated C implicit Link Directories: ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES}")
+    if (ENABLE_FORTRAN)
+        list(REMOVE_ITEM CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
+        message(STATUS "Updated Fortran implicit Link Directories: ${CMAKE_Fortran_IMPLICIT_LINK_DIRECTORIES}")
+    endif ()
+    if (ENABLE_CUDA)
+        list(REMOVE_ITEM CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES ${BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
+        message(STATUS "Updated CUDA implicit Link Directories: ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}")
+    endif ()
+endif()

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -159,13 +159,3 @@ blt_register_library(NAME          cuda
 blt_register_library(NAME      cuda_runtime
                      INCLUDES  ${CUDA_INCLUDE_DIRS}
                      LIBRARIES ${CUDA_LIBRARIES})
-
-# Allow the removal of implicitly found link directories
-# Note: This is a very specific fix for working around CMake adding implicit link
-# directories returned by the BlueOS compilers to link CUDA executables
-# They are added by logic found in the CMake source: Modules/CMakeTestCUDACompiler.cmake
-if(BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE)
-    message(STATUS "Removing implicit CUDA link directories: ${BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE}")
-    list(REMOVE_ITEM CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES ${BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE})
-    message(STATUS "Updated CUDA Implicit Link Directories: ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES}")
-endif()

--- a/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17.cmake
+++ b/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17.cmake
@@ -65,4 +65,4 @@ set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
 # Very specific fix for working around CMake adding implicit link directories returned by the BlueOS
 # compilers to link CUDA executables 
-set(BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")

--- a/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17_no_separable.cmake
+++ b/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17_no_separable.cmake
@@ -63,4 +63,4 @@ set(ENABLE_GTEST_DEATH_TESTS OFF CACHE BOOL "")
 
 # Very specific fix for working around CMake adding implicit link directories returned by the BlueOS
 # compilers to link CUDA executables 
-set(BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")
+set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/lib64" CACHE STRING "")


### PR DESCRIPTION
This is used to filter the implicit link directories for all enabled languages