### PR TITLE
Add an EXPORTABLE option to blt_import_library

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -58,6 +58,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   those cases.
 - ``blt_patch_target`` no longer attempts to set system include directories when a target
   has no include directories
+- Header-only libraries now can have dependencies via DEPENDS_ON in ``blt_add_library``
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added new ``blt_patch_target`` macro to simplify modifying properties of an existing CMake target.
   This macro accounts for known differences in compilers, target types, and CMake releases.
 - Added support for formatting CMake code using cmake-format.
+- Added an EXPORTABLE option to ``blt_import_library`` that allows imported libraries to be
+  added to an export set and installed.
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -528,12 +528,13 @@ endmacro(blt_patch_target)
 ##                     COMPILE_FLAGS [ flag1 [ flag2 ..]]
 ##                     LINK_FLAGS [ flag1 [ flag2 ..]]
 ##                     DEFINES [def1 [def2 ...]] 
-##                     GLOBAL [ON|OFF])
+##                     GLOBAL [ON|OFF]
+##                     EXPORTABLE [ON|OFF])
 ##
 ## Imports a library as a CMake target
 ##------------------------------------------------------------------------------
 macro(blt_import_library)
-    set(singleValueArgs NAME TREAT_INCLUDES_AS_SYSTEM GLOBAL)
+    set(singleValueArgs NAME TREAT_INCLUDES_AS_SYSTEM GLOBAL EXPORTABLE)
     set(multiValueArgs LIBRARIES
                        INCLUDES 
                        DEPENDS_ON
@@ -551,8 +552,12 @@ macro(blt_import_library)
         message(FATAL_ERROR "blt_import_library() must be called with argument NAME <name>")
     endif()
 
-    # Add all imported targets to a single imported interface target
-    if(${arg_GLOBAL})
+    if(${arg_EXPORTABLE})
+        if(${arg_GLOBAL})
+            message(FATAL_ERROR "blt_import_library: EXPORTABLE targets cannot be GLOBAL")
+        endif()
+        add_library(${arg_NAME} INTERFACE)
+    elseif(${arg_GLOBAL})
         add_library(${arg_NAME} INTERFACE IMPORTED GLOBAL)
     else()
         add_library(${arg_NAME} INTERFACE IMPORTED)

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -107,6 +107,11 @@ mark_as_advanced(BLT_ENABLE_MSVC_STATIC_MD_TO_MT)
 option(ENABLE_FOLDERS "Organize projects using folders (in generators that support this)" OFF)
 
 #------------------------------------------------------------------------------
+# Export/Install Options
+#------------------------------------------------------------------------------
+option(BLT_EXPORT_THIRDPARTY "Configure the third-party targets created by BLT to be exportable" OFF)
+
+#------------------------------------------------------------------------------
 # Advanced configuration options
 #------------------------------------------------------------------------------
 

--- a/cmake/thirdparty/SetupCUDA.cmake
+++ b/cmake/thirdparty/SetupCUDA.cmake
@@ -144,11 +144,12 @@ endif()
 # This logic is handled in the blt_add_library/executable
 # macros
 blt_import_library(NAME          cuda
-                     COMPILE_FLAGS ${_cuda_compile_flags}
-                     INCLUDES      ${CUDA_INCLUDE_DIRS}
-                     LIBRARIES     ${CUDA_LIBRARIES}
-                     LINK_FLAGS    "${CMAKE_CUDA_LINK_FLAGS}"
-                     )
+                   COMPILE_FLAGS ${_cuda_compile_flags}
+                   INCLUDES      ${CUDA_INCLUDE_DIRS}
+                   LIBRARIES     ${CUDA_LIBRARIES}
+                   LINK_FLAGS    "${CMAKE_CUDA_LINK_FLAGS}"
+                   EXPORTABLE    ${BLT_EXPORT_THIRDPARTY}
+                   )
 
 # same as 'cuda' but we don't flag your source files as
 # CUDA language.  This causes your source files to use 
