### PR TITLE
Re-add previous iteration of openMP patching logic

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -70,6 +70,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   will automatically be linked with the HIP or CUDA (NVCC) linker
 - Patched an issue with the FindHIP macros that added the inclusive scan of specified
   DEFINEs to compile commands
+- Re-added previous OpenMP flag patching logic to maintain compatibility with BLT-registered libraries
 
 ## [Version 0.3.6] - Release date 2020-07-27
 

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -124,6 +124,29 @@ function(blt_fix_fortran_openmp_flags target_name)
                                        LINK_LIBRARIES "${target_link_libs}" )
             endif()
 
+            # OpenMP is an interface library which doesn't have a LINK_FLAGS property
+            # in versions < 3.13
+            set(_property_name INTERFACE_LINK_LIBRARIES)
+            if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0" )
+                # In CMake 3.13+, LINK_FLAGS was converted to LINK_OPTIONS.
+                set(_property_name LINK_OPTIONS)
+            endif()
+
+            get_target_property(target_link_flags ${target_name} ${_property_name})
+            if ( target_link_flags )
+
+                message(STATUS "Fixing OpenMP Flags for target[${target_name}]")
+                message(STATUS "Detected link flags are: ${target_link_flags}")
+                message(STATUS "Replacing ${OpenMP_CXX_FLAGS} with ${OpenMP_Fortran_FLAGS}")
+
+                string( REPLACE "${OpenMP_CXX_FLAGS}" "${OpenMP_Fortran_FLAGS}"
+                        correct_link_flags
+                        "${target_link_flags}"
+                        )
+                message(STATUS "Fixed link flags are: ${correct_link_flags}")
+                set_target_properties( ${target_name} PROPERTIES ${_property_name}
+                                    "${correct_link_flags}" )
+            endif()
         endif()
 
     endif()

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -92,6 +92,7 @@ endfunction()
 function(blt_fix_fortran_openmp_flags target_name)
 
     if (ENABLE_FORTRAN AND ENABLE_OPENMP AND BLT_OPENMP_FLAGS_DIFFER)
+
         # The OpenMP interface library will have been added as a direct
         # link dependency instead of via flags
         get_target_property(target_link_libs ${target_name} LINK_LIBRARIES)
@@ -101,11 +102,18 @@ function(blt_fix_fortran_openmp_flags target_name)
             # the DAG.  Only the link flags need to be modified.
             list(FIND target_link_libs "openmp" _omp_index)
             if(${_omp_index} GREATER -1)
-                list(REMOVE_ITEM target_link_libs "openmp")
+                message(STATUS "Fixing OpenMP Flags for target[${target_name}]")
 
-                # Copy the compile flags verbatim
+                # Remove openmp from libraries
+                list(REMOVE_ITEM target_link_libs "openmp")
+                set_target_properties( ${target_name} PROPERTIES
+                                       LINK_LIBRARIES "${target_link_libs}" )
+
+                # Add openmp compile flags verbatim w/ generator expression
                 get_target_property(omp_compile_flags openmp INTERFACE_COMPILE_OPTIONS)
                 target_compile_options(${target_name} PUBLIC ${omp_compile_flags})
+
+                # Change CXX flags to Fortran flags
 
                 # These are set through blt_add_target_link_flags which needs to use
                 # the link_libraries for interface libraries in CMake < 3.13
@@ -114,36 +122,30 @@ function(blt_fix_fortran_openmp_flags target_name)
                 else()
                     get_target_property(omp_link_flags openmp INTERFACE_LINK_LIBRARIES)
                 endif()
-    
+
                 string( REPLACE "${OpenMP_CXX_FLAGS}" "${OpenMP_Fortran_FLAGS}"
                         correct_omp_link_flags
                         "${omp_link_flags}"
                         )
-                list(APPEND target_link_libs "${correct_omp_link_flags}")
-                set_target_properties( ${target_name} PROPERTIES
-                                       LINK_LIBRARIES "${target_link_libs}" )
+                target_link_options(${target_name} PRIVATE "${correct_omp_link_flags}")
             endif()
+
+            # Handle registered library general case
 
             # OpenMP is an interface library which doesn't have a LINK_FLAGS property
             # in versions < 3.13
-            set(_property_name INTERFACE_LINK_LIBRARIES)
+            set(_property_name LINK_FLAGS)
             if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0" )
                 # In CMake 3.13+, LINK_FLAGS was converted to LINK_OPTIONS.
                 set(_property_name LINK_OPTIONS)
             endif()
-
             get_target_property(target_link_flags ${target_name} ${_property_name})
             if ( target_link_flags )
-
-                message(STATUS "Fixing OpenMP Flags for target[${target_name}]")
-                message(STATUS "Detected link flags are: ${target_link_flags}")
-                message(STATUS "Replacing ${OpenMP_CXX_FLAGS} with ${OpenMP_Fortran_FLAGS}")
 
                 string( REPLACE "${OpenMP_CXX_FLAGS}" "${OpenMP_Fortran_FLAGS}"
                         correct_link_flags
                         "${target_link_flags}"
                         )
-                message(STATUS "Fixed link flags are: ${correct_link_flags}")
                 set_target_properties( ${target_name} PROPERTIES ${_property_name}
                                     "${correct_link_flags}" )
             endif()


### PR DESCRIPTION
It looks like the new approach I added in #421 that looks for the `openmp` imported library doesn't work for targets that don't call `target_link_libraries(openmp)` - namely, the old-style registered libraries.  To fix this I've added the old logic back in.