### PR TITLE
[feature/add-fruit-mpi] Add FRUIT's MPI unit test reporting features to BLT

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -30,6 +30,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added support for formatting CMake code using cmake-format.
 - Added an EXPORTABLE option to ``blt_import_library`` that allows imported libraries to be
   added to an export set and installed.
+- Added FRUIT's MPI parallel unit test reporting to BLT's internal copy of FRUIT
 
 ### Changed
 - MPI Support when using CMake 3.13 and newer: MPI linker flags are now passed

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -81,6 +81,7 @@ endif()
 option(ENABLE_GTEST        "Enable Google Test testing support (if ENABLE_TESTS=ON)" ${_CXX_enabled})
 option(ENABLE_GMOCK        "Enable Google Mock testing support (if ENABLE_TESTS=ON)" OFF)
 option(ENABLE_FRUIT        "Enable Fruit testing support (if ENABLE_TESTS=ON and ENABLE_FORTRAN=ON)" ON)
+option(ENABLE_FRUIT_MPI    "Enable Fruit MPI testing support (if ENABLE_TESTS=ON and ENABLE_FORTRAN=ON and ENABLE_FRUIT=ON and ENABLE_MPI=ON" OFF)
 option(ENABLE_GBENCHMARK   "Enable Google Benchmark support (if ENABLE_TESTS=ON)" ${ENABLE_BENCHMARKS})
 
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -290,6 +290,7 @@ if(CLANGFORMAT_FOUND)
     ../smoke/blt_mpi_smoke.cpp
     ../smoke/blt_openmp_smoke.cpp
     ../smoke/fortran_driver.cpp
+    ../smoke/fortran_mpi_driver.cpp
   )
 
   set(internal_tests_srcs

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -65,6 +65,19 @@ if (ENABLE_FORTRAN AND ENABLE_FRUIT)
                  COMMAND blt_fruit_smoke)
 endif()
 
