### PR TITLE
Fix scaling of logo on RTD

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -33,5 +33,5 @@
 }
 
 a img.logo {
-  scale: 75%
+  transform: scale(.75)
 }


### PR DESCRIPTION
The previous CSS worked in firefox but not chrome.
This appears to work for both.