### PR TITLE
Revert "add option to use mpi imported targets"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,9 +9,6 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
-## Added
-- Added ``BLT_USE_FIND_MPI_TARGETS`` option that directly uses the CMake targets provided by CMake's Find MPI for BLT's MPI support.
-
 ## [Version 0.4.0] - Release date 2021-04-09
 
 ## Added

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -117,8 +117,6 @@ option(BLT_EXPORT_THIRDPARTY "Configure the third-party targets created by BLT t
 #------------------------------------------------------------------------------
 
 option(ENABLE_FIND_MPI     "Enables CMake's Find MPI support (Turn off when compiling with the mpi wrapper directly)" ON)
-option(BLT_USE_FIND_MPI_TARGETS     "Directly use the CMake targets provided by CMake's Find MPI" OFF)
-
 
 option(
     ENABLE_GTEST_DEATH_TESTS

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -31,25 +31,7 @@ set(_mpi_includes )
 set(_mpi_libraries )
 set(_mpi_link_flags )
 
-
-if(ENABLE_FIND_MPI)
-    message(STATUS "FindMPI Enabled  (ENABLE_FIND_MPI == ON)")
-else()
-    message(STATUS "FindMPI Disabled (ENABLE_FIND_MPI == OFF) ")
-endif()
-
-
-if(BLT_USE_FIND_MPI_TARGETS)
-    message(STATUS "Using MPI CMake imported targets (BLT_USE_FIND_MPI_TARGETS == ON)")
-else()
-    message(STATUS "Not using MPI CMake imported targets (BLT_USE_FIND_MPI_TARGETS == OFF)")
-endif()
-
-
-if(NOT ENABLE_FIND_MPI AND BLT_USE_FIND_MPI_TARGETS)
-    message(FATAL_ERROR "ENABLE_FIND_MPI == false, but BLT_USE_FIND_MPI_TARGETS == true."
-                        "BLT_USE_FIND_MPI_TARGETS == true requires ENABLE_FIND_MPI == true.")
-endif()
+message(STATUS "Enable FindMPI:  ${ENABLE_FIND_MPI}")
 
 if (ENABLE_FIND_MPI)
     find_package(MPI REQUIRED)
@@ -141,33 +123,16 @@ if (ENABLE_FIND_MPI)
 endif()
 
 # Allow users to override CMake's FindMPI
-# Assuming we are not directly using targets it provides
 if (BLT_MPI_COMPILE_FLAGS)
-    if(BLT_USE_FIND_MPI_TARGETS)
-        message(FATAL_ERROR "Cannot override MPI Compile Flags when BLT_USE_FIND_MPI_TARGETS == true. "
-                            "(BLT_MPI_COMPILE_FLAGS provided, but BLT_USE_FIND_MPI_TARGETS == true)")
-    endif()
     set(_mpi_compile_flags ${BLT_MPI_COMPILE_FLAGS})
 endif()
 if (BLT_MPI_INCLUDES)
-    if(BLT_USE_FIND_MPI_TARGETS)
-        message(FATAL_ERROR "Cannot override MPI Includes when BLT_USE_FIND_MPI_TARGETS == true. "
-                            "(BLT_MPI_INCLUDES provided, but BLT_USE_FIND_MPI_TARGETS == true)")
-    endif()
     set(_mpi_includes ${BLT_MPI_INCLUDES})
 endif()
 if (BLT_MPI_LIBRARIES)
-    if(BLT_USE_FIND_MPI_TARGETS)
-        message(FATAL_ERROR "Cannot override MPI Libraries when BLT_USE_FIND_MPI_TARGETS == true. "
-                            "(BLT_MPI_LIBRARIES provided, but BLT_USE_FIND_MPI_TARGETS == true)")
-    endif()
     set(_mpi_libraries ${BLT_MPI_LIBRARIES})
 endif()
 if (BLT_MPI_LINK_FLAGS)
-    if(BLT_USE_FIND_MPI_TARGETS)
-        message(FATAL_ERROR "Cannot override MPI Link Flags when BLT_USE_FIND_MPI_TARGETS == true. "
-                            "(BLT_MPI_LINK_FLAGS provided, but BLT_USE_FIND_MPI_TARGETS == true)")
-    endif()
     set(_mpi_link_flags ${BLT_MPI_LINK_FLAGS})
 endif()
 
@@ -212,24 +177,10 @@ if (ENABLE_FORTRAN)
     endif()
 endif()
 
-
-if(BLT_USE_FIND_MPI_TARGETS)
-    if(TARGET MPI::MPI_C)
-        message(STATUS "Using MPI CMake imported targets: MPI::MPI_C MPI::MPI_CXX")
-        blt_register_library(NAME mpi
-                             LIBRARIES MPI::MPI_C MPI::MPI_CXX)
-    else()
-        message(FATAL_ERROR "Cannot use CMake imported targets for MPI."
-                            "(BLT_USE_FIND_MPI_TARGETS == true) "
-                            "but MPI::MPI_C CMake target is missing.")
-    endif()
-else()
-    # non imported targets case
-    blt_import_library(NAME          mpi
-                       INCLUDES      ${_mpi_includes}
-                       TREAT_INCLUDES_AS_SYSTEM ON
-                       LIBRARIES     ${_mpi_libraries}
-                       COMPILE_FLAGS ${_mpi_compile_flags}
-                       LINK_FLAGS    ${_mpi_link_flags} 
-                       EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})
-endif()
+blt_import_library(NAME          mpi
+                   INCLUDES      ${_mpi_includes}
+                   TREAT_INCLUDES_AS_SYSTEM ON
+                   LIBRARIES     ${_mpi_libraries}
+                   COMPILE_FLAGS ${_mpi_compile_flags}
+                   LINK_FLAGS    ${_mpi_link_flags} 
+                   EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})

--- a/cmake/thirdparty/SetupMPI.cmake
+++ b/cmake/thirdparty/SetupMPI.cmake
@@ -31,7 +31,13 @@ set(_mpi_includes )
 set(_mpi_libraries )
 set(_mpi_link_flags )
 
-message(STATUS "Enable FindMPI:  ${ENABLE_FIND_MPI}")
+
+if(ENABLE_FIND_MPI)
+    message(STATUS "FindMPI Enabled  (ENABLE_FIND_MPI == ON)")
+else()
+    message(STATUS "FindMPI Disabled (ENABLE_FIND_MPI == OFF) ")
+endif()
+
 
 if (ENABLE_FIND_MPI)
     find_package(MPI REQUIRED)

--- a/docs/tutorial/common_hpc_dependencies.rst
+++ b/docs/tutorial/common_hpc_dependencies.rst
@@ -86,13 +86,6 @@ Test. ``test_2.cpp`` provides an example driver for MPI with GoogleTest.
   BLT also has the variable ``ENABLE_FIND_MPI`` which turns off all CMake's ``FindMPI``
   logic and then uses the MPI wrapper directly when you provide them as the default
   compilers.
-  
-  BLT also provides ``BLT_USE_FIND_MPI_TARGETS`` that will directly use the
-  ``MPI::MPI_C`` and ``MPI::MPI_CXX`` targets provided by CMake's ``FindMPI``.
-  When enabled these targets are available for BLT ``DEPENDS_ON`` arguments
-  via unified name of ``mpi``.
-  This option requires ``ENABLE_FIND_MPI == true`` and is not compatible with
-  the ``BLT_`` override options above.
 
 
 CUDA


### PR DESCRIPTION
Reverts LLNL/blt#482

Life is complex -- turns out we don't need these options!