### PR TITLE
Fix CMake warning

### DIFF
--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -144,7 +144,7 @@ if(ENABLE_BENCHMARKS)
           message(FATAL_ERROR "Google Benchmark cannot be built when BUILD_SHARED_LIBS=ON or on Windows")
         endif()
 
-        set(BENCHMARK_ENABLE_TESTING OFF CACHE "" BOOL)
+        set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "")
         add_subdirectory(benchmark-1.5.0
                          ${BLT_BUILD_DIR}/thirdparty_builtin/benchmark-1.5.0)
 


### PR DESCRIPTION
CMake Warning (dev) at blt/thirdparty_builtin/CMakeLists.txt:147 (set):
  implicitly converting '' to 'STRING' type.
This warning is for project developers.  Use -Wno-dev to suppress it.