@@ -156,6 +157,7 @@ blt_import_library(NAME          cuda
 # linking with nvcc.
 # This logic is handled in the blt_add_library/executable
 # macros
-blt_import_library(NAME      cuda_runtime
-                     INCLUDES  ${CUDA_INCLUDE_DIRS}
-                     LIBRARIES ${CUDA_LIBRARIES})
+blt_import_library(NAME       cuda_runtime
+                   INCLUDES   ${CUDA_INCLUDE_DIRS}
+                   LIBRARIES  ${CUDA_LIBRARIES}
+                   EXPORTABLE ${BLT_EXPORT_THIRDPARTY})

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -44,4 +44,5 @@ blt_import_library(NAME          hip_runtime
                    DEFINES       ${HIP_RUNTIME_DEFINES}
                    COMPILE_FLAGS ${HIP_RUNTIME_COMPILE_FLAGS}
                    LIBRARIES     ${HIP_RUNTIME_LIBRARIES}
-                   TREAT_INCLUDES_AS_SYSTEM ON)
+                   TREAT_INCLUDES_AS_SYSTEM ON
+                   EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -182,4 +182,5 @@ blt_import_library(NAME          mpi
                    TREAT_INCLUDES_AS_SYSTEM ON
                    LIBRARIES     ${_mpi_libraries}
                    COMPILE_FLAGS ${_mpi_compile_flags}
-                   LINK_FLAGS    ${_mpi_link_flags} )
+                   LINK_FLAGS    ${_mpi_link_flags} 
+                   EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})

--- a/cmake/thirdparty/SetupOpenMP.cmake
+++ b/cmake/thirdparty/SetupOpenMP.cmake
@@ -54,4 +54,5 @@ message(STATUS "OpenMP Link Flags:    ${_link_flags}")
 
 blt_import_library(NAME openmp
                    COMPILE_FLAGS ${_compile_flags}
-                   LINK_FLAGS    ${_link_flags})
+                   LINK_FLAGS    ${_link_flags}
+                   EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -422,8 +422,11 @@ GLOBAL
   Whether to extend the visibility of the created library to global scope
 
 EXPORTABLE
-  Whether the created target should be exportable and ``install``-able - mutually
-  exclusive with the GLOBAL option
+  Whether the created target should be exportable and ``install``-able
+
+.. note:: Libraries marked EXPORTABLE cannot also be marked GLOBAL.  They also
+  must be added to any export set that includes a target that depends on the 
+  EXPORTABLE library.
 
 Allows libraries not built with CMake to be imported as native CMake targets
 in order to take full advantage of CMake's transitive dependency resolution.

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -422,7 +422,7 @@ GLOBAL
   Whether to extend the visibility of the created library to global scope
 
 EXPORTABLE
-  Whether the created target should be exportable and ``install``able - mutually
+  Whether the created target should be exportable and ``install``-able - mutually
   exclusive with the GLOBAL option
 
 Allows libraries not built with CMake to be imported as native CMake targets

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -384,7 +384,8 @@ blt_import_library
                         COMPILE_FLAGS            [flag1 [flag2 ..]]
                         LINK_FLAGS               [flag1 [flag2 ..]]
                         DEFINES                  [def1 [def2 ...]]
-                        GLOBAL                   [ON|OFF])
+                        GLOBAL                   [ON|OFF]
+                        EXPORTABLE               [ON|OFF])
 
 Creates a CMake target from build artifacts and system files generated outside of this build system.
 
@@ -419,6 +420,10 @@ DEFINES
 
 GLOBAL
   Whether to extend the visibility of the created library to global scope
+
+EXPORTABLE
+  Whether the created target should be exportable and ``install``able - mutually
+  exclusive with the GLOBAL option
 
 Allows libraries not built with CMake to be imported as native CMake targets
 in order to take full advantage of CMake's transitive dependency resolution.

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -424,10 +424,6 @@ GLOBAL
 EXPORTABLE
   Whether the created target should be exportable and ``install``-able
 
-.. note:: Libraries marked EXPORTABLE cannot also be marked GLOBAL.  They also
-  must be added to any export set that includes a target that depends on the 
-  EXPORTABLE library.
-
 Allows libraries not built with CMake to be imported as native CMake targets
 in order to take full advantage of CMake's transitive dependency resolution.
 
@@ -441,6 +437,18 @@ options to be associated with the library.
 As with BLT-registered libraries, it can be added to the DEPENDS_ON parameter
 when building another target or to ``target_link_libraries`` to transitively add in
 all includes, libraries, flags, and definitions associated with the imported library.
