### PR TITLE
Fix typo in blt_git_tag macro

### DIFF
--- a/cmake/BLTGitMacros.cmake
+++ b/cmake/BLTGitMacros.cmake
@@ -144,7 +144,7 @@ macro(blt_git_tag)
     endif()
 
     ## set working directory
-    if ( NOT DEFINED arg_SOURCE_DIR} )
+    if ( NOT DEFINED arg_SOURCE_DIR )
       set(git_dir ${CMAKE_CURRENT_SOURCE_DIR})
     else()
       set(git_dir ${arg_SOURCE_DIR})


### PR DESCRIPTION
The check for whether or not the caller supplied
a SOURCE_DIR when calling the macro had a typo
that was preventing calling the macro with a
specified SOURCE_DIR. Fixed that.