### PR TITLE
Propagate HIP/CUDA linker requirements up the DAG

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -67,9 +67,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   erroneously marking them as SYSTEM but this is not supported by PGI.
 - Check added to make sure that if HIP is enabled with fortran, the LINKER LANGUAGE
   is not changed back to Fortran.
-- If an executable needs to be linked with the HIP or CUDA (NVCC) linker, this information
-  is internally propagated up the dependency graph and used to override the LINKER_LANGUAGE
-  target property for executable targets
+- Executables that link to libraries that depend on `hip`/`cuda`(`_runtime`) will automatically
+  be linked with the HIP or CUDA (NVCC) linker
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -67,8 +67,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   erroneously marking them as SYSTEM but this is not supported by PGI.
 - Check added to make sure that if HIP is enabled with fortran, the LINKER LANGUAGE
   is not changed back to Fortran.
-- Executables that link to libraries that depend on `hip`/`cuda`(`_runtime`) will automatically
-  be linked with the HIP or CUDA (NVCC) linker
+- Executables that link to libraries that depend on `hip`/`hip_runtime`/`cuda`/`cuda_runtime`
+  will automatically be linked with the HIP or CUDA (NVCC) linker
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -68,7 +68,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Check added to make sure that if HIP is enabled with fortran, the LINKER LANGUAGE
   is not changed back to Fortran.
 - If an executable needs to be linked with the HIP or CUDA (NVCC) linker, this information
-  is internally propagated up the dependency graph and used to override the LINK_LANGUAGE
+  is internally propagated up the dependency graph and used to override the LINKER_LANGUAGE
+  target property for executable targets
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -67,6 +67,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   erroneously marking them as SYSTEM but this is not supported by PGI.
 - Check added to make sure that if HIP is enabled with fortran, the LINKER LANGUAGE
   is not changed back to Fortran.
+- If an executable needs to be linked with the HIP or CUDA (NVCC) linker, this information
+  is internally propagated up the dependency graph and used to override the LINK_LANGUAGE
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -809,7 +809,7 @@ macro(blt_add_executable)
     get_target_property(_blt_link_lang ${arg_NAME} BLT_LINKER_LANGUAGE_OVERRIDE)
     if(_blt_link_lang)
         # This is the final link (b/c executable), so override the actual LINKER_LANGUAGE
-        # The override will only ever be HIP or CUDA
+        # BLT currently uses this to override for HIP and CUDA linkers
         set_target_properties(${arg_NAME} PROPERTIES LINKER_LANGUAGE ${_blt_link_lang})
     endif()
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -804,9 +804,9 @@ macro(blt_add_executable)
                      DEPENDS_ON ${arg_DEPENDS_ON} 
                      OBJECT     FALSE)
 
-    # Override the linker language with BLT_LINKER_LANGUAGE_OVERRIDE, if applicable
+    # Override the linker language with INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE, if applicable
     # Will have just been populated by blt_setup_target
-    get_target_property(_blt_link_lang ${arg_NAME} BLT_LINKER_LANGUAGE_OVERRIDE)
+    get_target_property(_blt_link_lang ${arg_NAME} INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE)
     if(_blt_link_lang)
         # This is the final link (b/c executable), so override the actual LINKER_LANGUAGE
         # BLT currently uses this to override for HIP and CUDA linkers

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -804,11 +804,12 @@ macro(blt_add_executable)
                      DEPENDS_ON ${arg_DEPENDS_ON} 
                      OBJECT     FALSE)
 
-    # Override the linker language with BLT_LINKER_LANGUAGE, if applicable
+    # Override the linker language with BLT_LINKER_LANGUAGE_OVERRIDE, if applicable
     # Will have just been populated by blt_setup_target
-    get_target_property(_blt_link_lang ${arg_NAME} BLT_LINKER_LANGUAGE)
+    get_target_property(_blt_link_lang ${arg_NAME} BLT_LINKER_LANGUAGE_OVERRIDE)
     if(_blt_link_lang)
         # This is the final link (b/c executable), so override the actual LINKER_LANGUAGE
+        # The override will only ever be HIP or CUDA
         set_target_properties(${arg_NAME} PROPERTIES LINKER_LANGUAGE ${_blt_link_lang})
     endif()
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -796,17 +796,21 @@ macro(blt_add_executable)
     list(GET arg_SOURCES 0 _first)
     get_source_file_property(_lang ${_first} LANGUAGE)
     if(_lang STREQUAL Fortran)