+###############
+# fruit mpi test
+###############
+if (ENABLE_FORTRAN AND ENABLE_FRUIT AND ENABLE_MPI AND ENABLE_FRUIT_MPI)
+    blt_add_executable(NAME blt_fruit_mpi_smoke
+                       SOURCES blt_fruit_mpi_smoke.f90
+                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                       DEPENDS_ON fruit fruit_mpi MPI::MPI_Fortran
+                       FOLDER blt/tests )
+
+    blt_add_test(NAME blt_fruit_mpi_smoke
+                 COMMAND blt_fruit_mpi_smoke)
+endif()
 
 ################
 # OpenMP test

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -72,7 +72,7 @@ if (ENABLE_FORTRAN AND ENABLE_FRUIT AND ENABLE_MPI AND ENABLE_FRUIT_MPI)
     blt_add_executable(NAME blt_fruit_mpi_smoke
                        SOURCES blt_fruit_mpi_smoke.f90
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON fruit fruit_mpi MPI::MPI_Fortran
+                       DEPENDS_ON fruit_mpi
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_fruit_mpi_smoke

--- a/tests/smoke/blt_fruit_mpi_smoke.f90
+++ b/tests/smoke/blt_fruit_mpi_smoke.f90
@@ -1,0 +1,73 @@
+! Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+! other BLT Project Developers. See the top-level COPYRIGHT file for details
+!
+! SPDX-License-Identifier: (BSD-3-Clause)
+
+!------------------------------------------------------------------------------
+!
+! blt_fruit_smoke.f90
+!
+!------------------------------------------------------------------------------
+module fruit_mpi_smoke
+  use iso_c_binding
+  use fruit
+  use mpi
+  use fruit_mpi
+  implicit none
+
+contains
+!------------------------------------------------------------------------------
+
+  subroutine simple_mpi_test(comm)
+        integer, intent(in) :: comm
+        integer :: comm_size, comm_rank
+        integer :: mpi_err_stat
+        integer, parameter :: first_rank = 0
+
+        call mpi_comm_size(comm, comm_size, mpi_err_stat)
+        call mpi_comm_rank(comm, comm_rank, mpi_err_stat)
+
+        call assert_true(comm_rank .ge. first_rank, &
+             "MPI comm rank is negative; something strange is happening")
+        call assert_true(comm_rank .lt. comm_size, &
+             "MPI comm rank is greater than or equal to comm size")
+  end subroutine simple_mpi_test
+
+
+!----------------------------------------------------------------------
+end module fruit_mpi_smoke
+!----------------------------------------------------------------------
+
+program fortran_mpi_test
+  use fruit
+  use mpi
+  use fruit_mpi
+  use fruit_mpi_smoke
+  implicit none
+  logical :: ok_on_rank, ok_on_comm
+
+  integer :: mpi_err_stat
+  integer :: comm_size, comm_rank
+  integer, parameter :: comm = MPI_COMM_WORLD
+
+  call mpi_init(mpi_err_stat)
+  call mpi_comm_size(comm, comm_size, mpi_err_stat)
+  call mpi_comm_rank(comm, comm_rank, mpi_err_stat)
+
+  call init_fruit
+!----------
+! Our tests
+  call simple_mpi_test(comm)
+!----------
+
+  call fruit_summary_mpi(comm_size, comm_rank)
+  call is_all_successful(ok_on_rank)
+  call mpi_allreduce(ok_on_rank, ok_on_comm, 1, MPI_LOGICAL, MPI_LAND, comm, mpi_err_stat)
+
+  call fruit_finalize_mpi(comm_size, comm_rank)
+  call mpi_finalize(mpi_err_stat)
+  
+  if (.not. ok_on_comm) then
+     call exit(1)
+  endif
+end program fortran_mpi_test

--- a/tests/smoke/fortran_mpi_driver.cpp
+++ b/tests/smoke/fortran_mpi_driver.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2017-2019, Lawrence Livermore National Security, LLC and
+// other BLT Project Developers. See the top-level COPYRIGHT file for details
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+//----------------------------------------------------------------------
+
+/* 
+   fortran_mpi_test manages MPI_Init & MPI_Finalize. Do not put MPI
+   calls in this driver file -- put these calls in fortran_mpi_test,
+   which should be defined in blt_fruit_mpi_test.f90.
+ */
+extern "C" int fortran_mpi_test();
+
+int main()
+{
+  int result = 0;
+
+  // finalized when exiting main scope
+  result = fortran_mpi_test();
+
+  return result;
+}

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -123,7 +123,7 @@ if(ENABLE_TESTS)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)
 	    list(APPEND _blt_tpl_targets fruit)
-	    if(ENABLE_MPI) # TODO(oxberry1@llnl.gov): Replace with ENABLE_FRUIT_MPI
+	    if(ENABLE_FRUIT_MPI)
 	        list(APPEND _blt_tpl_targets fruit_mpi)
 	    endif()
         endif()

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -122,7 +122,10 @@ if(ENABLE_TESTS)
         if(ENABLE_FRUIT)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)
-            list(APPEND _blt_tpl_targets fruit)
+	    list(APPEND _blt_tpl_targets fruit)
+	    if(ENABLE_MPI) # TODO(oxberry1@llnl.gov): Replace with ENABLE_FRUIT_MPI
+	        list(APPEND _blt_tpl_targets fruit_mpi)
+	    endif()
         endif()
     endif()
 

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -119,6 +119,7 @@ if(ENABLE_TESTS)
     # Enable Fruit (FortRan UnIT testing) support
     if (ENABLE_FORTRAN)
         message(STATUS "Fruit Support is ${ENABLE_FRUIT}")
+        message(STATUS "Fruit MPI Support is ${ENABLE_FRUIT_MPI}")
         if(ENABLE_FRUIT)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -124,7 +124,7 @@ if(ENABLE_TESTS)
             add_subdirectory(fruit-3.4.1
                              ${BLT_BUILD_DIR}/thirdparty_builtin/fruit-3.4.1)
 	    list(APPEND _blt_tpl_targets fruit)
