### PR TITLE
Remove nonexistent includes/libraries from "hip" target

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -54,6 +54,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   blt_add_code_checks; previously, these combinations were implied to
   be errors in BLT documentation, but BLT would not return an error in
   those cases.
+- ``blt_patch_target`` no longer attempts to set system include directories when a target
+  has no include directories
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -482,11 +482,14 @@ macro(blt_patch_target)
     # PGI does not support -isystem
     if( (${arg_TREAT_INCLUDES_AS_SYSTEM}) AND (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI"))
         get_target_property(_target_includes ${arg_NAME} INTERFACE_INCLUDE_DIRECTORIES)
-        if(_standard_lib_interface)
-            target_include_directories(${arg_NAME} SYSTEM ${_scope} ${_target_includes})
-        else()
-            set_property(TARGET ${arg_NAME} PROPERTY
-                         INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${_target_includes})
+        # Don't copy if the target had no include directories
+        if(_target_includes)
+            if(_standard_lib_interface)
+                target_include_directories(${arg_NAME} SYSTEM ${_scope} ${_target_includes})
+            else()
+                set_property(TARGET ${arg_NAME} PROPERTY
+                            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${_target_includes})
+            endif()
         endif()
     endif()
 

--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -469,12 +469,6 @@ macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files
     set(include_directories_generator "$<TARGET_PROPERTY:${_target},INCLUDE_DIRECTORIES>")
     list(APPEND HIP_HIPCC_INCLUDE_ARGS "$<$<BOOL:${include_directories_generator}>:-I$<JOIN:${include_directories_generator}, -I>>")
 
-    ############ START BLT CHANGE ############
-    # Add the interface include directories
-    set(interface_include_directories_generator "$<TARGET_PROPERTY:${_target},INTERFACE_INCLUDE_DIRECTORIES>")
-    list(APPEND HIP_HIPCC_INCLUDE_ARGS "$<$<BOOL:${interface_include_directories_generator}>:-I$<JOIN:${interface_include_directories_generator}, -I>>")
-    ############ END BLT CHANGE ############
-
     get_directory_property(_hip_include_directories INCLUDE_DIRECTORIES)
     list(REMOVE_DUPLICATES _hip_include_directories)
     if(_hip_include_directories)

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -34,7 +34,7 @@ set(HIP_RUNTIME_COMPILE_FLAGS "${HIP_RUNTIME_COMPILE_FLAGS};-D${HIP_RUNTIME_DEFI
 # through a hip compiler (hipcc)
 # This is currently used only as an indicator for blt_add_hip* -- FindHIP/hipcc will handle resolution
 # of all required HIP-related includes/libraries/flags.
-blt_import_library(NAME      hip TREAT_INCLUDES_AS_SYSTEM ON)
+blt_import_library(NAME      hip)
 
 # depend on 'hip_runtime', if you only need to use hip
 # headers or link to hip libs, but don't need to run your source

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -14,8 +14,6 @@ find_package(HIP REQUIRED)
 
 message(STATUS "HIP version:      ${HIP_VERSION_STRING}")
 message(STATUS "HIP platform:     ${HIP_PLATFORM}")
-#message(STATUS "HIP Include Path: ${HIP_INCLUDE_DIRS}")
-#message(STATUS "HIP Libraries:    ${HIP_LIBRARIES}")
 
 if(${HIP_PLATFORM} STREQUAL "hcc")
 	set(HIP_RUNTIME_DEFINE "__HIP_PLATFORM_HCC__")
@@ -34,10 +32,9 @@ set(HIP_RUNTIME_COMPILE_FLAGS "${HIP_RUNTIME_COMPILE_FLAGS};-D${HIP_RUNTIME_DEFI
 # depend on 'hip', if you need to use hip
 # headers, link to hip libs, and need to run your source
 # through a hip compiler (hipcc)
-blt_import_library(NAME      hip
-                   INCLUDES  ${HIP_INCLUDE_DIRS}
-                   LIBRARIES ${HIP_LIBRARIES}
-                   TREAT_INCLUDES_AS_SYSTEM ON)
+# This is currently used only as an indicator for blt_add_hip* -- FindHIP/hipcc will handle resolution
+# of all required HIP-related includes/libraries/flags.
+blt_import_library(NAME      hip TREAT_INCLUDES_AS_SYSTEM ON)
 
 # depend on 'hip_runtime', if you only need to use hip
 # headers or link to hip libs, but don't need to run your source


### PR DESCRIPTION
After some further investigation of the issue that motivated #427, it appears that the underlying issue was related to a nonexistent/empty variable being used to configure the include directories for the `hip` target.  This resulted in the include directories for a HIP-dependent target comparing false and thus "poisoning" the generator expression used by `hip_add_library`/`hip_add_executable`.  

This did not appear until `hip` became a real CMake target in #421 due to the different setup logic used for BLT-registered libraries.
 
Removing these empty variables and adding a check in ``blt_patch_target`` appears to be sufficient and allows the patch to `FindHIP` to be removed.

Also, I noticed that BLT does not distinguish between `hip` and `hip_runtime` in that it appears to use `hipcc` to compile targets depending on either one (unlike with `cuda` vs `cuda_runtime`): https://github.com/LLNL/blt/blob/995a058193b4ae55daf5d34f0ede1ee1f2d26668/cmake/BLTPrivateMacros.cmake#L558 versus https://github.com/LLNL/blt/blob/995a058193b4ae55daf5d34f0ede1ee1f2d26668/cmake/BLTPrivateMacros.cmake#L430

Is this intentional?