### PR TITLE
fix for hip build: fpic error

### DIFF
--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -503,7 +503,7 @@ macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files
     if(_hip_build_shared_libs)
         list(APPEND HIP_HCC_FLAGS "-fPIC")
         list(APPEND HIP_CLANG_FLAGS "-fPIC")
-        list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
+        list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler -fPIC")
     endif()
 
     # Set host compiler

--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -503,7 +503,11 @@ macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files
     if(_hip_build_shared_libs)
         list(APPEND HIP_HCC_FLAGS "-fPIC")
         list(APPEND HIP_CLANG_FLAGS "-fPIC")
-        list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler -fPIC")
+        if("x${HIP_PLATFORM}" STREQUAL "xnvcc") # hip using nvcc cuda underneath
+           list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
+        else() # platform is hcc
+            list(APPEND HIP_HIPCC_FLAGS "-fPIC")
+        endif()
     endif()
 
     # Set host compiler

--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -504,7 +504,7 @@ macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files
         list(APPEND HIP_HCC_FLAGS "-fPIC")
         list(APPEND HIP_CLANG_FLAGS "-fPIC")
         if("x${HIP_PLATFORM}" STREQUAL "xnvcc") # hip using nvcc cuda underneath
-           list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
+            list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
         else() # platform is hcc
             list(APPEND HIP_HIPCC_FLAGS "-fPIC")
         endif()

--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -503,11 +503,7 @@ macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files
     if(_hip_build_shared_libs)
         list(APPEND HIP_HCC_FLAGS "-fPIC")
         list(APPEND HIP_CLANG_FLAGS "-fPIC")
-        if("x${HIP_PLATFORM}" STREQUAL "xnvcc") # hip using nvcc cuda underneath
-            list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
-        else() # platform is hcc
-            list(APPEND HIP_HIPCC_FLAGS "-fPIC")
-        endif()
+        list(APPEND HIP_NVCC_FLAGS "--shared -Xcompiler '-fPIC'")
     endif()
 
     # Set host compiler

--- a/cmake/thirdparty/FindHIP/run_hipcc.cmake
+++ b/cmake/thirdparty/FindHIP/run_hipcc.cmake
@@ -53,7 +53,7 @@ execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --compiler OUTPUT_VARIABLE H
 execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --runtime OUTPUT_VARIABLE HIP_RUNTIME OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT host_flag)
     set(__CC ${HIP_HIPCC_EXECUTABLE})
-    if("${HIP_PLATFORM}" STREQUAL "amd")
+    if("${HIP_PLATFORM}" STREQUAL "hcc")
         if("${HIP_COMPILER}" STREQUAL "hcc")
             if(NOT "x${HCC_HOME}" STREQUAL "x")
                 set(ENV{HCC_HOME} ${HCC_HOME})

--- a/cmake/thirdparty/FindHIP/run_hipcc.cmake
+++ b/cmake/thirdparty/FindHIP/run_hipcc.cmake
@@ -53,7 +53,9 @@ execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --compiler OUTPUT_VARIABLE H
 execute_process(COMMAND ${HIP_HIPCONFIG_EXECUTABLE} --runtime OUTPUT_VARIABLE HIP_RUNTIME OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(NOT host_flag)
     set(__CC ${HIP_HIPCC_EXECUTABLE})
-    if("${HIP_PLATFORM}" STREQUAL "hcc")
+    # ROCm version 4.0 and higher will use amd for the platform, but older
+    # versions use hcc. Keep both for backwards compatibility.
+    if("${HIP_PLATFORM}" STREQUAL "hcc" OR "${HIP_PLATFORM}" STREQUAL "amd")
         if("${HIP_COMPILER}" STREQUAL "hcc")
             if(NOT "x${HCC_HOME}" STREQUAL "x")
                 set(ENV{HCC_HOME} ${HCC_HOME})


### PR DESCRIPTION
When building RAJA+hip with spack, I got the error below. The issue appears to be the snippet, --shared -Xcompiler '-fPIC' -g -O2 , with extra quotes around -fPIC . This fix should resolve the issue.


     121    /opt/rocm/hip/bin/hipcc -M /var/tmp/taller1/spack-stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-src/src/MemUtil
            s_CUDA.cpp -o /tmp/taller1/spack-stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-build-b4qt3dt/CMakeFiles/RAJA.di
            r/src/RAJA_generated_MemUtils_CUDA.cpp.o.depend.pre --amdgpu-target=gfx900 --shared -Xcompiler '-fPIC' -g -O2 -I/var/tmp/taller1/spack-
            stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-src/include -I/tmp/taller1/spack-stage/spack-stage-raja-develop-b
            4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-build-b4qt3dt/include -I/var/tmp/taller1/spack-stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte7
            3dtv3r2bzkz2i/spack-src/tpl/cub -I/var/tmp/taller1/spack-stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-src/tpl/
            rocPRIM/rocprim/include -I/var/tmp/taller1/spack-stage/spack-stage-raja-develop-b4qt3dtl6mlnht4fte73dtv3r2bzkz2i/spack-src/tpl/camp/inc
            lude
  >> 122    clang-11: error: no such file or directory: ''-fPIC''
  >> 123    CMake Error at RAJA_generated_AlignedRangeIndexSetBuilders.cpp.o.cmake:143 (message):
