### PR TITLE
Leave generated coverage files intact for later use

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -37,6 +37,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - HIP CMake utilities updated to AMD's latest version
 - Updated ``add_code_coverage_target`` to ``blt_add_code_coverage_target``, which now supports
   user-specified source directories
+- Code coverage targets leave LCOV-generated files intact for later use; these files will
+  still be removed by ``make clean``
 
 ### Fixed
 - ClangFormat checks now support multiple Python executable names

--- a/cmake/SetupCodeCoverageReports.cmake
+++ b/cmake/SetupCodeCoverageReports.cmake
@@ -96,8 +96,7 @@ function(blt_add_code_coverage_target)
         COMMAND ${LCOV_EXECUTABLE} --no-external --gcov-tool ${GCOV_EXECUTABLE} ${_coverage_directories} --capture --output-file ${arg_NAME}.info
         COMMAND ${LCOV_EXECUTABLE} --no-external --gcov-tool ${GCOV_EXECUTABLE} ${_coverage_directories} --remove ${arg_NAME}.info '/usr/include/*' --output-file ${arg_NAME}.info.cleaned
         COMMAND ${GENHTML_EXECUTABLE} -o ${arg_NAME} ${arg_NAME}.info.cleaned
-        COMMAND ${CMAKE_COMMAND} -E remove ${arg_NAME}.info ${arg_NAME}.info.cleaned
-
+        BYPRODUCTS ${arg_NAME}.info ${arg_NAME}.info.cleaned
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
         COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
     )


### PR DESCRIPTION
The LCOV-generated files may be useful for further processing or as part of an upload to a coverage service.  Instead of unconditionally deleting them, this proposed change adds them as `BYPRODUCTS` to the coverage target such that they are still cleaned up by a `make clean` but are available after the target is "built".