### PR TITLE
Missing curly bracket

### DIFF
--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -11,7 +11,7 @@
 ################################
 find_package(hip REQUIRED)
 
-message(STATUS "HIP version:      ${hip_VERSION")
+message(STATUS "HIP version:      ${hip_VERSION}")
 message(STATUS "HIP platform:     ${HIP_PLATFORM}")
 
 if (NOT ROCM_PATH)


### PR DESCRIPTION
Small fix:
```
CMake Error at cmake/blt/cmake/thirdparty/SetupHIP.cmake:14 (message):
  Syntax error in cmake code at

    src/cmake/blt/cmake/thirdparty/SetupHIP.cmake:14

  when parsing string

    HIP version:      ${hip_VERSION

  There is an unterminated variable reference.
Call Stack (most recent call first):
  cmake/blt/cmake/thirdparty/SetupThirdParty.cmake:56 (include)
  cmake/blt/SetupBLT.cmake:112 (include)
  CMakeLists.txt:100 (include)


-- Configuring incomplete, errors occurred!
```
