### PR TITLE
[feature/add-yapf-support] Add support for Python source code formatting using YAPF

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
 Status](https://dev.azure.com/llnl-blt/blt/_apis/build/status/LLNL.blt?branchName=develop)](https://dev.azure.com/llnl-blt/blt/_build/latest?definitionId=1&branchName=develop)
 [![Documentation Status](https://readthedocs.org/projects/llnl-blt/badge/?version=develop)](https://llnl-blt.readthedocs.io/en/develop/?badge=develop)
 
-BLT is a streamlined [CMake](https://cmake.org)-based foundation for 
+BLT is a streamlined [CMake](https://cmake.org)-based foundation for
 <b>B</b>uilding, <b>L</b>inking and <b>T</b>esting large-scale high performance computing (HPC) applications.
 
-BLT makes it easy to get up and running on a wide range of HPC compilers, 
+BLT makes it easy to get up and running on a wide range of HPC compilers,
 operating systems and technologies:
  * Compiler families:
-      [gcc](https://gcc.gnu.org), 
-      [clang](https://clang.llvm.org), 
-      [Intel](https://software.intel.com/en-us/compilers), 
-      [XL](https://www.ibm.com/us-en/marketplace/ibm-c-and-c-plus-plus-compiler-family), 
+      [gcc](https://gcc.gnu.org),
+      [clang](https://clang.llvm.org),
+      [Intel](https://software.intel.com/en-us/compilers),
+      [XL](https://www.ibm.com/us-en/marketplace/ibm-c-and-c-plus-plus-compiler-family),
       [Visual Studio](https://visualstudio.microsoft.com/vs/features/cplusplus)
- * Operating systems: 
-      Linux, 
-      Mac OS, 
+ * Operating systems:
+      Linux,
+      Mac OS,
       Windows
  * HPC programming models:
-      [MPI](https://www.mpi-forum.org/), 
-      [OpenMP](https://www.openmp.org/), 
-      [CUDA](https://developer.nvidia.com/cuda-zone), 
+      [MPI](https://www.mpi-forum.org/),
+      [OpenMP](https://www.openmp.org/),
+      [CUDA](https://developer.nvidia.com/cuda-zone),
       [HIP](https://gpuopen.com/compute-product/hip-convert-cuda-to-portable-c-code)
  * Unit testing and benchmarking (built-in):
       [Google Test (gtest and gmock)](https://github.com/google/googletest),
@@ -35,11 +35,12 @@ operating systems and technologies:
       [AStyle](http://astyle.sourceforge.net),
       [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html),
       [Uncrustify](http://uncrustify.sourceforge.net)
+      [YAPF](https://github.com/google/yapf)
  * Code quality
       [clang-query](http://clang.llvm.org/docs/LibASTMatchers.html),
       [clang-tidy](https://clang.llvm.org/extra/clang-tidy),
       [Cppcheck](http://cppcheck.sourceforge.net)
- 
+
 
 Getting started
 ---------------
@@ -73,10 +74,10 @@ Developers include:
  * Richard Hornung, LLNL
  * Randolph Settgast, LLNL
 
-Please see our [contributing guide](https://github.com/LLNL/blt/blob/develop/CONTRIBUTING.md) 
+Please see our [contributing guide](https://github.com/LLNL/blt/blob/develop/CONTRIBUTING.md)
 for details about how to contribute to the project.
 
-The full list of project contributors can be found on the 
+The full list of project contributors can be found on the
 [BLT Contributors Page](https://github.com/LLNL/BLT/graphs/contributors).
 
 Open-Source Projects using BLT
@@ -103,7 +104,7 @@ Copyrights and patents in the BLT project are retained by contributors.
 No copyright assignment is required to contribute to BLT.
 
 See [LICENSE](./LICENSE) for details.
- 
+
 Unlimited Open Source - BSD 3-clause Distribution
 `LLNL-CODE-725085`  `OCEC-17-023`
 
@@ -125,22 +126,22 @@ BLT bundles its external dependencies in thirdparty_builtin/.  These
 packages are covered by various permissive licenses.  A summary listing
 follows.  See the license included with each package for full details.
 
-PackageName: fruit  
-PackageHomePage: https://sourceforge.net/projects/fortranxunit/  
-PackageLicenseDeclared: BSD-3-Clause  
+PackageName: fruit
+PackageHomePage: https://sourceforge.net/projects/fortranxunit/
+PackageLicenseDeclared: BSD-3-Clause
 
-PackageName: gbenchmark  
-PackageHomePage: https://github.com/google/benchmark  
-PackageLicenseDeclared: Apache-2.0  
+PackageName: gbenchmark
+PackageHomePage: https://github.com/google/benchmark
+PackageLicenseDeclared: Apache-2.0
 
-PackageName: gmock  
-PackageHomePage: https://github.com/google/googlemock  
-PackageLicenseDeclared: BSD-3-Clause  
+PackageName: gmock
+PackageHomePage: https://github.com/google/googlemock
+PackageLicenseDeclared: BSD-3-Clause
 
-PackageName: gtest  
-PackageHomePage: https://github.com/google/googletest  
-PackageLicenseDeclared: BSD-3-Clause  
+PackageName: gtest
+PackageHomePage: https://github.com/google/googletest
+PackageLicenseDeclared: BSD-3-Clause
 
-PackageName: run-clang-format  
-PackageHomePage: https://github.com/Sarcasm/run-clang-format  
-PackageLicenseDeclared: MIT  
+PackageName: run-clang-format
+PackageHomePage: https://github.com/Sarcasm/run-clang-format
+PackageLicenseDeclared: MIT

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -20,6 +20,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   implicit link directories for all languages
 - Added user option for enforcing specific versions of autoformatters - the new options are
   ``BLT_REQUIRED_ASTYLE_VERSION``, ``BLT_REQUIRED_CLANGFORMAT_VERSION``, and ``BLT_REQUIRED_UNCRUSTIFY_VERSION``
+- Added support for formatting Python code using YAPF.
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -176,7 +176,8 @@ if (NOT BLT_LOADED)
                CACHE STRING "List of known file extensions used for C/CXX sources")
     set(BLT_Fortran_FILE_EXTS ".F" ".f" ".f90" ".F90"
                CACHE STRING "List of known file extensions used for Fortran sources")
-
+    set(BLT_Python_FILE_EXTS ".py"
+               CACHE STRING "List of known file extensions used for Python sources")
 
     ################################
     # Setup compiler options

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -36,6 +36,7 @@ option(ENABLE_VALGRIND     "Enables Valgrind support" ON)
 option(ENABLE_ASTYLE       "Enables AStyle support" ON)
 option(ENABLE_CLANGFORMAT  "Enables ClangFormat support" ON)
 option(ENABLE_UNCRUSTIFY   "Enables Uncrustify support" ON)
+option(ENABLE_YAPF         "Enables Yapf support" OFF)
 
 #------------------------------------------------------------------------------
 # Build Options

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -36,7 +36,7 @@ option(ENABLE_VALGRIND     "Enables Valgrind support" ON)
 option(ENABLE_ASTYLE       "Enables AStyle support" ON)
 option(ENABLE_CLANGFORMAT  "Enables ClangFormat support" ON)
 option(ENABLE_UNCRUSTIFY   "Enables Uncrustify support" ON)
-option(ENABLE_YAPF         "Enables Yapf support" OFF)
+option(ENABLE_YAPF         "Enables Yapf support" ON)
 
 #------------------------------------------------------------------------------
 # Build Options

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -552,17 +552,20 @@ endmacro(blt_add_hip_executable)
 ##------------------------------------------------------------------------------
 ## blt_split_source_list_by_language( SOURCES <sources>
 ##                                    C_LIST <list name>
-##                                    Fortran_LIST <list name>)
+##                                    Fortran_LIST <list name>
+##                                    Python_LIST <list name>)
 ##
-## Filters source list by file extension into C/C++ and Fortran source lists
-## based on BLT_C_FILE_EXTS and BLT_Fortran_FILE_EXTS (global BLT variables).
-## Files with no extension or generator expressions that are not object libraries
-## (of the form "$<TARGET_OBJECTS:nameofobjectlibrary>") will throw fatal errors.
-##------------------------------------------------------------------------------
+## Filters source list by file extension into C/C++, Fortran, and
+## Python source lists based on the global BLT variables
+## BLT_C_FILE_EXTS, BLT_Fortran_FILE_EXTS, and BLT_Python_FILE_EXTS,
+## respectively.  Files with no extension or generator expressions
+## that are not object libraries (of the form
+## "$<TARGET_OBJECTS:nameofobjectlibrary>") will throw fatal errors.
+## ------------------------------------------------------------------------------
 macro(blt_split_source_list_by_language)
 
     set(options)
-    set(singleValueArgs C_LIST Fortran_LIST)
+    set(singleValueArgs C_LIST Fortran_LIST Python_LIST)
     set(multiValueArgs SOURCES)
 
     # Parse the arguments
@@ -599,8 +602,12 @@ macro(blt_split_source_list_by_language)
             if (DEFINED arg_Fortran_LIST)
                 list(APPEND ${arg_Fortran_LIST} ${_file})
             endif()
+        elseif(${_ext_lower} IN_LIST BLT_Python_FILE_EXTS)
+            if (DEFINED arg_Python_LIST)
+                list(APPEND ${arg_Python_LIST} ${_file})
+            endif()
         else()
-            message(FATAL_ERROR "blt_split_source_list_by_language given source file with unknown file extension. Add the missing extension to the corresponding list (BLT_C_FILE_EXTS or BLT_Fortran_FILE_EXTS).\n Unknown file: ${_file}")
+            message(FATAL_ERROR "blt_split_source_list_by_language given source file with unknown file extension. Add the missing extension to the corresponding list (BLT_C_FILE_EXTS, BLT_Fortran_FILE_EXTS, or BLT_Python_FILE_EXTS).\n Unknown file: ${_file}")
         endif()
     endforeach()
 

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -94,6 +94,7 @@ endforeach()
 ##                      ASTYLE_CFG_FILE      <Path to AStyle config file>
 ##                      CLANGFORMAT_CFG_FILE <Path to ClangFormat config file>
 ##                      UNCRUSTIFY_CFG_FILE  <Path to Uncrustify config file>
+##                      YAPF_CFG_FILE        <Path to Yapf config file>
 ##                      CPPCHECK_FLAGS       <List of flags added to Cppcheck>
 ##                      CLANGQUERY_CHECKER_DIRECTORIES [dir1 [dir2]])
 ##
@@ -104,7 +105,7 @@ endforeach()
 macro(blt_add_code_checks)
 
     set(options )
-    set(singleValueArgs PREFIX ASTYLE_CFG_FILE CLANGFORMAT_CFG_FILE UNCRUSTIFY_CFG_FILE)
+    set(singleValueArgs PREFIX ASTYLE_CFG_FILE CLANGFORMAT_CFG_FILE UNCRUSTIFY_CFG_FILE YAPF_CFG_FILE)
     set(multiValueArgs SOURCES CPPCHECK_FLAGS CLANGQUERY_CHECKER_DIRECTORIES)
 
     cmake_parse_arguments(arg
@@ -218,6 +219,25 @@ macro(blt_add_code_checks)
                                    CFG_FILE          ${arg_UNCRUSTIFY_CFG_FILE} 
                                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                                    SRC_FILES         ${_c_sources} )
+    endif()
+
+    if (YAPF_FOUND AND DEFINED arg_YAPF_CFG_FILE)
+        set(_check_target_name ${arg_PREFIX}_yapf_check)
+        blt_error_if_target_exists(${_check_target_name} ${_error_msg})
+        set(_style_target_name ${arg_PREFIX}_yapf_style)
+        blt_error_if_target_exists(${_style_target_name} ${_error_msg})
+
+        blt_add_yapf_target( NAME              ${_check_target_name}
+                             MODIFY_FILES      FALSE
+                             CFG_FILE          ${arg_YAPF_CFG_FILE}
+                             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                             SRC_FILES         ${_py_sources} )
+
+        blt_add_yapf_target( NAME              ${_style_target_name}
+                             MODIFY_FILES      TRUE
+                             CFG_FILE          ${arg_YAPF_CFG_FILE}
+                             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                             SRC_FILES         ${_py_sources} )
     endif()
 
     if (CPPCHECK_FOUND)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -44,6 +44,17 @@ if(UNCRUSTIFY_FOUND)
     add_dependencies(${BLT_CODE_STYLE_TARGET_NAME} uncrustify_style)
 endif()
 
+if(YAPF_FOUND)
+    set(BLT_REQUIRED_YAPF_VERSION "" CACHE STRING "Required version of yapf")
+    # targets for verifying formatting
+    add_custom_target(yapf_check)
+    add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} yapf_check)
+
+    # targets for modifying formatting
+    add_custom_target(yapf_style)
+    add_dependencies(${BLT_CODE_STYLE_TARGET_NAME} yapf_style)
+endif()
+
 if(CPPCHECK_FOUND)
     add_custom_target(cppcheck_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} cppcheck_check)
@@ -67,8 +78,8 @@ endif()
 
 # Code check targets should only be run on demand
 foreach(target 
-        check uncrustify_check astyle_check clangformat_check cppcheck_check
-        style uncrustify_style astyle_style clangformat_style
+        check yapf_check uncrustify_check astyle_check clangformat_check cppcheck_check
+        style yapf_style uncrustify_style astyle_style clangformat_style
         clang_query_check interactive_clang_query_check clang_tidy_check)
     if(TARGET ${target})
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -135,9 +135,11 @@ macro(blt_add_code_checks)
     # Generate source lists based on language
     set(_c_sources)
     set(_f_sources)
+    set(_py_sources)
     blt_split_source_list_by_language(SOURCES      ${_rel_sources}
                                       C_LIST       _c_sources
-                                      Fortran_LIST _f_sources)
+                                      Fortran_LIST _f_sources
+                                      Python_LIST  _py_sources)
 
     # Check that no more than one formatting config file was supplied
     # for C-style languages.

--- a/cmake/thirdparty/SetupThirdParty.cmake
+++ b/cmake/thirdparty/SetupThirdParty.cmake
@@ -95,6 +95,8 @@ blt_find_executable(NAME        ClangFormat
 blt_find_executable(NAME        Uncrustify
                     EXECUTABLES uncrustify)
 
+blt_find_executable(NAME        Yapf
+                    EXECUTABLES yapf)
 
 #------------------------------------
 # Static analysis via Cppcheck

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -342,6 +342,33 @@ if(CLANGFORMAT_FOUND)
       
 endif()
 
+if(YAPF_FOUND)
+  # Test case where a style target running yapf should do nothing, and
+  # a corresponding check target should return 0
+  set(internal_conformant_python_srcs
+    src/test_yapf_conformant.py)
+
+  blt_add_code_checks(
+    PREFIX           yapf_conformant_tests
+    SOURCES          ${internal_conformant_python_srcs}
+    YAPF_CFG_FILE    ${CMAKE_CURRENT_SOURCE_DIR}/yapf.cfg )
+
+  # Test case where a style target running yapf should reformat the source file,
+  # and a corresponding check target should return a nonzero code
+  #
+  # After styling, test_yapf_conformant.py and
+  # test_yapf_nonconformant.py should have the same contents
+  set(internal_nonconformant_python_srcs
+    src/test_yapf_nonconformant.py)
+
+  blt_add_code_checks(
+    PREFIX           yapf_nonconformant_tests
+    SOURCES          ${internal_nonconformant_python_srcs
+    YAPF_CFG_FILE    ${CMAKE_CURRENT_SOURCE_DIR}/yapf.cfg)
+endif() # end if(YAPF_FOUND)
+
+
+
 # Check blt_add_test with a command that is not a target
 if(WIN32)
     configure_file(return_true_win32.in tests/return_true.bat COPYONLY)

--- a/tests/internal/src/test_yapf_conformant.py
+++ b/tests/internal/src/test_yapf_conformant.py
@@ -1,0 +1,18 @@
+# Example from google/yapf repo
+x = {'a': 37, 'b': 42, 'c': 927}
+
+y = 'hello ' 'world'
+z = 'hello ' + 'world'
+a = 'hello {}'.format('world')
+
+
+class foo(object):
+    def f(self):
+        return 37 * -+2
+
+    def g(self, x, y=42):
+        return y
+
+
+def f(a):
+    return 37 + -+a[42 - x:y**3]

--- a/tests/internal/src/test_yapf_nonconformant.py
+++ b/tests/internal/src/test_yapf_nonconformant.py
@@ -1,0 +1,15 @@
+# Example from google/yapf repo
+x = {  'a':37,'b':42,
+
+'c':927}
+
+y = 'hello ''world'
+z = 'hello '+'world'
+a = 'hello {}'.format('world')
+class foo  (     object  ):
+  def f    (self   ):
+    return       37*-+2
+  def g(self, x,y=42):
+      return y
+def f  (   a ) :
+  return      37+-+a[42-x :  y**3]

--- a/tests/internal/yapf.cfg
+++ b/tests/internal/yapf.cfg
@@ -1,0 +1,6 @@
+# Style settings example shown in
+# https://github.com/google/yapf/blob/master/README.rst
+[style]
+based_on_style = pep8
+spaces_before_comment = 4
+split_before_logical_operator = true


### PR DESCRIPTION
Adds support for Python source code formatting using YAPF.

Should probably be considered WIP until I test it on Python code; uploading a bit early to check that I haven't broken anything the CI is already testing before trying it out on an internal project.