### PR TITLE
fix: add missing brace to yapf nonconformant test

### DIFF
--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -363,7 +363,7 @@ if(YAPF_FOUND)
 
   blt_add_code_checks(
     PREFIX           yapf_nonconformant_tests
-    SOURCES          ${internal_nonconformant_python_srcs
+    SOURCES          ${internal_nonconformant_python_srcs}
     YAPF_CFG_FILE    ${CMAKE_CURRENT_SOURCE_DIR}/yapf.cfg)
 endif() # end if(YAPF_FOUND)
 


### PR DESCRIPTION
This commit adds a missing brace to the yapf nonconformant style test
so that a CMake variable is interpolated correctly. The current
version lacks this brace, which is a syntax error.