### PR TITLE
Add options to enforce autoformatter version

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,7 +19,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added variable BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE that will be used to filter
   implicit link directories for all languages
 - Added user option for enforcing specific versions of autoformatters - the new options are
-  ``BLT_REQUIRED_ASTYLE_VER``, ``BLT_REQUIRED_CLANGFORMAT_VER``, and ``BLT_REQUIRED_UNCRUSTIFY_VER``
+  ``BLT_REQUIRED_ASTYLE_VERSION``, ``BLT_REQUIRED_CLANGFORMAT_VERSION``, and ``BLT_REQUIRED_UNCRUSTIFY_VERSION``
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,7 +18,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   parameter of blt_add_executable
 - Added variable BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE that will be used to filter
   implicit link directories for all languages
-- Added user option for enforcing specific versions of autoformatters
+- Added user option for enforcing specific versions of autoformatters - the new options are
+  ``BLT_REQUIRED_ASTYLE_VER``, ``BLT_REQUIRED_CLANGFORMAT_VER``, and ``BLT_REQUIRED_UNCRUSTIFY_VER``
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -18,6 +18,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   parameter of blt_add_executable
 - Added variable BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE that will be used to filter
   implicit link directories for all languages
+- Added user option for enforcing specific versions of autoformatters
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -10,7 +10,7 @@ add_custom_target(${BLT_CODE_CHECK_TARGET_NAME})
 add_custom_target(${BLT_CODE_STYLE_TARGET_NAME})
 
 if(ASTYLE_FOUND)
-    set(BLT_REQUIRED_ASTYLE_VER "" CACHE STRING "Required version of astyle")
+    set(BLT_REQUIRED_ASTYLE_VERSION "" CACHE STRING "Required version of astyle")
     # targets for verifying formatting
     add_custom_target(astyle_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} astyle_check)
@@ -21,7 +21,7 @@ if(ASTYLE_FOUND)
 endif()
 
 if(CLANGFORMAT_FOUND)
-    set(BLT_REQUIRED_CLANGFORMAT_VER "" CACHE STRING "Required version of clang-format")
+    set(BLT_REQUIRED_CLANGFORMAT_VERSION "" CACHE STRING "Required version of clang-format")
     # targets for verifying formatting
     add_custom_target(clangformat_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clangformat_check)
@@ -32,7 +32,7 @@ if(CLANGFORMAT_FOUND)
 endif()
 
 if(UNCRUSTIFY_FOUND)
-    set(BLT_REQUIRED_UNCRUSTIFY_VER "" CACHE STRING "Required version of uncrustify")
+    set(BLT_REQUIRED_UNCRUSTIFY_VERSION "" CACHE STRING "Required version of uncrustify")
     # targets for verifying formatting
     add_custom_target(uncrustify_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} uncrustify_check)
@@ -495,12 +495,12 @@ macro(blt_add_astyle_target)
         OUTPUT_STRIP_TRAILING_WHITESPACE )
     string(REGEX MATCH "([0-9]+(\\.)?)+$" _astyle_version ${_version_str})
 
-    if(BLT_REQUIRED_ASTYLE_VER)
+    if(BLT_REQUIRED_ASTYLE_VERSION)
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_astyle_version} ${BLT_REQUIRED_ASTYLE_VER} VERSION_POS)
+        string(FIND ${_astyle_version} ${BLT_REQUIRED_ASTYLE_VERSION} VERSION_POS)
         if (NOT VERSION_POS EQUAL 0)
-            message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQUIRED_ASTYLE_VER} is required, found ${_astyle_version}")
+            message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQUIRED_ASTYLE_VERSION} is required, found ${_astyle_version}")
         endif()
     endif()
 
@@ -594,7 +594,7 @@ macro(blt_add_clangformat_target)
     endif()
 
     # If a required version was set, check it
-    if(BLT_REQUIRED_CLANGFORMAT_VER)
+    if(BLT_REQUIRED_CLANGFORMAT_VERSION)
         execute_process(COMMAND ${CLANGFORMAT_EXECUTABLE} --version
                         OUTPUT_VARIABLE _version_str
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -602,9 +602,9 @@ macro(blt_add_clangformat_target)
         string(REGEX MATCH "([0-9a-zA-Z\\-]+(\\.)?)+$" _clangformat_version ${_version_str})
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_clangformat_version} ${BLT_REQUIRED_CLANGFORMAT_VER} VERSION_POS)
+        string(FIND ${_clangformat_version} ${BLT_REQUIRED_CLANGFORMAT_VERSION} VERSION_POS)
         if (NOT VERSION_POS EQUAL 0)
