### PR TITLE
Bugfix: Disable SYSTEM flag for IMPORTED targets on PGI

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -61,6 +61,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - ``blt_patch_target`` no longer attempts to set system include directories when a target
   has no include directories
 - Header-only libraries now can have dependencies via DEPENDS_ON in ``blt_add_library``
+- Added a workaround for include directories of imported targets on PGI. CMake was 
+  erroneously marking them as SYSTEM but this is not supported by PGI.
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -101,14 +101,6 @@ if (NOT BLT_LOADED)
     ################################
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-
-    ################################
-    # PGI doesn't support the SYSTEM flag, which is the default for imported targets.
-    ################################
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
-        set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
-    endif()
-
     ################################
     # Macros
     ################################

--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -101,6 +101,14 @@ if (NOT BLT_LOADED)
     ################################
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+
+    ################################
+    # PGI doesn't support the SYSTEM flag, which is the default for imported targets.
+    ################################
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+        set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
+    endif()
+
     ################################
     # Macros
     ################################

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -84,6 +84,14 @@ else()
 endif()
 
 
+#################################################################################
+# PGI doesn't support a SYSTEM flag for include directories. Since this is CMake's
+# default for imported targets, we need to disable this feature for PGI.
+#################################################################################
+if(${C_COMPILER_FAMILY_IS_PGI})
+    set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
+endif()
+
 ################################################
 # Support for extra compiler flags and defines
 ################################################


### PR DESCRIPTION
PGI does not support the `isystem` flag, but CMake's default for
imported targets is to mark include directories as SYTEM for imported targets.
As a workaround, we disable this feature for PGI.

Resolves #439 