### PR TITLE
split HEADERS from SOURCES on blt_add_executable

### DIFF
--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -549,6 +549,7 @@ endmacro(blt_add_library)
 ##------------------------------------------------------------------------------
 ## blt_add_executable( NAME        <name>
 ##                     SOURCES     [source1 [source2 ...]]
+##                     HEADERS     [header1 [header2 ...]]
 ##                     INCLUDES    [dir1 [dir2 ...]]
 ##                     DEFINES     [define1 [define2 ...]]
 ##                     DEPENDS_ON  [dep1 [dep2 ...]]
@@ -562,7 +563,7 @@ macro(blt_add_executable)
 
     set(options )
     set(singleValueArgs NAME OUTPUT_DIR OUTPUT_NAME FOLDER)
-    set(multiValueArgs SOURCES INCLUDES DEFINES DEPENDS_ON)
+    set(multiValueArgs HEADERS SOURCES INCLUDES DEFINES DEPENDS_ON)
 
     # Parse the arguments to the macro
     cmake_parse_arguments(arg
@@ -580,9 +581,10 @@ macro(blt_add_executable)
     if (ENABLE_HIP)
         blt_add_hip_executable(NAME         ${arg_NAME}
                                SOURCES      ${arg_SOURCES}
+                               HEADERS      ${arg_HEADERS}
                                DEPENDS_ON   ${arg_DEPENDS_ON})
     else()
-        add_executable( ${arg_NAME} ${arg_SOURCES} )
+        add_executable( ${arg_NAME} ${arg_SOURCES} ${arg_HEADERS})
 
         if (ENABLE_CUDA AND NOT ENABLE_CLANG_CUDA)
             blt_setup_cuda_target(
@@ -639,7 +641,7 @@ macro(blt_add_executable)
         blt_set_target_folder(TARGET ${arg_NAME} FOLDER "${arg_FOLDER}")
     endif()
 
-    blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} )
+    blt_update_project_sources( TARGET_SOURCES ${arg_SOURCES} ${arg_HEADERS} )
 
     blt_clean_target(TARGET ${arg_NAME})
 

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -495,13 +495,14 @@ endmacro(blt_add_hip_library)
 ##------------------------------------------------------------------------------
 ## blt_add_hip_executable(NAME         <libname>
 ##                        SOURCES      [source1 [source2 ...]]
+##                        HEADERS      [header1 [header2 ...]]
 ##                        DEPENDS_ON   [dep1 ...]
 ##------------------------------------------------------------------------------
 macro(blt_add_hip_executable)
 
     set(options)
     set(singleValueArgs NAME)
-    set(multiValueArgs SOURCES DEPENDS_ON)
+    set(multiValueArgs HEADERS SOURCES DEPENDS_ON)
 
     # Parse the arguments
     cmake_parse_arguments(arg "${options}" "${singleValueArgs}"
@@ -544,7 +545,7 @@ macro(blt_add_hip_executable)
 
         hip_add_executable( ${arg_NAME} ${arg_SOURCES} )
     else()
-        add_executable( ${arg_NAME} ${arg_SOURCES} )
+        add_executable( ${arg_NAME} ${arg_SOURCES} ${arg_HEADERS})
     endif()
 
 endmacro(blt_add_hip_executable)

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -69,6 +69,7 @@ blt_add_executable
 
     blt_add_executable( NAME        <name>
                         SOURCES     [source1 [source2 ...]]
+                        HEADERS     [header1 [header2 ...]]
                         INCLUDES    [dir1 [dir2 ...]]
                         DEFINES     [define1 [define2 ...]]
                         DEPENDS_ON  [dep1 [dep2 ...]]
@@ -83,6 +84,9 @@ NAME
 
 SOURCES
   List of all sources to be added
+
+HEADERS
+  List of all headers to be added
 
 INCLUDES
   List of include directories both used by this target and inherited by dependent


### PR DESCRIPTION
This makes `blt_add_executable` learn `HEADERS` like `blt_add_library` already does.  This came up when in Axom's CUDA separable compilation build, where adding headers to the `SOURCES` list caused them to be compiled separately from the source file they were included on.

It is important to associate headers with an executable for dependency checking and IDE folder support.