-        get_source_file_property(_is_hip ${_first} HIP_SOURCE_PROPERTY_FORMAT)
-        #Don't reset the linker if the NVCC or HIP linker is required
-        if (NOT (CUDA_LINK_WITH_NVCC OR ${_is_hip}))
-            set_target_properties( ${arg_NAME} PROPERTIES LINKER_LANGUAGE Fortran )
-        endif()
+        set_target_properties( ${arg_NAME} PROPERTIES LINKER_LANGUAGE Fortran )
         target_include_directories(${arg_NAME} PRIVATE ${CMAKE_Fortran_MODULE_DIRECTORY})
     endif()
        
     blt_setup_target(NAME       ${arg_NAME}
                      DEPENDS_ON ${arg_DEPENDS_ON} 
                      OBJECT     FALSE)
+
+    # Override the linker language with BLT_LINKER_LANGUAGE, if applicable
+    # Will have just been populated by blt_setup_target
+    get_target_property(_blt_link_lang ${arg_NAME} BLT_LINKER_LANGUAGE)
+    if(_blt_link_lang)
+        # This is the final link (b/c executable), so override the actual LINKER_LANGUAGE
+        set_target_properties(${arg_NAME} PROPERTIES LINKER_LANGUAGE ${_blt_link_lang})
+    endif()
 
     # fix the openmp flags for fortran if needed
     # NOTE: this needs to be called after blt_setup_target()

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -394,10 +394,10 @@ macro(blt_setup_target)
             # If it's an interface library CMake doesn't even allow us to query the property
             get_target_property(_dep_type ${dependency} TYPE)
             if(NOT "${_dep_type}" STREQUAL "INTERFACE_LIBRARY")
-                get_target_property(_blt_link_lang ${dependency} BLT_LINKER_LANGUAGE_OVERRIDE)
+                get_target_property(_blt_link_lang ${dependency} INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE)
                 # TODO: Do we need to worry about overwriting?  Should only ever be HIP or CUDA
                 if(_blt_link_lang)
-                    set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE ${_blt_link_lang})
+                    set_target_properties(${arg_NAME} PROPERTIES INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE ${_blt_link_lang})
                 endif()
             endif()
         endif()
@@ -448,7 +448,7 @@ macro(blt_setup_cuda_target)
             set_target_properties( ${arg_NAME} PROPERTIES LINKER_LANGUAGE CUDA)
             # This will be propagated up to executable targets that depend on this
             # library, which will need the HIP linker
-            set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE CUDA)
+            set_target_properties( ${arg_NAME} PROPERTIES INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE CUDA)
         endif()
     endif()
 
@@ -548,7 +548,7 @@ macro(blt_add_hip_library)
     if (${_depends_on_hip_runtime} OR ${_depends_on_hip})
         # This will be propagated up to executable targets that depend on this
         # library, which will need the HIP linker
-        set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE HIP)
+        set_target_properties( ${arg_NAME} PROPERTIES INTERFACE_BLT_LINKER_LANGUAGE_OVERRIDE HIP)
     endif()
 
 endmacro(blt_add_hip_library)

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -319,7 +319,7 @@ macro(blt_setup_target)
     endforeach()
 
     # Add dependency's information
-    foreach(     ${_expanded_DEPENDS_ON} )
+    foreach( dependency ${_expanded_DEPENDS_ON} )
         string(TOUPPER ${dependency} uppercase_dependency )
 
         if ( NOT arg_OBJECT AND _BLT_${uppercase_dependency}_IS_OBJECT_LIBRARY )
@@ -391,10 +391,13 @@ macro(blt_setup_target)
         endif()
         # Propagate the overridden linker language, if applicable
         if(TARGET ${dependency})
-            get_target_property(_blt_link_lang ${dependency} BLT_LINKER_LANGUAGE)
-            # TODO: Do we need to worry about overwriting?  Should only ever be HIP or CUDA
-            if(_blt_link_lang)
-                set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE ${_blt_link_lang})
+            get_target_property(_dep_type ${dependency} TYPE)
+            if(NOT "${_dep_type}" STREQUAL "INTERFACE_LIBRARY")
+                get_target_property(_blt_link_lang ${dependency} BLT_LINKER_LANGUAGE)
+                # TODO: Do we need to worry about overwriting?  Should only ever be HIP or CUDA
+                if(_blt_link_lang)
+                    set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE ${_blt_link_lang})
+                endif()
             endif()
         endif()
     endforeach()

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -446,8 +446,8 @@ macro(blt_setup_cuda_target)
     if (${_depends_on_cuda_runtime} OR ${_depends_on_cuda})
         if (CUDA_LINK_WITH_NVCC)
             set_target_properties( ${arg_NAME} PROPERTIES LINKER_LANGUAGE CUDA)