-            message(FATAL_ERROR "blt_add_clangformat_target: clang-format ${BLT_REQUIRED_CLANGFORMAT_VER} is required, found ${_clangformat_version}")
+            message(FATAL_ERROR "blt_add_clangformat_target: clang-format ${BLT_REQUIRED_CLANGFORMAT_VERSION} is required, found ${_clangformat_version}")
         endif()
     endif()
 
@@ -698,12 +698,12 @@ macro(blt_add_uncrustify_target)
         OUTPUT_STRIP_TRAILING_WHITESPACE )
     string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?" _uncrustify_version ${_version_str})
 
-    if(BLT_REQUIRED_UNCRUSTIFY_VER)
+    if(BLT_REQUIRED_UNCRUSTIFY_VERSION)
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_uncrustify_version} ${BLT_REQUIRED_UNCRUSTIFY_VER} VERSION_POS)
+        string(FIND ${_uncrustify_version} ${BLT_REQUIRED_UNCRUSTIFY_VERSION} VERSION_POS)
         if (NOT VERSION_POS EQUAL 0)
-            message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQUIRED_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
+            message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQUIRED_UNCRUSTIFY_VERSION} is required, found ${_uncrustify_version}")
         endif()
     endif()
 

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -505,6 +505,15 @@ macro(blt_add_astyle_target)
                             " Current AStyle executable: '${ASTYLE_EXECUTABLE}' "
                             " Current AStyle version is: ${_astyle_version}."    )
         endif()
+
+        if(BLT_REQD_ASTYLE_VER)
+            # The user may only specify a part of the version (e.g. just the maj ver)
+            # so check for substring
+            string(FIND ${_astyle_version} ${BLT_REQD_ASTYLE_VER} VERSION_MATCHES)
+            if (VERSION_MATCHES EQUAL -1)
+                message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQD_ASTYLE_VER} is required, found ${_astyle_version}")
+            endif()
+        endif()
     endif()
 
     if(_generate_target)
@@ -580,6 +589,21 @@ macro(blt_add_clangformat_target)
         set(_wd ${arg_WORKING_DIRECTORY})
     else()
         set(_wd ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
+
+    # If a required version was set, check it
+    if(BLT_REQD_CLANGFORMAT_VER)
+        execute_process(COMMAND ${CLANGFORMAT_EXECUTABLE} --version
+                        OUTPUT_VARIABLE _version_str
+                        OUTPUT_STRIP_TRAILING_WHITESPACE)
+        # The version number is the last token - can contain non-numeric
+        string(REGEX MATCH "([0-9a-zA-Z\\-]+(\\.)?)+$" _clangformat_version ${_version_str})
+        # The user may only specify a part of the version (e.g. just the maj ver)
+        # so check for substring
+        string(FIND ${_clangformat_version} ${BLT_REQD_CLANGFORMAT_VER} VERSION_MATCHES)
+        if (VERSION_MATCHES EQUAL -1)
+            message(FATAL_ERROR "blt_add_clangformat_target: clang-format ${BLT_REQD_CLANGFORMAT_VER} is required, found ${_clangformat_version}")
+        endif()
     endif()
 
     set(_generate_target TRUE)
@@ -684,7 +708,17 @@ macro(blt_add_uncrustify_target)
                             " for style check targets. "
                             " Current uncrustify executable: '${UNCRUSTIFY_EXECUTABLE}' "
                             " Current uncrustify version is: ${_uncrustify_version}."    )
-        endif()        
+        endif()
+
+        if(BLT_REQD_UNCRUSTIFY_VER)
+            # The user may only specify a part of the version (e.g. just the maj ver)
+            # so check for substring
+            string(FIND ${_uncrustify_version} ${BLT_REQD_UNCRUSTIFY_VER} VERSION_MATCHES)
+            if (VERSION_MATCHES EQUAL -1)
+                message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQD_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
+            endif()
+        endif()
+    endif() 
     endif()
 
     if(_generate_target)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -10,7 +10,7 @@ add_custom_target(${BLT_CODE_CHECK_TARGET_NAME})
 add_custom_target(${BLT_CODE_STYLE_TARGET_NAME})
 
 if(ASTYLE_FOUND)
