### PR TITLE
Minimal support for cmake 3.21 hip targets

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added support for IntelLLVM compiler family to blt_append_custom_compiler_flag
+- Added support for hip targets configured with cmake 3.21 native hip support
 
 ### Changed
 - `BLT_C_FILE_EXTS` updated to include `.cuh`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -15,6 +15,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Changed
 - `BLT_C_FILE_EXTS` updated to include `.cuh`
+- Fold `BLT_CLANG_HIP_ARCH` into the `CMAKE_HIP_ARCHITECTURES` variable
 
 ## [Version 0.4.1] - Release date 2021-07-20
 

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -66,6 +66,7 @@ set(BLT_CLANG_HIP_ARCH "gfx906" CACHE STRING "AMDGPU ISA target to use when gene
 mark_as_advanced(BLT_CLANG_HIP_ARCH)
 option(ENABLE_HCC         "Enable HCC support" OFF)
 set(BLT_ROCM_ARCH "gfx900" CACHE STRING "gfx architecture to use when generating ROCm code")
+set(CMAKE_HIP_ARCHITECTURES "${BLT_ROCM_ARCH}" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # Test Options

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -65,8 +65,7 @@ mark_as_advanced(ENABLE_CLANG_HIP)
 set(BLT_CLANG_HIP_ARCH "gfx906" CACHE STRING "AMDGPU ISA target to use when generating HIP code with Clang" )
 mark_as_advanced(BLT_CLANG_HIP_ARCH)
 option(ENABLE_HCC         "Enable HCC support" OFF)
-set(BLT_ROCM_ARCH "gfx900" CACHE STRING "gfx architecture to use when generating ROCm code")
-set(CMAKE_HIP_ARCHITECTURES "${BLT_ROCM_ARCH}" CACHE STRING "")
+set(CMAKE_HIP_ARCHITECTURES "gfx900" CACHE STRING "gfx architecture to use when generating HIP/ROCm code")
 
 #------------------------------------------------------------------------------
 # Test Options

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -72,7 +72,7 @@ if (ENABLE_CLANG_HIP)
     if (NOT (${HIP_PLATFORM} STREQUAL "clang"))
         message(FATAL_ERROR "ENABLE_CLANG_HIP requires HIP_PLATFORM=clang")
     endif()
-    set(_hip_compile_flags -x;hip)
+    set(_hip_compile_flags $(_hip_compile_flags)-x;hip)
     # Using clang HIP, we need to construct a few CPP defines and compiler flags
     foreach(_arch ${BLT_CLANG_HIP_ARCH})
         string(TOUPPER ${_arch} _UPARCH)
@@ -114,7 +114,16 @@ else()
 # through a hip compiler (hipcc)
 # This is currently used only as an indicator for blt_add_hip* -- FindHIP/hipcc will handle resolution
 # of all required HIP-related includes/libraries/flags.
-    blt_import_library(NAME      hip)
+    # Using clang HIP, we need to construct a few CPP defines and compiler flags
+    foreach(_arch ${CMAKE_HIP_ARCHITECTURES})
+        string(TOUPPER ${_arch} _UPARCH)
+        string(TOLOWER ${_arch} _lowarch)
+        list(APPEND _hip_compile_flags "--offload-arch=${_lowarch}")
+        set(_hip_compile_defines "${HIP_RUNTIME_DEFINES};-D__HIP_ARCH_${_UPARCH}__=1")
+    endforeach(_arch)
+    blt_import_library(NAME      hip
+                       DEFINES          ${_hip_compile_defines}
+                       COMPILE_FLAGS    ${_hip_compile_flags})
 endif()
 
 


### PR DESCRIPTION
The hip support in cmake 3.21 requires that the hip architecture is set
for all targets.  This sets the default based on the value of the
BLT_ROCM_ARCH, which is enough to satisfy it by default for all
targets.