+
+The EXPORTABLE option is intended to be used to simplify the process of exporting a project.
+Instead of handwriting package location logic in a CMake package configuration file, the
+EXPORTABLE targets can be exported with the targets defined by the project.
+
+.. note:: Libraries marked EXPORTABLE cannot also be marked GLOBAL.  They also
+  must be added to any export set that includes a target that depends on the 
+  EXPORTABLE library.
+
+.. note:: It is highly recommended that EXPORTABLE imported targets be installed with a
+  project-specific namespace/prefix, either with the NAMESPACE option of CMake's install() command,
+  or the EXPORT_NAME target property.  This mitigates the risk of conflicting target names.
 
 In CMake terms, the imported libraries will be ``INTERFACE`` libraries.
 

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -204,6 +204,8 @@ Header-only libraries are useful when you do not want the library separately com
 are using C++ templates that require the library's user to instantiate them. These libraries
 have headers but no sources. To create a header-only library (CMake calls them INTERFACE libraries),
 simply list all headers under the HEADERS argument and do not specify SOURCES (because there aren't any).
+Header-only libraries can have dependencies like compiled libraries - these will be propagated to targets
+that depend on the header-only library.
 
 Object libraries are basically a collection of compiled source files that are not
 archived or linked. They are sometimes useful when you want to solve compilicated linking

--- a/docs/tutorial/exporting_blt_targets.rst
+++ b/docs/tutorial/exporting_blt_targets.rst
@@ -3,7 +3,7 @@
 .. # 
 .. # SPDX-License-Identifier: (BSD-3-Clause)
 
-Exporting BLT-created Targets
+Exporting BLT Created Targets
 =============================
 
 BLT provides several built-in targets for commonly used libraries:

--- a/docs/tutorial/exporting_blt_targets.rst
+++ b/docs/tutorial/exporting_blt_targets.rst
@@ -1,0 +1,74 @@
+.. # Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+.. # other BLT Project Developers. See the top-level COPYRIGHT file for details
+.. # 
+.. # SPDX-License-Identifier: (BSD-3-Clause)
+
+Exporting BLT-created Targets
+=============================
+
+BLT provides several built-in targets for commonly used libraries:
+
+ * ``mpi`` (when ``ENABLE_MPI`` is on)
+ * ``openmp`` (when ``ENABLE_OPENMP`` is on)
+ * ``cuda`` and ``cuda_runtime`` (when ``ENABLE_CUDA`` is on)
+ * ``hip`` and ``hip_runtime`` (when ``ENABLE_HIP`` is on)
+
+These targets can be made exportable in order to make them available to users of
+your project via CMake's ``install()`` command.  Setting BLT's ``BLT_EXPORT_THIRDPARTY``
+option to ``ON`` will mark all active targets in the above list as ``EXPORTABLE``
+(see the ``blt_import_library()`` documentation for more info).
+
+.. note:: If a target in your project is added to an export set, any of its dependencies
+  marked ``EXPORTABLE`` must be added to the same export set.  Failure to add them will
+  result in a CMake error in the exporting project.
+
+Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
+
+.. code-block:: cmake
+
+    # BLT configuration - enable MPI
+    set(ENABLE_MPI ON CACHE BOOL "")
+    # and mark the subsequently created MPI target as exportable
+    set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
+
+    # Later, a project might mark a target as dependent on MPI
+    blt_add_executable( NAME    example_1
+                        SOURCES example_1.cpp
+                        DEPENDS_ON mpi )
+
+    # Add the example_1 target to the example-targets export set
+    install(TARGETS example_1 EXPORT example-targets)
+
+    # Add the MPI target to the same export set - this is required
+    # because the mpi target was marked exportable
+    install(TARGETS mpi EXPORT example-targets)
+
+    # To avoid collisions with projects that import "example-targets",
+    # one option is to prefix the name of the MPI target
+    # With this approach the exported name of example_1 is unchanged
+    set_target_properties(mpi PROPERTIES EXPORT_NAME example::mpi)
+
+    # Alternatively, 
+
+To avoid collisions with projects that import "example-targets", there are
+two options for adjusting the exported name of the ``mpi`` target.
+
+The first is to rename only the ``mpi`` target's exported name:
+
+.. code-block:: cmake
+
+    set_target_properties(mpi PROPERTIES EXPORT_NAME example::mpi)
+    install(EXPORT example-targets)
+
+With this approach the ``example_1`` target's exported name is unchanged - a 
+project that imports the ``example-targets`` export set will have ``example_1``
+and ``example::mpi`` targets made available.
+
+Another approach is to install all targets in the export set behind a namespace:
+
+.. code-block:: cmake
+
+    install(EXPORT example-targets NAMESPACE example::)
+
+With this approach all targets in the export set are prefixed, so an importing
+project will have ``example::example_1`` and ``example::mpi`` targets made available.

--- a/docs/tutorial/exporting_blt_targets.rst
+++ b/docs/tutorial/exporting_blt_targets.rst
@@ -30,6 +30,7 @@ Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
     set(ENABLE_MPI ON CACHE BOOL "")
     # and mark the subsequently created MPI target as exportable
     set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
+    # Both of the above must happen before SetupBLT.cmake is included
 
     # Later, a project might mark a target as dependent on MPI
     blt_add_executable( NAME    example_1
@@ -48,8 +49,6 @@ Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
     # With this approach the exported name of example_1 is unchanged
     set_target_properties(mpi PROPERTIES EXPORT_NAME example::mpi)
 
-    # Alternatively, 
-
 To avoid collisions with projects that import "example-targets", there are
 two options for adjusting the exported name of the ``mpi`` target.
 
@@ -62,7 +61,8 @@ The first is to rename only the ``mpi`` target's exported name:
 
 With this approach the ``example_1`` target's exported name is unchanged - a 
 project that imports the ``example-targets`` export set will have ``example_1``
-and ``example::mpi`` targets made available.
+and ``example::mpi`` targets made available.  The imported ``example_1`` will
+depend on ``example::mpi``.
 
 Another approach is to install all targets in the export set behind a namespace:
 
@@ -72,3 +72,4 @@ Another approach is to install all targets in the export set behind a namespace:
 
 With this approach all targets in the export set are prefixed, so an importing
 project will have ``example::example_1`` and ``example::mpi`` targets made available.
+The imported ``example::example_1`` will depend on ``example::mpi``.

--- a/docs/tutorial/exporting_blt_targets.rst
+++ b/docs/tutorial/exporting_blt_targets.rst
@@ -31,6 +31,7 @@ Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
     # and mark the subsequently created MPI target as exportable
     set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
     # Both of the above must happen before SetupBLT.cmake is included
+    include(/path/to/SetupBLT.cmake)
 
     # Later, a project might mark a target as dependent on MPI
     blt_add_executable( NAME    example_1
@@ -43,11 +44,6 @@ Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
     # Add the MPI target to the same export set - this is required
     # because the mpi target was marked exportable
     install(TARGETS mpi EXPORT example-targets)
-
-    # To avoid collisions with projects that import "example-targets",
-    # one option is to prefix the name of the MPI target
-    # With this approach the exported name of example_1 is unchanged
-    set_target_properties(mpi PROPERTIES EXPORT_NAME example::mpi)
 
 To avoid collisions with projects that import "example-targets", there are
 two options for adjusting the exported name of the ``mpi`` target.

--- a/docs/tutorial/external_dependencies.rst
+++ b/docs/tutorial/external_dependencies.rst
@@ -54,7 +54,10 @@ though it does not support the creation of targets with the same name as a targe
     can also be used to manage visibility.
 
 BLT's ``mpi``, ``cuda``, ``cuda_runtime``, and ``openmp`` targets are all defined via ``blt_import_library()``. 
-You can see how in ``blt/thirdparty_builtin/CMakelists.txt``.
+You can see how in ``blt/thirdparty_builtin/CMakelists.txt``.  If your project exports targets and you would like
+BLT's provided third-party targets to also be exported (for example, if a project that imports your project does not
+use BLT), you can set the ``BLT_EXPORT_THIRDPARTY`` option to ``ON``.
+
 
 .. admonition:: blt_register_library
    :class: hint

--- a/docs/tutorial/external_dependencies.rst
+++ b/docs/tutorial/external_dependencies.rst
@@ -64,7 +64,7 @@ BLT's provided third-party targets to also be exported (for example, if a projec
 use BLT), you can set the ``BLT_EXPORT_THIRDPARTY`` option to ``ON``.  As with other EXPORTABLE targets created by
 ``blt_import_library()``, these targets should be prefixed with the name of the project.  Either the ``EXPORT_NAME``
 target property or the ``NAMESPACE`` option to CMake's ``install`` command can be used to modify the name of an
-installed target.
+installed target.  See the "Exporting BLT Targets" page for more info.
 
 
 .. admonition:: blt_register_library

--- a/docs/tutorial/external_dependencies.rst
+++ b/docs/tutorial/external_dependencies.rst
@@ -27,14 +27,19 @@ For example, to find and add the external dependency *axom* as a CMake target, y
     include(FindAxom.cmake)
     blt_import_library(NAME      axom
                        TREAT_INCLUDES_AS_SYSTEM ON
-                       DEFINES   HAVE_AXOM=1
-                       INCLUDES  ${AXOM_INCLUDES}
-                       LIBRARIES ${AXOM_LIBRARIES})
+                       DEFINES    HAVE_AXOM=1
+                       INCLUDES   ${AXOM_INCLUDES}
+                       LIBRARIES  ${AXOM_LIBRARIES}
+                       EXPORTABLE ON)
 
 Then *axom* is available to be used in the DEPENDS_ON list in the following
 ``blt_add_executable()`` or ``blt_add_library()`` calls, or in any CMake command that accepts a target.
