### PR TITLE
Update macOS image to 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ strategy:
       CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
       TEST_TARGET: 'linux_clang10'
     osx_gcc:
-      VM_ImageName: 'macos-10.14'
+      VM_ImageName: 'macos-1015'
       CMAKE_FLAGS: ''
       TEST_TARGET: 'osx_gcc'
     windows:


### PR DESCRIPTION
The `macOS` image for 10.14 is being deprecated.
See https://github.com/LLNL/axom/issues/715