### PR TITLE
fix: fruit_mpi blt_add_library: add depends_on arg

### DIFF
--- a/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
+++ b/thirdparty_builtin/fruit-3.4.1/CMakeLists.txt
@@ -20,6 +20,7 @@ if(ENABLE_FRUIT_MPI)
     blt_add_library(
         NAME fruit_mpi
         SOURCES fruit_mpi.f90
+        DEPENDS_ON fruit MPI::MPI_Fortran
     )
     blt_register_library( NAME fruit_mpi
                           DEPENDS_ON fruit MPI::MPI_Fortran


### PR DESCRIPTION
This commit adds a missing DEPENDS_ON argument to the blt_add_library
macro invocation for fruit_mpi. Without this argument, CMake will not
propagate target dependencies correctly, and users will observe
"missing module imports" errors directing them to modify their include
directory search path.