### PR TITLE
Don't build executables depending on hip_runtime as HIP

### DIFF
--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -728,7 +728,7 @@ macro(blt_add_hip_executable)
         endif()
     endforeach()
 
-    if (${_depends_on_hip} OR ${_depends_on_hip_runtime})
+    if (${_depends_on_hip})
         # if hip is in depends_on, flag each file's language as HIP
         # instead of leaving it up to CMake to decide
         # Note: we don't do this when depending on just 'hip_runtime'

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -226,6 +226,15 @@ if (ENABLE_HIP)
     blt_add_test(NAME blt_hip_runtime_smoke
                  COMMAND blt_hip_runtime_smoke)
 
+    blt_add_executable(NAME blt_hip_runtime_c_smoke
+                       SOURCES blt_hip_runtime_c_smoke.c
+                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                       DEPENDS_ON hip_runtime
+                       FOLDER blt/tests )
+
+    blt_add_test(NAME blt_hip_runtime_c_smoke
+                 COMMAND blt_hip_runtime_c_smoke)
+
     if(ENABLE_GTEST)
         blt_add_executable(NAME blt_hip_gtest_smoke
                            SOURCES blt_hip_gtest_smoke.cpp

--- a/tests/smoke/blt_hip_runtime_c_smoke.c
+++ b/tests/smoke/blt_hip_runtime_c_smoke.c
@@ -1,0 +1,34 @@
+// Copyright (c) 2017-2021, Lawrence Livermore National Security, LLC and
+// other BLT Project Developers. See the top-level LICENSE file for details
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+//-----------------------------------------------------------------------------
+//
+// file: blt_hip_runtime_c_smoke.c
+//
+//-----------------------------------------------------------------------------
+
+#include "hip/hip_runtime_api.h"
+
+int main()
+{
+  int nDevices;
+
+  hipGetDeviceCount(&nDevices);
+  for (int i = 0; i < nDevices; i++)
+  {
+    hipDeviceProp_t prop;
+    hipGetDeviceProperties(&prop, i);
+    printf("Device Number: %d\n", i);
+    printf("  Device name: %s\n", prop.name);
+    printf("  Memory Clock Rate (KHz): %d\n",
+           prop.memoryClockRate);
+    printf("  Memory Bus Width (bits): %d\n",
+           prop.memoryBusWidth);
+    printf("  Peak Memory Bandwidth (GB/s): %f\n\n",
+           2.0*prop.memoryClockRate*(prop.memoryBusWidth/8)/1.0e6);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Prior to this change, any executable depending on `hip_runtime` would be built as if it was HIP. This caused problems with C executables after #520 was fixed.

This PR adds a smoke test and fixes the issue.