### PR TITLE
change COMPILER_FAMILY_IS flags to CACHE variables so users can have …

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -17,37 +17,37 @@
 # and CMAKE_CXX_COMPILER_ID for all other cases
 
 if("${CMAKE_BUILD_TOOL}" MATCHES "(msdev|devenv|nmake|MSBuild)")
-    set(COMPILER_FAMILY_IS_MSVC 1)
+    set(COMPILER_FAMILY_IS_MSVC 1 CACHE BOOL "")
     message(STATUS "Compiler family is MSVC")
 
     if(CMAKE_GENERATOR_TOOLSET AND "${CMAKE_GENERATOR_TOOLSET}" MATCHES "Intel")
-        set(COMPILER_FAMILY_IS_MSVC_INTEL 1) 
+        set(COMPILER_FAMILY_IS_MSVC_INTEL 1 CACHE BOOL "")
         message(STATUS "Toolset is ${CMAKE_GENERATOR_TOOLSET}")
     endif()
 else()
     #Determine C/C++ compiler family. 
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        set(C_COMPILER_FAMILY_IS_GNU 1)
+        set(C_COMPILER_FAMILY_IS_GNU 1 CACHE BOOL "")
         message(STATUS "C Compiler family is GNU")
 
     elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # For Clang or AppleClang
-        set(C_COMPILER_FAMILY_IS_CLANG 1)
+        set(C_COMPILER_FAMILY_IS_CLANG 1 CACHE BOOL "")
         message(STATUS "C Compiler family is Clang")
 
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "XL")
-        set(C_COMPILER_FAMILY_IS_XL 1)
+        set(C_COMPILER_FAMILY_IS_XL 1 CACHE BOOL "")
         message(STATUS "C Compiler family is XL")
 
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-        set(C_COMPILER_FAMILY_IS_INTEL 1)
+        set(C_COMPILER_FAMILY_IS_INTEL 1 CACHE BOOL "")
         message(STATUS "C Compiler family is Intel")
 
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
-        set(C_COMPILER_FAMILY_IS_PGI 1)
+        set(C_COMPILER_FAMILY_IS_PGI 1 CACHE BOOL "")
         message(STATUS "C Compiler family is PGI")
 
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Cray")
-        set(C_COMPILER_FAMILY_IS_CRAY 1)
+        set(C_COMPILER_FAMILY_IS_CRAY 1 CACHE BOOL "")
         message(STATUS "C Compiler family is Cray")
 
     else()
@@ -55,27 +55,27 @@ else()
     endif()
     # Determine Fortran compiler family 
     if("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
-        set(Fortran_COMPILER_FAMILY_IS_GNU 1)
+        set(Fortran_COMPILER_FAMILY_IS_GNU 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is GNU")
 
     elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Clang") # For Clang or AppleClang
-        set(Fortran_COMPILER_FAMILY_IS_CLANG 1)
+        set(Fortran_COMPILER_FAMILY_IS_CLANG 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is Clang")
 
     elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "XL")
-        set(Fortran_COMPILER_FAMILY_IS_XL 1)
+        set(Fortran_COMPILER_FAMILY_IS_XL 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is XL")
 
     elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Intel")
-        set(Fortran_COMPILER_FAMILY_IS_INTEL 1)
+        set(Fortran_COMPILER_FAMILY_IS_INTEL 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is Intel")
 
     elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "PGI")
-        set(Fortran_COMPILER_FAMILY_IS_PGI 1)
+        set(Fortran_COMPILER_FAMILY_IS_PGI 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is PGI")
 
     elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Cray")
-        set(Fortran_COMPILER_FAMILY_IS_CRAY 1)
+        set(Fortran_COMPILER_FAMILY_IS_CRAY 1 CACHE BOOL "")
         message(STATUS "Fortran Compiler family is Cray")
 
     elseif(ENABLE_FORTRAN)


### PR DESCRIPTION
…control over detected family type.