-    set(BLT_REQD_ASTYLE_VER "" CACHE STRING "Required version of astyle")
+    set(BLT_REQUIRED_ASTYLE_VER "" CACHE STRING "Required version of astyle")
     # targets for verifying formatting
     add_custom_target(astyle_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} astyle_check)
@@ -21,7 +21,7 @@ if(ASTYLE_FOUND)
 endif()
 
 if(CLANGFORMAT_FOUND)
-    set(BLT_REQD_CLANGFORMAT_VER "" CACHE STRING "Required version of clang-format")
+    set(BLT_REQUIRED_CLANGFORMAT_VER "" CACHE STRING "Required version of clang-format")
     # targets for verifying formatting
     add_custom_target(clangformat_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clangformat_check)
@@ -32,7 +32,7 @@ if(CLANGFORMAT_FOUND)
 endif()
 
 if(UNCRUSTIFY_FOUND)
-    set(BLT_REQD_UNCRUSTIFY_VER "" CACHE STRING "Required version of uncrustify")
+    set(BLT_REQUIRED_UNCRUSTIFY_VER "" CACHE STRING "Required version of uncrustify")
     # targets for verifying formatting
     add_custom_target(uncrustify_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} uncrustify_check)
@@ -495,12 +495,12 @@ macro(blt_add_astyle_target)
         OUTPUT_STRIP_TRAILING_WHITESPACE )
     string(REGEX MATCH "([0-9]+(\\.)?)+$" _astyle_version ${_version_str})
 
-    if(BLT_REQD_ASTYLE_VER)
+    if(BLT_REQUIRED_ASTYLE_VER)
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_astyle_version} ${BLT_REQD_ASTYLE_VER} VERSION_MATCHES)
-        if (VERSION_MATCHES EQUAL -1)
-            message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQD_ASTYLE_VER} is required, found ${_astyle_version}")
+        string(FIND ${_astyle_version} ${BLT_REQUIRED_ASTYLE_VER} VERSION_POS)
+        if (NOT VERSION_POS EQUAL 0)
+            message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQUIRED_ASTYLE_VER} is required, found ${_astyle_version}")
         endif()
     endif()
 
@@ -594,7 +594,7 @@ macro(blt_add_clangformat_target)
     endif()
 
     # If a required version was set, check it
-    if(BLT_REQD_CLANGFORMAT_VER)
+    if(BLT_REQUIRED_CLANGFORMAT_VER)
         execute_process(COMMAND ${CLANGFORMAT_EXECUTABLE} --version
                         OUTPUT_VARIABLE _version_str
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -602,9 +602,9 @@ macro(blt_add_clangformat_target)
         string(REGEX MATCH "([0-9a-zA-Z\\-]+(\\.)?)+$" _clangformat_version ${_version_str})
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_clangformat_version} ${BLT_REQD_CLANGFORMAT_VER} VERSION_MATCHES)
-        if (VERSION_MATCHES EQUAL -1)
-            message(FATAL_ERROR "blt_add_clangformat_target: clang-format ${BLT_REQD_CLANGFORMAT_VER} is required, found ${_clangformat_version}")
+        string(FIND ${_clangformat_version} ${BLT_REQUIRED_CLANGFORMAT_VER} VERSION_POS)
+        if (NOT VERSION_POS EQUAL 0)
+            message(FATAL_ERROR "blt_add_clangformat_target: clang-format ${BLT_REQUIRED_CLANGFORMAT_VER} is required, found ${_clangformat_version}")
         endif()
     endif()
 
@@ -698,12 +698,12 @@ macro(blt_add_uncrustify_target)
         OUTPUT_STRIP_TRAILING_WHITESPACE )
     string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?" _uncrustify_version ${_version_str})
 
-    if(BLT_REQD_UNCRUSTIFY_VER)
+    if(BLT_REQUIRED_UNCRUSTIFY_VER)
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring
-        string(FIND ${_uncrustify_version} ${BLT_REQD_UNCRUSTIFY_VER} VERSION_MATCHES)
-        if (VERSION_MATCHES EQUAL -1)
-            message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQD_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
+        string(FIND ${_uncrustify_version} ${BLT_REQUIRED_UNCRUSTIFY_VER} VERSION_POS)
+        if (NOT VERSION_POS EQUAL 0)
+            message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQUIRED_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
         endif()
     endif()
 

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -10,6 +10,7 @@ add_custom_target(${BLT_CODE_CHECK_TARGET_NAME})
 add_custom_target(${BLT_CODE_STYLE_TARGET_NAME})
 
 if(ASTYLE_FOUND)
