### PR TITLE
feat: check for multiple C format cfgs incl clang

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -39,6 +39,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   This caused a crash. blt_add_clang_query_target learned parameter CHECKER_DIRECTORIES
   and blt_add_code_checks learned parameter CLANGQUERY_CHECKER_DIRECTORIES.  Both still
   respect BLT_CLANGQUERY_CHECKER_DIRECTORIES.
+- It is now a fatal error to supply CLANGFORMAT_CFG_FILE plus
+  ASTYLE_CFG_FILE or UNCRUSTIFY_CFG_FILE arguments to
+  blt_add_code_checks; previously, these combinations were implied to
+  be errors in BLT documentation, but BLT would not return an error in
+  those cases.
 
 ## [Version 0.3.6] - Release date 2020-07-27
 
@@ -50,8 +55,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added blt_assert_exists() utility macro.
-- Additional link flags for CUDA may now be specified by setting 
-  ``CMAKE_CUDA_LINK_FLAGS`` when configuring CMake either in a host-config 
+- Additional link flags for CUDA may now be specified by setting
+  ``CMAKE_CUDA_LINK_FLAGS`` when configuring CMake either in a host-config
   or at the command-line.
 - Added support for ClangFormat.
 
@@ -119,7 +124,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Handle FindMPI variable MPIEXEC changed to MPIEXEC_EXECUTABLE in CMake 3.10+.
   This now works regardless of which the user defines or what CMake returns.
 - Handle CMake target property LINK_FLAGS changed to LINK_OPTIONS in CMake 3.13+.
-  blt_add_target_link_flags() handles this under the covers and converts the 
+  blt_add_target_link_flags() handles this under the covers and converts the
   users strings to a list (3.13+) or list to a string (<3.13).  New property supports
   generator expressions so thats a plus.
 - Improved how all BLT MPI information is being merged together and reported to users.

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -126,12 +126,23 @@ macro(blt_add_code_checks)
                                       C_LIST       _c_sources
                                       Fortran_LIST _f_sources)
 
-    # Check that at most one formatting config file was supplied
-    if (DEFINED arg_UNCRUSTIFY_CFG_FILE AND DEFINED arg_ASTYLE_CFG_FILE)
-        message(FATAL_ERROR 
-          "blt_add_code_checks macro does not support multiple "
-          "style config parameters within the same invocation. "
-          "Both UNCRUSTIFY_CFG_FILE and ASTYLE_CFG_FILE were supplied.")
+    # Check that no more than one formatting config file was supplied
+    # for C-style languages.
+    set(_c_formatter_cfgs_supplied)
+    foreach (_c_formatter ASTYLE UNCRUSTIFY CLANGFORMAT)
+      if (DEFINED arg_${_c_formatter}_CFG_FILE)
+        list(APPEND _c_formatter_cfgs_supplied ${_c_formatter}_CFG_FILE)
+      endif()
+    endforeach()
+    list(LENGTH _c_formatter_cfgs_supplied _num_c_formatter_cfgs_supplied)
+    if (_num_c_formatter_cfgs_supplied GREATER 1)
+      message(FATAL_ERROR
+        "blt_add_code_checks macro does not support multiple "
+        "style config parameters within the same invocation. "
+        "At most one of ASTYLE_CFG_FILE, CLANGFORMAT_CFG_FILE, "
+        "and UNCRUSTIFY_CFG_FILE may be supplied. "
+        "The following style config parameters were supplied: "
+        ${_c_formatter_cfgs_supplied})
     endif()
 
     # Add code checks


### PR DESCRIPTION
This commit checks to see if a user has supplied more than one C-style
language formatter configuration file in blt_add_code_checks,
including CLANGFORMAT_CFG_FILE, which was previously excluded from
this check.

Prior to this commit, BLT returned a fatal error only if
ASTYLE_CFG_FILE and UNCRUSTIFY_CFG_FILE were supplied to
blt_add_code_checks. However, invocations supplying one of these
arguments plus CLANGFORMAT_CFG_FILE also seem undesirable, and the
documentation seems to imply that a check should be done to disallow
these combinations as well. Both of these observations motivate the
change in this commit.

I haven't yet added this change to the release notes because I wanted to make sure I wasn't missing some sort of use case for projects that intend to use `clang-format` plus `astyle` or `uncrustify`. Assuming the CMake changes proposed are reasonable, I'm happy to add this change to the release notes.
