### PR TITLE
docs: add SPHINX_EXECUTABLE prereq to sphinx target

### DIFF
--- a/docs/api/documentation.rst
+++ b/docs/api/documentation.rst
@@ -1,6 +1,6 @@
 .. # Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
 .. # other BLT Project Developers. See the top-level COPYRIGHT file for details
-.. # 
+.. #
 .. # SPDX-License-Identifier: (BSD-3-Clause)
 
 Documenation Macros
@@ -14,11 +14,11 @@ blt_add_doxygen_target
 
     blt_add_doxygen_target(doxygen_target_name)
 
-Creates a build target for invoking doxygen to generate docs. Expects to 
-find a Doxyfile.in in the directory the macro is called in. 
+Creates a build target for invoking doxygen to generate docs. Expects to
+find a Doxyfile.in in the directory the macro is called in.
 
-This macro sets up the doxygen paths so that the doc builds happen 
-out of source. For ``make install``, this will place the resulting docs in 
+This macro sets up the doxygen paths so that the doc builds happen
+out of source. For ``make install``, this will place the resulting docs in
 docs/doxygen/<doxygen_target_name>.
 
 
@@ -29,14 +29,16 @@ blt_add_sphinx_target
 
     blt_add_sphinx_target(sphinx_target_name)
 
-Creates a build target for invoking sphinx to generate docs. Expects to
-find a conf.py or conf.py.in in the directory the macro is called in. 
+Creates a build target for invoking sphinx to generate docs. Expects
+to find a conf.py or conf.py.in in the directory the macro is called
+in. Requires that a CMake variable named ``SPHINX_EXECUTABLE``
+contains the path to the ``sphinx-build`` executable.
 
 If conf.py is found, it is directly used as input to sphinx.
 
 If conf.py.in is found, this macro uses CMake's configure_file() command
 to generate a conf.py, which is then used as input to sphinx.
 
-This macro sets up the sphinx paths so that the doc builds happen 
-out of source. For ``make install``, this will place the resulting docs in 
+This macro sets up the sphinx paths so that the doc builds happen
+out of source. For ``make install``, this will place the resulting docs in
 docs/sphinx/<sphinx_target_name>.


### PR DESCRIPTION
Documents the prerequisite that `SPHINX_EXECUTABLE` be defined and must contain the path to the `sphinx-build` executable in order to use `blt_add_sphinx_target()`.