-	    if(ENABLE_FRUIT_MPI)
+	    if(ENABLE_MPI AND ENABLE_FRUIT_MPI)
 	        list(APPEND _blt_tpl_targets fruit_mpi)
 	    endif()
         endif()

--- a/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
+++ b/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
@@ -22,7 +22,7 @@ if(ENABLE_FRUIT_MPI)
         SOURCES fruit_mpi.f90
     )
     blt_register_library( NAME fruit_mpi
-                          DEPENDS_ON fruit MPI::Fortran
+                          DEPENDS_ON fruit MPI::MPI_Fortran
                           FORTRAN_MODULES ${CMAKE_Fortran_MODULE_DIRECTORY}
                           INCLUDES ${CMAKE_Fortran_MODULE_DIRECTORY}
                           LIBRARIES fruit_mpi

--- a/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
+++ b/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
@@ -16,7 +16,7 @@ blt_register_library( NAME fruit
                       LIBRARIES fruit 
 )
 
-if(ENABLE_MPI) # TODO(oxberry1@llnl.gov): Replace with ENABLE_FRUIT_MPI
+if(ENABLE_FRUIT_MPI) 
     blt_add_library(
         NAME fruit_mpi
         SOURCES fruit_mpi.f90

--- a/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
+++ b/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
@@ -15,3 +15,16 @@ blt_register_library( NAME fruit
                       INCLUDES ${CMAKE_Fortran_MODULE_DIRECTORY}
                       LIBRARIES fruit 
 )
+
+if(ENABLE_MPI) # TODO(oxberry1@llnl.gov): Replace with ENABLE_FRUIT_MPI
+    blt_add_library(
+        NAME fruit_mpi
+        SOURCES fruit_mpi.f90
+    )
+    blt_register_library( NAME fruit_mpi
+                          DEPENDS_ON fruit MPI::Fortran
+                          FORTRAN_MODULES ${CMAKE_Fortran_MODULE_DIRECTORY}
+                          INCLUDES ${CMAKE_Fortran_MODULE_DIRECTORY}
+                          LIBRARIES fruit_mpi
+    )
+endif()

--- a/thirdparty_builtin/fruit-3.4.1/fruit_mpi.f90
+++ b/thirdparty_builtin/fruit-3.4.1/fruit_mpi.f90
@@ -1,0 +1,261 @@
+module fruit_mpi
+  use fruit
+  use mpi
+  implicit none
+  private
+
+  integer, parameter :: XML_OPEN = 20
+  integer, parameter :: XML_WORK = 21
+  character(len = *), parameter :: xml_filename = "result.xml"
+  integer, parameter :: NUMBER_LENGTH = 10
+  integer, parameter :: FN_LENGTH = 50
+
+  public ::          fruit_init_mpi_xml
+  interface          fruit_init_mpi_xml
+    module procedure fruit_init_mpi_xml_
+  end interface
+
+  public ::          fruit_finalize_mpi
+  interface          fruit_finalize_mpi
+    module procedure fruit_finalize_mpi_
+  end interface
+
+  public ::          fruit_summary_mpi
+  interface          fruit_summary_mpi
+    module procedure fruit_summary_mpi_
+  end interface
+
+  public ::          fruit_summary_mpi_xml
+  interface          fruit_summary_mpi_xml
+    module procedure fruit_summary_mpi_xml_
+  end interface
+contains
+  subroutine fruit_init_mpi_xml_(rank)
+    integer, intent(in) :: rank
+    character(len = FN_LENGTH) :: xml_filename_work
+
+    write(xml_filename_work, '("result_tmp_", i5.5, ".xml")') rank
+    call set_xml_filename_work(xml_filename_work)
+
+    call init_fruit_xml(rank)
+  end subroutine fruit_init_mpi_xml_
+
+  subroutine     fruit_finalize_mpi_(size, rank)
+    integer, intent(in) :: size, rank
+    if (size < 0) print *, "size negative"
+    if (rank < 0) print *, "rank negative"
+    call         fruit_finalize
+  end subroutine fruit_finalize_mpi_
+
+  subroutine     fruit_summary_mpi_(size, rank)
+    integer, intent(in) :: size, rank
+    integer :: fail_assert_sum
+    integer :: succ_assert_sum
+    integer :: fail_case_sum
+    integer :: succ_case_sum
+
+    integer :: fail_assert
+    integer :: succ_assert
+    integer :: fail_case
+    integer :: succ_case
+
+    integer :: message_index
+    integer :: num_msgs
+    integer :: num_msgs_sum
+    integer, allocatable :: num_msgs_rank(:)
+
+    integer :: ierr
+    integer :: i
+    integer :: imsg
+    integer :: status(MPI_STATUS_SIZE)
+
+    integer, parameter :: MSG_LENGTH_HERE = 256
+    character(len = MSG_LENGTH_HERE), allocatable :: msgs(:)
+    character(len = MSG_LENGTH_HERE), allocatable :: msgs_all(:)
+
+    call get_assert_and_case_count(&
+    & fail_assert,  succ_assert, &
+    & fail_case,    succ_case)
+
+    call get_message_index(message_index)
+    num_msgs = message_index - 1
+    allocate(msgs(num_msgs))
+    call get_message_array(msgs)
+
+    allocate(num_msgs_rank(size))
+    call MPI_Allgather(&
+    & num_msgs,      1, MPI_INTEGER, &
+    & num_msgs_rank, 1, MPI_INTEGER, MPI_COMM_WORLD, ierr)
+
+    num_msgs_sum = sum(num_msgs_rank(:))
+    allocate(msgs_all(num_msgs_sum))
+
+    ! array msgs_all:
+    !
+    ! | msgs(:) of rank 0  | msgs(:) of rank 1   | msgs(:) of rank 2  |
+    ! |                    |                     |                    |
+    ! | num_msgs_rank(1)   |  num_msgs_rank(2)   | num_msgs_rank(3)   |
+    ! |                    |                     |                    |
+    ! |                    |                     |                    |
+    !                       A                     A                  A
+    !                       |                     |                  |
+    !              sum(num_msgs_rank(1:1))+1      |             num_msgs_sum
+    !                                    sum(num_msgs_rank(1:2))+1
+
+    if (rank == 0) then
+      msgs_all(1:num_msgs) = msgs(1:num_msgs)
+      do i = 1, size - 1
+        imsg = sum(num_msgs_rank(1:i)) + 1
+        call MPI_RECV(&
+        & msgs_all(imsg), &
+        & num_msgs_rank(i + 1) * MSG_LENGTH_HERE, MPI_CHARACTER, &
+        & i, 7, MPI_COMM_WORLD, status, ierr)
+      enddo
+    else
+      call MPI_Send(&
+      & msgs, &
+      & num_msgs * MSG_LENGTH_HERE               , MPI_CHARACTER, &
+      & 0, 7, MPI_COMM_WORLD, ierr)
+    endif
+
+    call MPI_REDUCE(&
+    & fail_assert    , &
+    & fail_assert_sum, 1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & succ_assert    , &
+    & succ_assert_sum, 1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & fail_case    , &
+    & fail_case_sum,   1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & succ_case    , &
+    & succ_case_sum,   1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    if (rank == 0) then
+      write (*,*)
+      write (*,*)
+      write (*,*) '    Start of FRUIT summary: '
+      write (*,*)
+
+      if (fail_assert_sum > 0) then
+         write (*,*) 'Some tests failed!'
+      else
+         write (*,*) 'SUCCESSFUL!'
+      end if
+
+      write (*,*)
+      write (*,*) '  -- Failed assertion messages:'
+
+      do i = 1, num_msgs_sum
+        write (*, "(A)") '   '//trim(msgs_all(i))
+      end do
+
+      write (*, *) '  -- end of failed assertion messages.'
+      write (*, *)
+
+      if (succ_assert_sum + fail_assert_sum /= 0) then
+        call fruit_summary_table(&
+        & succ_assert_sum, fail_assert_sum, &
+        & succ_case_sum  , fail_case_sum    &
+        &)
+      endif
+      write(*, *) '  -- end of FRUIT summary'
+    endif
+  end subroutine fruit_summary_mpi_
+
+  subroutine     fruit_summary_mpi_xml_(size, rank)
+    integer, intent(in) :: size, rank
+
+    character(len = 1000) :: whole_line
+    character(len =  100) :: full_count
+    character(len =  100) :: fail_count
+    character(len = FN_LENGTH)              :: xml_filename_work
+    character(len = FN_LENGTH), allocatable :: xml_filename_work_all(:)
+
+    integer :: fail_assert    , succ_assert    , fail_case     , succ_case
+    integer :: fail_assert_sum, succ_assert_sum, fail_case_sum , succ_case_sum
+    integer :: i
+    integer :: status(MPI_STATUS_SIZE)
+    integer :: ierr
+
+    call get_xml_filename_work(xml_filename_work)
+
+    allocate(xml_filename_work_all(size))
+
+    if (rank /= 0) then
+    call MPI_Send(    xml_filename_work, &
+    &     FN_LENGTH, MPI_CHARACTER,     0, 8, MPI_COMM_WORLD, ierr)
+    endif
+    if (rank == 0) then
+      xml_filename_work_all(1) = xml_filename_work
+
+      do i = 1+1, size
+        call MPI_RECV(xml_filename_work_all(i), &
+        & FN_LENGTH, MPI_CHARACTER, i - 1, 8, MPI_COMM_WORLD, status, ierr)
+      enddo
+    endif
+
+    call get_assert_and_case_count(&
+    & fail_assert,  succ_assert, &
+    & fail_case,    succ_case)
+
+    call MPI_REDUCE(&
+    & fail_assert    , &
+    & fail_assert_sum, 1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & succ_assert    , &
+    & succ_assert_sum, 1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & fail_case    , &
+    & fail_case_sum,   1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    call MPI_REDUCE(&
+    & succ_case    , &
+    & succ_case_sum,   1, MPI_INTEGER, MPI_SUM, 0, MPI_COMM_WORLD, ierr)
+
+    full_count = int_to_str(succ_case_sum + fail_case_sum)
+    fail_count = int_to_str(                fail_case_sum)
+
+    if (rank == 0) then
+      open (XML_OPEN, file = xml_filename, action ="write", status = "replace")
+        write(XML_OPEN, '("<?xml version=""1.0"" encoding=""UTF-8""?>")')
+        write(XML_OPEN, '("<testsuites>")')
+        write(XML_OPEN, '("  <testsuite errors=""0"" ")', advance = "no")
+        write(XML_OPEN, '("tests=""", a, """ ")', advance = "no") &
+        &  trim(full_count)
+        write(XML_OPEN, '("failures=""", a, """ ")', advance = "no") &
+        &  trim(fail_count)
+        write(XML_OPEN, '("name=""", a, """ ")', advance = "no") &
+        &  "name of test suite"
+        write(XML_OPEN, '("id=""1"">")')
+
+        do i = 1, size
+          open (XML_WORK, FILE = xml_filename_work_all(i))
+            do
+              read(XML_WORK, '(a)', end = 999) whole_line
+              write(XML_OPEN, '(a)') trim(whole_line)
+            enddo
+        999 continue
+          close(XML_WORK)
+        enddo
+
+        write(XML_OPEN, '("  </testsuite>")')
+        write(XML_OPEN, '("</testsuites>")')
+      close(XML_OPEN)
+    endif
+    if (size < 0) print *, "size < 0"
+  end subroutine fruit_summary_mpi_xml_
+
+  function int_to_str(i)
+    integer, intent(in) :: i
+    character(LEN = NUMBER_LENGTH) :: int_to_str
+
+    write(int_to_str, '(i10)') i
+    int_to_str = adjustl(int_to_str)
+  end function int_to_str
+end module fruit_mpi


### PR DESCRIPTION
Resolves #444.

This pull request adds another source file from FRUIT 3.4.1 -- `fruit_mpi.f90` -- that adds some procedures reporting unit test successes and failures over ranks in a given communicator. These additional procedures don't conflict with the API in `fruit.f90`.