### PR TITLE
fix for umpire hip-enabled build

### DIFF
--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -25,7 +25,7 @@ endif()
 #        2. The header hsa.h is found redundantly in both /opt/rocm/include/hsa/hsa.h
 #           and /opt/rocm/hsa/include/hsa/hsa.h . I only listed ${HIP_ROOT_DIR}/../include
 #           (pointing us to /opt/rocm/include/hsa/) below.
-if ( IS_DIRECTORY "${HIP_ROOT_DIR}/hcc/include" ) # this path only exists on older rocm installs
+if ( IS_DIRECTORY "${HIP_ROOT_DIR}/hcc/include" )
         set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include;${HIP_ROOT_DIR}/../include;${HIP_ROOT_DIR}/hcc/include" CACHE STRING "")
 else()
         set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include;${HIP_ROOT_DIR}/../include" CACHE STRING "")

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -20,10 +20,15 @@ if(${HIP_PLATFORM} STREQUAL "hcc")
 elseif(${HIP_PLATFORM} STREQUAL "nvcc")
 	set(HIP_RUNTIME_DEFINE "__HIP_PLATFORM_NVCC__")
 endif()
+
+# Notes: 1. the ${HIP_ROOT_DIR}/hcc/include only exists on older rocm installs, hence a check is required
+#        2. The header hsa.h is found redundantly in both /opt/rocm/include/hsa/hsa.h
+#           and /opt/rocm/hsa/include/hsa/hsa.h . I only listed ${HIP_ROOT_DIR}/../include
+#           (pointing us to /opt/rocm/include/hsa/) below.
 if ( IS_DIRECTORY "${HIP_ROOT_DIR}/hcc/include" ) # this path only exists on older rocm installs
-        set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include;${HIP_ROOT_DIR}/hcc/include" CACHE STRING "")
+        set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include;${HIP_ROOT_DIR}/../include;${HIP_ROOT_DIR}/hcc/include" CACHE STRING "")
 else()
-        set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" CACHE STRING "")
+        set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include;${HIP_ROOT_DIR}/../include" CACHE STRING "")
 endif()
 set(HIP_RUNTIME_COMPILE_FLAGS "${HIP_RUNTIME_COMPILE_FLAGS};-D${HIP_RUNTIME_DEFINE};-Wno-unused-parameter")
 # set(HIP_RUNTIME_LIBRARIES "${HIP_ROOT_DIR}/hcc/lib")


### PR DESCRIPTION
This is a fix for the hip-enabled umpire build. We ran into an error

[ 23%] Building CXX object src/tpl/umpire/src/umpire/resource/CMakeFiles/umpire_resource.dir/HipDeviceResourceFactory.cpp.o
In file included from /g/g17/taller1/CARE_SPACK/CHAI/src/tpl/umpire/src/umpire/resource/HipDeviceResourceFactory.cpp:9:
In file included from /opt/rocm/hip/include/hip/hip_runtime.h:64:
In file included from /opt/rocm/hip/include/hip/hip_runtime_api.h:366:
/opt/rocm/hip/include/hip/hcc_detail/hip_runtime_api.h:48:10: fatal error: 'hsa/hsa.h' file not found
#include <hsa/hsa.h>
         ^~~~~~~~~~~

When trying to build umpire (NOT using spack, by hand) .

This fix was inspired by David Beckinsale's work here: https://github.com/LLNL/Umpire/blob/develop/scripts/uberenv/packages/umpire/package.py#L326 , where he sets HIP_RUNTIME_INCLUDE_DIRS . Thank you @davidbeckingsale  for your help and advice!