### PR TITLE
Append -dirty to Git hashcode when working tree is dirty

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -41,6 +41,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   user-specified source directories
 - Code coverage targets leave LCOV-generated files intact for later use; these files will
   still be removed by ``make clean``
+- ``blt_git_hashcode`` will append a ``-dirty` suffix if the working tree is dirty (modified)
 
 ### Fixed
 - ClangFormat checks now support multiple Python executable names

--- a/cmake/BLTGitMacros.cmake
+++ b/cmake/BLTGitMacros.cmake
@@ -235,10 +235,11 @@ macro(blt_git_hashcode)
     endif()
 
     ## set target ref
+    ## match nothing to ensure that a tag isn't added
     if ( NOT DEFINED arg_ON_BRANCH )
-      set(git_cmd rev-parse --short HEAD )
+      set(git_cmd describe --match='$^' --always --dirty )
     else()
-      set(git_cmd rev-parse --short ${arg_ON_BRANCH} )
+      set(git_cmd describe --match='$^' --always ${arg_ON_BRANCH} )
     endif()
 
      blt_git( SOURCE_DIR ${git_dir}

--- a/docs/api/git.rst
+++ b/docs/api/git.rst
@@ -167,6 +167,9 @@ branch. In addition, the caller may specify the target Git repository using
 the SOURCE_DIR argument. Otherwise, if SOURCE_DIR is not specified, the
 macro will use ${CMAKE_CURRENT_SOURCE_DIR}.
 
+If ON_BRANCH is not specified and the current working tree is dirty (e.g.,
+files have been modified), then ``-dirty`` will be appended to the HASHCODE.
+
 A return code for the Git command is returned to the caller via the CMake
 variable provided with the RETURN_CODE argument. A non-zero return code
 indicates that an error has occured.
@@ -180,4 +183,3 @@ indicates that an error has occured.
         message( FATAL_ERROR "blt_git_hashcode failed!" )
     endif()
     message( STATUS "sha1=${sha1}" )
-


### PR DESCRIPTION
This replaces `rev-parse` with `describe`, which was introduced in Git 2.4.12.  Do we need to support versions of Git older than that?