+
 CMake targets created by ``blt_import_library()`` are ``INTERFACE`` libraries that can be installed
-and exported.
+and exported if the ``EXPORTABLE`` option is enabled.  For example, if the ``calc_pi`` project depends on
+Axom, it could export its ``axom`` target.  To avoid introducing target name conflicts for users of the
+``calc_pi`` project who might also create a target called ``axom``, ``axom`` should be exported as
+``calc_pi::axom``.
 
 This is especially helpful for "converting" external libraries that are not built with CMake
 into CMake-friendly imported targets.
@@ -56,7 +61,10 @@ though it does not support the creation of targets with the same name as a targe
 BLT's ``mpi``, ``cuda``, ``cuda_runtime``, and ``openmp`` targets are all defined via ``blt_import_library()``. 
 You can see how in ``blt/thirdparty_builtin/CMakelists.txt``.  If your project exports targets and you would like
 BLT's provided third-party targets to also be exported (for example, if a project that imports your project does not
-use BLT), you can set the ``BLT_EXPORT_THIRDPARTY`` option to ``ON``.
+use BLT), you can set the ``BLT_EXPORT_THIRDPARTY`` option to ``ON``.  As with other EXPORTABLE targets created by
+``blt_import_library()``, these targets should be prefixed with the name of the project.  Either the ``EXPORT_NAME``
+target property or the ``NAMESPACE`` option to CMake's ``install`` command can be used to modify the name of an
+installed target.
 
 
 .. admonition:: blt_register_library

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -33,5 +33,6 @@ Parts of the tutorial also require MPI, CUDA, Sphinx and Doxygen.
     using_flags
     unit_testing
     external_dependencies
+    exporting_blt_targets
     creating_documentation
     recommendations


### PR DESCRIPTION
Since CMake does not provide a convenient way to "re-export" imported targets (see [this mailing list thread](https://cmake.org/pipermail/cmake/2019-July/069810.html) for example), this PR provides a more convenient way of exporting imported targets.

For example, if a project `proj` uses MPI via BLT's `mpi` target and wants to make its mpi target available to projects that import it, it can now configure BLT with `BLT_EXPORT_THIRDPARTY=ON`, which allows it to be exported like any other target:
```cmake
install(TARGETS     mpi
        EXPORT      proj-targets
        DESTINATION lib)
# Can also be namespaced if needed
set_target_properties(mpi PROPERTIES EXPORT_NAME proj::mpi)
```

Note that targets marked `EXPORTABLE` cannot also be `GLOBAL` (due to an underlying CMake limitation) and *must* be added to all export sets that include targets dependent on the `EXPORTABLE` target.