### PR TITLE
Remove target-specific generator expression from HIP_HIPCC_FLAGS

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   is not changed back to Fortran.
 - Executables that link to libraries that depend on `hip`/`hip_runtime`/`cuda`/`cuda_runtime`
   will automatically be linked with the HIP or CUDA (NVCC) linker
+- Patched an issue with the FindHIP macros that added the inclusive scan of specified
+  DEFINEs to compile commands
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -269,6 +269,10 @@ if(ENABLE_CLANGQUERY OR ENABLE_CLANGTIDY)
   add_subdirectory(src/static_analysis)
 endif()
 
+if(ENABLE_HIP)
+  add_subdirectory(src/hip_defines_test)
+endif()
+
 #------------------------------------------------------------------------------
 # Format the testing code using ClangFormat
 #------------------------------------------------------------------------------
@@ -278,6 +282,7 @@ if(CLANGFORMAT_FOUND)
     ../smoke/blt_cuda_mpi_smoke.cpp
     ../smoke/blt_cuda_openmp_smoke.cpp
     ../smoke/blt_cuda_runtime_smoke.cpp
+    ../smoke/blt_cuda_gtest_smoke.cpp
     ../smoke/blt_cuda_smoke.cpp
     ../smoke/blt_fruit_smoke.f90
     ../smoke/blt_gbenchmark_smoke.cpp
@@ -286,6 +291,7 @@ if(CLANGFORMAT_FOUND)
     ../smoke/blt_hcc_runtime_smoke.cpp
     ../smoke/blt_hcc_smoke.cpp
     ../smoke/blt_hip_runtime_smoke.cpp
+    ../smoke/blt_hip_gtest_smoke.cpp
     ../smoke/blt_hip_smoke.cpp
     ../smoke/blt_mpi_smoke.cpp
     ../smoke/blt_openmp_smoke.cpp
@@ -330,6 +336,9 @@ if(CLANGFORMAT_FOUND)
     src/test_cuda_device_call_from_kernel/CudaTests.cpp
     src/test_cuda_device_call_from_kernel/Parent.cpp
     src/test_cuda_device_call_from_kernel/Parent.hpp
+
+    src/hip_defines_test/foo.cpp
+    src/hip_defines_test/bar.cpp
   )
 
   # Specify the major version for astyle

--- a/tests/internal/src/hip_defines_test/CMakeLists.txt
+++ b/tests/internal/src/hip_defines_test/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+# other BLT Project Developers. See the top-level COPYRIGHT file for details
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+###############################################################################
+#
+# Tests to make sure that definitions from one target do not propagate to another
+#
+###############################################################################
+
+blt_add_executable(NAME       blt_hip_defines_test_foo
+                   SOURCES    foo.cpp
+                   DEFINES    FOO_ONLY
+                   DEPENDS_ON hip)
+
+blt_add_executable(NAME       blt_hip_defines_test_bar
+                   SOURCES    bar.cpp
+                   DEFINES    BAR_ONLY
+                   DEPENDS_ON hip)
+
+blt_add_test( NAME blt_test_hip_defines_first
+              COMMAND blt_hip_defines_test_foo
+            )
+
+blt_add_test( NAME blt_test_hip_defines_second
+              COMMAND blt_hip_defines_test_bar
+            )

--- a/tests/internal/src/hip_defines_test/bar.cpp
+++ b/tests/internal/src/hip_defines_test/bar.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other BLT Project Developers. See the top-level COPYRIGHT file for details
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+int main()
+{
+    #if !defined(FOO_ONLY) && defined(BAR_ONLY)
+    return 0;
+    #else
+    return 1;
+    #endif
+}

--- a/tests/internal/src/hip_defines_test/foo.cpp
+++ b/tests/internal/src/hip_defines_test/foo.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other BLT Project Developers. See the top-level COPYRIGHT file for details
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+int main()
+{
+    #if defined(FOO_ONLY) && !defined(BAR_ONLY)
+    return 0;
+    #else
+    return 1;
+    #endif
+}


### PR DESCRIPTION
When adding compile definitions to a HIP target, the inclusive scan of compile definitions is used:
```cmake
blt_add_executable(NAME foo DEPENDS_ON hip DEFINES FOO_ONLY) # compile cmd will have -DFOO_ONLY
blt_add_executable(NAME bar DEPENDS_ON hip DEFINES BAR_ONLY) # compile cmd will have -DFOO_ONLY -DBAR_ONLY
blt_add_executable(NAME baz DEPENDS_ON hip DEFINES BAZ_ONLY) # compile cmd will have -DFOO_ONLY -DBAR_ONLY -DBAZ_ONLY
```

The following code in `FindHIP.cmake` appears to be the reason:
https://github.com/LLNL/blt/blob/b7e2bdcae5bd9f8250d05581d57dcfdf608bacd0/cmake/thirdparty/FindHIP.cmake#L486-L488

Specifically, target-specific generator expressions (for the compile definitions) are added to the global `HIP_HIPCC_FLAGS` variable.
Because the flags are written (via `generate_file`) to a `run_hipcc` script immediately after the above snippet, the state of `HIP_HCC_FLAGS` is "preserved" when the target is built.  This is also why the definitions are an inclusive scan and not a union.

Because the flags are preserved, the problematic generator expression can just be removed from the global flags after the `run_hipcc` script is written.

The following snippet also looks like it exhibits the same behavior, but I am not sure if it should be fixed in this PR or if we should wait to see if it affects any users:
https://github.com/LLNL/blt/blob/b7e2bdcae5bd9f8250d05581d57dcfdf608bacd0/cmake/thirdparty/FindHIP.cmake#L468-L470