### PR TITLE
Fix hip

### DIFF
--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -83,6 +83,23 @@ if(UNIX AND NOT APPLE AND NOT CYGWIN)
     endif()
     mark_as_advanced(HIP_HIPCC_EXECUTABLE)
 
+    # Find hip clang executable
+    if(NOT DEFINED HIP_CLANG_PATH)
+        find_path(
+            HIP_CLANG_PATH
+            NAMES clang++
+            PATHS
+            "$ENV{HIP_CLANG_PATH}"
+            "$ENV{ROCM_PATH}"
+            "$ENV{HIP_PATH}/../llvm/bin"
+            "${HIP_ROOT_DIR}/../llvm/bin"
+            "/opt/rocm/llvm/bin"
+            PATH_SUFFIXES bin
+            NO_DEFAULT_PATH
+            )
+    endif()
+    set(HIP_CLANG_EXECUTABLE "${HIP_CLANG_PATH}/clang++")
+
     # Find HIPCONFIG executable
     find_program(
         HIP_HIPCONFIG_EXECUTABLE
@@ -210,6 +227,8 @@ set(CMAKE_SHARED_LIBRARY_LINK_DYNAMIC_HIP_FLAGS ${CMAKE_SHARED_LIBRARY_LINK_DYNA
 
 set(HIP_CLANG_PARALLEL_BUILD_COMPILE_OPTIONS "")
 set(HIP_CLANG_PARALLEL_BUILD_LINK_OPTIONS "")
+
+
 
 if("${HIP_COMPILER}" STREQUAL "nvcc")
     # Set the CMake Flags to use the nvcc Compiler.
@@ -643,17 +662,6 @@ macro(HIP_ADD_EXECUTABLE hip_target)
         endif()
         set(CMAKE_HIP_LINK_EXECUTABLE "${HIP_HIPCC_CMAKE_LINKER_HELPER} ${HCC_HOME} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
     elseif("${HIP_COMPILER}" STREQUAL "clang")
-        if("x${HIP_CLANG_PATH}" STREQUAL "x")
-            if(DEFINED ENV{HIP_CLANG_PATH})
-                set(HIP_CLANG_PATH $ENV{HIP_CLANG_PATH})
-            elseif(DEFINED ENV{ROCM_PATH})
-                set(HIP_CLANG_PATH "$ENV{ROCM_PATH}/llvm/bin")
-            elseif(DEFINED ENV{HIP_PATH})
-                set(HIP_CLANG_PATH "$ENV{HIP_PATH}/../llvm/bin")
-            else()
-                set(HIP_CLANG_PATH "/opt/rocm/llvm/bin")
-            endif()
-        endif()
         set(CMAKE_HIP_LINK_EXECUTABLE "${HIP_HIPCC_CMAKE_LINKER_HELPER} ${HIP_CLANG_PATH} ${HIP_CLANG_PARALLEL_BUILD_LINK_OPTIONS} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
     else()
         set(CMAKE_HIP_LINK_EXECUTABLE "${HIP_HIPCC_CMAKE_LINKER_HELPER} <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")

--- a/cmake/thirdparty/FindHIP.cmake
+++ b/cmake/thirdparty/FindHIP.cmake
@@ -90,7 +90,7 @@ if(UNIX AND NOT APPLE AND NOT CYGWIN)
             NAMES clang++
             PATHS
             "$ENV{HIP_CLANG_PATH}"
-            "$ENV{ROCM_PATH}"
+            "$ENV{ROCM_PATH}/llvm/bin"
             "$ENV{HIP_PATH}/../llvm/bin"
             "${HIP_ROOT_DIR}/../llvm/bin"
             "/opt/rocm/llvm/bin"

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -111,7 +111,8 @@ if (ENABLE_CLANG_HIP)
                        COMPILE_FLAGS    ${_hip_compile_flags}
                        DEPENDS_ON       ${HIP_RUNTIME_LIBRARIES})
 else()
-
+    # hipcc does not receive a standard flag from cmake or from BLT otherwise
+    set(HIP_HIPCC_FLAGS ${HIP_HIPCC_FLAGS} -std=${BLT_CXX_STD})
     # depend on 'hip', if you need to use hip
     # headers, link to hip libs, and need to run your source
     # through a hip compiler (hipcc)


### PR DESCRIPTION
This is meant to fix the issues in #520.

It also works around a bug in FindHIP that was requiring environment variables and cmake variables to be set to properly initialize the input to the linking helper.  This lets the BLT_CXX_STD variable work for hipcc compiles, and removes a kinda nasty bug related to path detection in the AMD perl-based wrappers.

fixes #520 