### PR TITLE
fix escape of . character in clangformat regex

### DIFF
--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -684,7 +684,7 @@ macro(blt_add_clangformat_target)
                         OUTPUT_VARIABLE _version_str
                         OUTPUT_STRIP_TRAILING_WHITESPACE)
         # The version number is the last token - can contain non-numeric
-        string(REGEX MATCH "([0-9a-zA-Z\\-]+\.[0-9a-zA-Z\\-]+\.?[0-9a-zA-Z\\-]?)"
+        string(REGEX MATCH "([0-9a-zA-Z\\-]+\\.[0-9a-zA-Z\\-]+\\.?[0-9a-zA-Z\\-]?)"
                _clangformat_version ${_version_str})
         # The user may only specify a part of the version (e.g. just the maj ver)
         # so check for substring


### PR DESCRIPTION
slight modification of regex from #500 for #499.

The changes in #500 return `Cray clang-format v` for the clang-format --version output `Cray clang-format version 12.0.0 (59041842ced75ac192c0f1331989ae45f58d7caf)`. This PR will correctly return `12.0.0`