-            # This will be propagated up to the final executable target, which will
-            # need the NVCC linker
+            # This will be propagated up to executable targets that depend on this
+            # library, which will need the HIP linker
             set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE CUDA)
         endif()
     endif()
@@ -522,6 +522,7 @@ macro(blt_add_hip_library)
         set(_depends_on_hip_runtime TRUE)
     endif()
 
+
     if (${_depends_on_hip})
         # if hip is in depends_on, flag each file's language as HIP
         # instead of leaving it up to CMake to decide
@@ -540,10 +541,14 @@ macro(blt_add_hip_library)
         # Link to the hip_runtime target so it gets pulled in by targets
         # depending on this target
         target_link_libraries(${arg_NAME} PUBLIC hip_runtime)
-        # An executable depending on this library needs to use the HIP linker
-        set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE HIP)
     else()
         add_library( ${arg_NAME} ${arg_LIBRARY_TYPE} ${arg_SOURCES} ${arg_HEADERS} )
+    endif()
+
+    if (${_depends_on_hip_runtime} OR ${_depends_on_hip})
+        # This will be propagated up to executable targets that depend on this
+        # library, which will need the HIP linker
+        set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE HIP)
     endif()
 
 endmacro(blt_add_hip_library)

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -391,12 +391,13 @@ macro(blt_setup_target)
         endif()
         # Propagate the overridden linker language, if applicable
         if(TARGET ${dependency})
+            # If it's an interface library CMake doesn't even allow us to query the property
             get_target_property(_dep_type ${dependency} TYPE)
             if(NOT "${_dep_type}" STREQUAL "INTERFACE_LIBRARY")
-                get_target_property(_blt_link_lang ${dependency} BLT_LINKER_LANGUAGE)
+                get_target_property(_blt_link_lang ${dependency} BLT_LINKER_LANGUAGE_OVERRIDE)
                 # TODO: Do we need to worry about overwriting?  Should only ever be HIP or CUDA
                 if(_blt_link_lang)
-                    set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE ${_blt_link_lang})
+                    set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE ${_blt_link_lang})
                 endif()
             endif()
         endif()
@@ -447,7 +448,7 @@ macro(blt_setup_cuda_target)
             set_target_properties( ${arg_NAME} PROPERTIES LINKER_LANGUAGE CUDA)
             # This will be propagated up to the final executable target, which will
             # need the NVCC linker
-            set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE CUDA)
+            set_target_properties( ${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE CUDA)
         endif()
     endif()
 
@@ -540,7 +541,7 @@ macro(blt_add_hip_library)
         # depending on this target
         target_link_libraries(${arg_NAME} PUBLIC hip_runtime)
         # An executable depending on this library needs to use the HIP linker
-        set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE HIP)
+        set_target_properties(${arg_NAME} PROPERTIES BLT_LINKER_LANGUAGE_OVERRIDE HIP)
     else()
         add_library( ${arg_NAME} ${arg_LIBRARY_TYPE} ${arg_SOURCES} ${arg_HEADERS} )
     endif()

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -26,8 +26,6 @@ else()
         set(HIP_RUNTIME_INCLUDE_DIRS "${HIP_ROOT_DIR}/include" CACHE STRING "")
 endif()
 set(HIP_RUNTIME_COMPILE_FLAGS "${HIP_RUNTIME_COMPILE_FLAGS};-D${HIP_RUNTIME_DEFINE};-Wno-unused-parameter")
-# set(HIP_RUNTIME_LIBRARIES "${HIP_ROOT_DIR}/hcc/lib")
-# set(HIP_RUNTIME_LIBRARIES "${HIP_ROOT_DIR}/hcc/lib")
 
 # depend on 'hip', if you need to use hip
 # headers, link to hip libs, and need to run your source
@@ -43,6 +41,5 @@ blt_import_library(NAME          hip_runtime
                    INCLUDES      ${HIP_RUNTIME_INCLUDE_DIRS}
                    DEFINES       ${HIP_RUNTIME_DEFINES}
                    COMPILE_FLAGS ${HIP_RUNTIME_COMPILE_FLAGS}
-                   LIBRARIES     ${HIP_RUNTIME_LIBRARIES}
                    TREAT_INCLUDES_AS_SYSTEM ON
                    EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})


### PR DESCRIPTION
This PR introduces a `BLT_LINKER_LANGUAGE_OVERRIDE` target property used to convey the requirement that an executable depending on (directly or transitively) `cuda`/`hip` or their respective `runtime` targets be linked with the NVCC/HIP linker.

This property is copied from dependencies as part of `blt_setup` target to ensure correct behavior when the cuda/hip dependency is transitive.