### PR TITLE
Map Flang Fortran COMPILER_ID to Clang family of compilers.

### DIFF
--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -66,6 +66,10 @@ else()
         set(Fortran_COMPILER_FAMILY_IS_CLANG 1)
         message(STATUS "Fortran Compiler family is Clang")
 
+    elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang") # For Flang compilers
+        set(Fortran_COMPILER_FAMILY_IS_CLANG 1 CACHE BOOL "")
+        message(STATUS "Fortran Compiler family is Clang")
+
     elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "XL")
         set(Fortran_COMPILER_FAMILY_IS_XL 1)
         message(STATUS "Fortran Compiler family is XL")


### PR DESCRIPTION
The amdflang compiler reports as Flang, would like to group this with Clang family of compilers. 