### PR TITLE
Restore INTERFACE includes for GoogleTest and GoogleMock targets

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -29,7 +29,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Prefixed blt_register_library() internal variables with ``_`` to avoid collision
   with input parameters.
 - Turn off system includes for registered libraries when using the PGI compiler
-- Removed unneeded INTERFACE system includes added by googletest that was causing problems
+- Removed unneeded SYSTEM includes added by googletest that was causing problems
   in PGI builds (BLT was adding them already to the register library calls)
 - Removed variable BLT_CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES_EXCLUDE, functionality now
   provided for all languages using BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE variable

--- a/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
+++ b/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
@@ -106,14 +106,14 @@ endif()
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
-#if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-#  target_include_directories(gmock SYSTEM INTERFACE
-#    "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
-#    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-#  target_include_directories(gmock_main SYSTEM INTERFACE
-#    "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
-#    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-#endif()
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+  target_include_directories(gmock INTERFACE
+    "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gmock_main INTERFACE
+    "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+endif()
 
 ########################################################################
 #

--- a/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
+++ b/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
@@ -130,14 +130,14 @@ cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 # If the CMake version supports it, attach header directory information
 # to the targets for when we are part of a parent build (ie being pulled
 # in via add_subdirectory() rather than being a standalone build).
-#if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
-#  target_include_directories(gtest SYSTEM INTERFACE
-#    "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
-#    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-#  target_include_directories(gtest_main SYSTEM INTERFACE
-#    "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
-#    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-#endif()
+if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+  target_include_directories(gtest INTERFACE
+    "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gtest_main INTERFACE
+    "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+endif()
 target_link_libraries(gtest_main PUBLIC gtest)
 
 ########################################################################

--- a/thirdparty_builtin/patches/gtest-2020-10-07-interface-includes.patch
+++ b/thirdparty_builtin/patches/gtest-2020-10-07-interface-includes.patch
@@ -1,0 +1,34 @@
+diff --git a/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt b/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
+index 17ca62f..d32b70b 100644
+--- a/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
++++ b/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
+@@ -107,10 +107,10 @@ endif()
+ # to the targets for when we are part of a parent build (ie being pulled
+ # in via add_subdirectory() rather than being a standalone build).
+ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+-  target_include_directories(gmock INTERFACE
++  target_include_directories(gmock SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+-  target_include_directories(gmock_main INTERFACE
++  target_include_directories(gmock_main SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gmock_build_include_dirs}>"
+     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+ endif()
+diff --git a/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt b/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
+index ae08085..4fd7b52 100644
+--- a/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
++++ b/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
+@@ -131,10 +131,10 @@ cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
+ # to the targets for when we are part of a parent build (ie being pulled
+ # in via add_subdirectory() rather than being a standalone build).
+ if (DEFINED CMAKE_VERSION AND NOT "${CMAKE_VERSION}" VERSION_LESS "2.8.11")
+-  target_include_directories(gtest INTERFACE
++  target_include_directories(gtest SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+-  target_include_directories(gtest_main INTERFACE
++  target_include_directories(gtest_main SYSTEM INTERFACE
+     "$<BUILD_INTERFACE:${gtest_build_include_dirs}>"
+     "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+ endif()


### PR DESCRIPTION
Removing these completely breaks projects that use the targets and depend on them directly, without using a BLT macro with `DEPENDS_ON`