+    set(BLT_REQD_ASTYLE_VER "" CACHE STRING "Required version of astyle")
     # targets for verifying formatting
     add_custom_target(astyle_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} astyle_check)
@@ -20,6 +21,7 @@ if(ASTYLE_FOUND)
 endif()
 
 if(CLANGFORMAT_FOUND)
+    set(BLT_REQD_CLANGFORMAT_VER "" CACHE STRING "Required version of clang-format")
     # targets for verifying formatting
     add_custom_target(clangformat_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clangformat_check)
@@ -30,6 +32,7 @@ if(CLANGFORMAT_FOUND)
 endif()
 
 if(UNCRUSTIFY_FOUND)
+    set(BLT_REQD_UNCRUSTIFY_VER "" CACHE STRING "Required version of uncrustify")
     # targets for verifying formatting
     add_custom_target(uncrustify_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} uncrustify_check)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -487,19 +487,27 @@ macro(blt_add_astyle_target)
 
     set(_generate_target TRUE)
 
+    # Check the version -- output is of the form "Artistic Style Version X.Y.Z"
+    execute_process(
+        COMMAND ${ASTYLE_EXECUTABLE} --version
+        OUTPUT_VARIABLE _version_str
+        ERROR_VARIABLE  _version_str
+        OUTPUT_STRIP_TRAILING_WHITESPACE )
+    string(REGEX MATCH "([0-9]+(\\.)?)+$" _astyle_version ${_version_str})
+
+    if(BLT_REQD_ASTYLE_VER)
+        # The user may only specify a part of the version (e.g. just the maj ver)
+        # so check for substring
+        string(FIND ${_astyle_version} ${BLT_REQD_ASTYLE_VER} VERSION_MATCHES)
+        if (VERSION_MATCHES EQUAL -1)
+            message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQD_ASTYLE_VER} is required, found ${_astyle_version}")
+        endif()
+    endif()
+
     if(${arg_MODIFY_FILES})
         set(MODIFY_FILES_FLAG --suffix=none)
     else()
         set(MODIFY_FILES_FLAG --dry-run)
-
-        # Check the version -- output is of the form "Artistic Style Version X.Y.Z"
-        execute_process(
-            COMMAND ${ASTYLE_EXECUTABLE} --version
-            OUTPUT_VARIABLE _version_str
-            ERROR_VARIABLE  _version_str
-            OUTPUT_STRIP_TRAILING_WHITESPACE )
-        string(REGEX MATCH "([0-9]+(\\.)?)+$" _astyle_version ${_version_str})
-        
         # Skip 'check' target if version is not high enough 
         if(_astyle_version VERSION_LESS 2.05)
             set(_generate_target FALSE)
@@ -507,15 +515,6 @@ macro(blt_add_astyle_target)
                             " for style check targets. "
                             " Current AStyle executable: '${ASTYLE_EXECUTABLE}' "
                             " Current AStyle version is: ${_astyle_version}."    )
-        endif()
-
-        if(BLT_REQD_ASTYLE_VER)
-            # The user may only specify a part of the version (e.g. just the maj ver)
-            # so check for substring
-            string(FIND ${_astyle_version} ${BLT_REQD_ASTYLE_VER} VERSION_MATCHES)
-            if (VERSION_MATCHES EQUAL -1)
-                message(FATAL_ERROR "blt_add_astyle_target: astyle ${BLT_REQD_ASTYLE_VER} is required, found ${_astyle_version}")
-            endif()
         endif()
     endif()
 
@@ -692,17 +691,26 @@ macro(blt_add_uncrustify_target)
 
     set(_generate_target TRUE)
 
+    # Check the version -- output is of the form "uncrustify X.Y.Z"
+    execute_process(
+        COMMAND ${UNCRUSTIFY_EXECUTABLE} --version
+        OUTPUT_VARIABLE _version_str
+        OUTPUT_STRIP_TRAILING_WHITESPACE )
+    string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?" _uncrustify_version ${_version_str})
+
+    if(BLT_REQD_UNCRUSTIFY_VER)
+        # The user may only specify a part of the version (e.g. just the maj ver)
+        # so check for substring
+        string(FIND ${_uncrustify_version} ${BLT_REQD_UNCRUSTIFY_VER} VERSION_MATCHES)
+        if (VERSION_MATCHES EQUAL -1)
+            message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQD_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
+        endif()
+    endif()
+
     if(${arg_MODIFY_FILES})
         set(MODIFY_FILES_FLAG --replace;--no-backup)
     else()
         set(MODIFY_FILES_FLAG "--check")
