### PR TITLE
Add support for header-only library dependencies

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -56,6 +56,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   those cases.
 - ``blt_patch_target`` no longer attempts to set system include directories when a target
   has no include directories
+- Header-only libraries now can have dependencies via DEPENDS_ON in ``blt_add_library``
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -292,6 +292,15 @@ macro(blt_setup_target)
         message( FATAL_ERROR "Must provide a NAME argument to the 'blt_setup_target' macro" )
     endif()
 
+    # Default to "real" scope, unless it's an interface library
+    set(_private_scope PRIVATE)
+    set(_public_scope  PUBLIC)
+    get_target_property(_target_type ${arg_NAME} TYPE)
+    if("${_target_type}" STREQUAL "INTERFACE_LIBRARY")
+        set(_private_scope INTERFACE)
+        set(_public_scope  INTERFACE)
+    endif()
+
     # Expand dependency list
     set(_expanded_DEPENDS_ON ${arg_DEPENDS_ON})
     foreach( i RANGE 50 )
@@ -313,21 +322,21 @@ macro(blt_setup_target)
         string(TOUPPER ${dependency} uppercase_dependency )
 
         if ( NOT arg_OBJECT AND _BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
-            target_sources(${arg_NAME} PRIVATE $<TARGET_OBJECTS:${dependency}>)
+            target_sources(${arg_NAME} ${_private_scope} $<TARGET_OBJECTS:${dependency}>)
         endif()
 
         if ( DEFINED _BLT_${uppercase_dependency}_INCLUDES )
             if ( _BLT_${uppercase_dependency}_TREAT_INCLUDES_AS_SYSTEM )
-                target_include_directories( ${arg_NAME} SYSTEM PUBLIC
+                target_include_directories( ${arg_NAME} SYSTEM ${_public_scope}
                     ${_BLT_${uppercase_dependency}_INCLUDES} )
             else()
-                target_include_directories( ${arg_NAME} PUBLIC
+                target_include_directories( ${arg_NAME} ${_public_scope}
                     ${_BLT_${uppercase_dependency}_INCLUDES} )
             endif()
         endif()
 
         if ( DEFINED _BLT_${uppercase_dependency}_FORTRAN_MODULES )
-            target_include_directories( ${arg_NAME} PUBLIC
+            target_include_directories( ${arg_NAME} ${_public_scope}
                 ${_BLT_${uppercase_dependency}_FORTRAN_MODULES} )
         endif()
 
@@ -358,15 +367,15 @@ macro(blt_setup_target)
             # actual CMake targets
             if(NOT "${_BLT_${uppercase_dependency}_LIBRARIES}"
                     STREQUAL "BLT_NO_LIBRARIES" )
-                target_link_libraries( ${arg_NAME} PUBLIC
+                target_link_libraries( ${arg_NAME} ${_public_scope}
                     ${_BLT_${uppercase_dependency}_LIBRARIES} )
             endif()
         else()
-            target_link_libraries( ${arg_NAME} PUBLIC ${dependency} )
+            target_link_libraries( ${arg_NAME} ${_public_scope} ${dependency} )
         endif()
 
         if ( DEFINED _BLT_${uppercase_dependency}_DEFINES )
-            target_compile_definitions( ${arg_NAME} PUBLIC
+            target_compile_definitions( ${arg_NAME} ${_public_scope}
                 ${_BLT_${uppercase_dependency}_DEFINES} )
         endif()
 

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -204,6 +204,8 @@ Header-only libraries are useful when you do not want the library separately com
 are using C++ templates that require the library's user to instantiate them. These libraries
 have headers but no sources. To create a header-only library (CMake calls them INTERFACE libraries),
 simply list all headers under the HEADERS argument and do not specify SOURCES (because there aren't any).
+Header-only libraries can have dependencies like compiled libraries - these will be propagated to targets
+that depend on the header-only library.
 
 Object libraries are basically a collection of compiled source files that are not
 archived or linked. They are sometimes useful when you want to solve compilicated linking

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -67,8 +67,12 @@ if(ENABLE_GTEST)
     #  Header-only test
     #------------------------------------------------------
 
+    blt_add_target_definitions(TO                 example
+                               TARGET_DEFINITIONS BLT_EXAMPLE_LIB)
+
     blt_add_library(NAME blt_header_only
-                    HEADERS "src/HeaderOnly.hpp")
+                    HEADERS "src/HeaderOnly.hpp"
+                    DEPENDS_ON example)
 
     # This executable depends on the header-only library
 

--- a/tests/internal/src/HeaderOnly.hpp
+++ b/tests/internal/src/HeaderOnly.hpp
@@ -6,12 +6,19 @@
 #ifndef BLT_HEADER_ONLY_HPP
 #define BLT_HEADER_ONLY_HPP
 
+#include "Example.hpp"
+
+#ifndef BLT_EXAMPLE_LIB
+  #error Compile definitions were not propagated from "example" library
+#endif
+
 namespace blt
 {
 
 inline bool ReturnTrue()
 {
-  return true;
+  Example e;
+  return e.ReturnTrue();
 }
 
 } // end of namespace blt


### PR DESCRIPTION
Currently header-only libraries cannot specify dependencies with `DEPENDS_ON` in `blt_add_library` because `blt_setup_target` "hardcodes" `PUBLIC`/`PRIVATE` access specifiers.  This PR forces the use of `INTERFACE` access specifiers in `blt_setup_target` when the target is an `INTERFACE_LIBRARY`.