-
-        # Check the version -- output is of the form "uncrustify X.Y.Z"
-        execute_process(
-            COMMAND ${UNCRUSTIFY_EXECUTABLE} --version
-            OUTPUT_VARIABLE _version_str
-            OUTPUT_STRIP_TRAILING_WHITESPACE )
-        string(REGEX MATCH "([0-9]+(\\.)?)+(_[a-zA-Z])?" _uncrustify_version ${_version_str})
 
         # Skip 'check' target if version is not high enough 
         if(_uncrustify_version VERSION_LESS 0.61)
@@ -712,16 +720,6 @@ macro(blt_add_uncrustify_target)
                             " Current uncrustify executable: '${UNCRUSTIFY_EXECUTABLE}' "
                             " Current uncrustify version is: ${_uncrustify_version}."    )
         endif()
-
-        if(BLT_REQD_UNCRUSTIFY_VER)
-            # The user may only specify a part of the version (e.g. just the maj ver)
-            # so check for substring
-            string(FIND ${_uncrustify_version} ${BLT_REQD_UNCRUSTIFY_VER} VERSION_MATCHES)
-            if (VERSION_MATCHES EQUAL -1)
-                message(FATAL_ERROR "blt_add_uncrustify_target: uncrustify ${BLT_REQD_UNCRUSTIFY_VER} is required, found ${_uncrustify_version}")
-            endif()
-        endif()
-    endif() 
     endif()
 
     if(_generate_target)

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -84,6 +84,17 @@ are out of compliance with your code formatting and a `style` build target that 
 modify your source files.  It also creates smaller child build targets that follow the pattern
 `<PREFIX>_<astyle|clangformat|uncrustify>_<check|style>`.
 
+If a particular version of a code formatting tool is required, you can configure BLT to enforce
+that version by setting ``BLT_REQD_<CLANGFORMAT|ASTYLE|UNCRUSTIFY>_VER`` to as much of the version
+as you need.  For example:
+
+.. code-block:: cmake
+
+  # If astyle major version 3 is required (3.0, 3.1, etc are acceptable)
+  set(BLT_REQD_ASTYLE_VER "3")
+  # Or, if exactly 3.1 is needed
+  set(BLT_REQD_ASTYLE_VER "3.1")
+
 This macro supports the following static analysis tools with their requirements:
 
 - CppCheck

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -85,15 +85,15 @@ modify your source files.  It also creates smaller child build targets that foll
 `<PREFIX>_<astyle|clangformat|uncrustify>_<check|style>`.
 
 If a particular version of a code formatting tool is required, you can configure BLT to enforce
-that version by setting ``BLT_REQD_<CLANGFORMAT|ASTYLE|UNCRUSTIFY>_VER`` to as much of the version
+that version by setting ``BLT_REQUIRED_<CLANGFORMAT|ASTYLE|UNCRUSTIFY>_VER`` to as much of the version
 as you need.  For example:
 
 .. code-block:: cmake
 
   # If astyle major version 3 is required (3.0, 3.1, etc are acceptable)
-  set(BLT_REQD_ASTYLE_VER "3")
+  set(BLT_REQUIRED_ASTYLE_VER "3")
   # Or, if exactly 3.1 is needed
-  set(BLT_REQD_ASTYLE_VER "3.1")
+  set(BLT_REQUIRED_ASTYLE_VER "3.1")
 
 This macro supports the following static analysis tools with their requirements:
 

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -85,15 +85,15 @@ modify your source files.  It also creates smaller child build targets that foll
 `<PREFIX>_<astyle|clangformat|uncrustify>_<check|style>`.
 
 If a particular version of a code formatting tool is required, you can configure BLT to enforce
-that version by setting ``BLT_REQUIRED_<CLANGFORMAT|ASTYLE|UNCRUSTIFY>_VER`` to as much of the version
+that version by setting ``BLT_REQUIRED_<CLANGFORMAT|ASTYLE|UNCRUSTIFY>_VERSION`` to as much of the version
 as you need.  For example:
 
 .. code-block:: cmake
 
   # If astyle major version 3 is required (3.0, 3.1, etc are acceptable)
-  set(BLT_REQUIRED_ASTYLE_VER "3")
+  set(BLT_REQUIRED_ASTYLE_VERSION "3")
   # Or, if exactly 3.1 is needed
-  set(BLT_REQUIRED_ASTYLE_VER "3.1")
+  set(BLT_REQUIRED_ASTYLE_VERSION "3.1")
 
 This macro supports the following static analysis tools with their requirements:
 

--- a/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17.cmake
+++ b/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17.cmake
@@ -18,8 +18,8 @@
 # Compilers
 #---------------------------------------
 
-set(_CLANG_VER "clang-upstream-2019.08.15")
-set(_CLANG_DIR "/usr/tce/packages/clang/${_CLANG_VER}")
+set(_CLANG_VERSION "clang-upstream-2019.08.15")
+set(_CLANG_DIR "/usr/tce/packages/clang/${_CLANG_VERSION}")
 set(_GCC_DIR "/usr/tce/packages/gcc/gcc-8.3.1")
 
 set(CMAKE_C_COMPILER "${_CLANG_DIR}/bin/clang" CACHE PATH "")
@@ -37,7 +37,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,${_GCC_DIR}/lib" CACHE PATH "Adds a missin
 #---------------------------------------
 set(ENABLE_MPI ON CACHE BOOL "")
 
-set(_MPI_BASE_DIR "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-${_CLANG_VER}")
+set(_MPI_BASE_DIR "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-${_CLANG_VERSION}")
 
 set(MPI_C_COMPILER "${_MPI_BASE_DIR}/bin/mpicc" CACHE PATH "")
 set(MPI_CXX_COMPILER "${_MPI_BASE_DIR}/bin/mpicxx" CACHE PATH "")

--- a/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17_no_separable.cmake
+++ b/host-configs/llnl/blueos_3_ppc64le_ib_p9/clang@upstream_nvcc_c++17_no_separable.cmake
@@ -18,8 +18,8 @@
 # Compilers
 #---------------------------------------
 
-set(_CLANG_VER "clang-upstream-2019.08.15")
-set(_CLANG_DIR "/usr/tce/packages/clang/${_CLANG_VER}")
+set(_CLANG_VERSION "clang-upstream-2019.08.15")
+set(_CLANG_DIR "/usr/tce/packages/clang/${_CLANG_VERSION}")
 set(_GCC_DIR "/usr/tce/packages/gcc/gcc-8.3.1")
 
 set(CMAKE_C_COMPILER "${_CLANG_DIR}/bin/clang" CACHE PATH "")
@@ -37,7 +37,7 @@ set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,${_GCC_DIR}/lib" CACHE PATH "Adds a missin
 #---------------------------------------
 set(ENABLE_MPI ON CACHE BOOL "")
 
-set(_MPI_BASE_DIR "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-${_CLANG_VER}")
+set(_MPI_BASE_DIR "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-${_CLANG_VERSION}")
 
 set(MPI_C_COMPILER "${_MPI_BASE_DIR}/bin/mpicc" CACHE PATH "")
 set(MPI_CXX_COMPILER "${_MPI_BASE_DIR}/bin/mpicxx" CACHE PATH "")

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -328,7 +328,7 @@ if(CLANGFORMAT_FOUND)
   )
 
   # Specify the major version for astyle
-  set(BLT_REQD_ASTYLE_VER "3")
+  set(BLT_REQUIRED_ASTYLE_VER "3")
 
   blt_add_code_checks(
       PREFIX          smoke_tests

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -327,6 +327,9 @@ if(CLANGFORMAT_FOUND)
     src/test_cuda_device_call_from_kernel/Parent.hpp
   )
 
+  # Specify the major version for astyle
+  set(BLT_REQD_ASTYLE_VER "3")
+
   blt_add_code_checks(
       PREFIX          smoke_tests
       SOURCES         ${smoke_tests_srcs}

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -328,7 +328,7 @@ if(CLANGFORMAT_FOUND)
   )
 
   # Specify the major version for astyle
-  set(BLT_REQUIRED_ASTYLE_VER "3")
+  set(BLT_REQUIRED_ASTYLE_VERSION "3")
 
   blt_add_code_checks(
       PREFIX          smoke_tests


### PR DESCRIPTION
This PR allows projects to specify the autoformatter version they require, which could prevent situations where different tool versions could result in inconsistent changes being made between users.