### PR TITLE
Guard Google Benchmark smoke test better

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@
 
 variables:
   DOCKER_FLAGS: "--user='root' -v `pwd`:/blt -w /blt/build $(Compiler_ImageName)"
+  C_COMPILERS: "-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER)"
+  MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
 
 strategy:
   matrix:
@@ -15,9 +17,31 @@ strategy:
       CXX_COMPILER: '/usr/bin/g++'
       CMAKE_BIN_DIR: '/usr/bin'
       MPI_DIR: '/usr'
-      MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
-      CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
-      TEST_TARGET: 'linux_gcc8'
+      CMAKE_FLAGS: '$(C_COMPILERS) $(MPI_FLAGS) -DENABLE_GTEST_DEATH_TESTS=OFF -DENABLE_OPENMP=ON'
+    linux_gcc11:
+      VM_ImageName: 'ubuntu-20.04'
+      Compiler_ImageName: 'axom/tpls:gcc-11_01-27-22_05h-56m'
+      C_COMPILER: '/usr/bin/gcc'
+      CXX_COMPILER: '/usr/bin/g++'
+      CMAKE_BIN_DIR: '/usr/bin'
+      MPI_DIR: '/usr'
+      CMAKE_FLAGS: '$(C_COMPILERS) $(MPI_FLAGS) -DENABLE_GTEST_DEATH_TESTS=OFF -DENABLE_OPENMP=ON'
+    linux_gcc11_benchmarks:
+      VM_ImageName: 'ubuntu-20.04'
+      Compiler_ImageName: 'axom/tpls:gcc-11_01-27-22_05h-56m'
+      C_COMPILER: '/usr/bin/gcc'
+      CXX_COMPILER: '/usr/bin/g++'
+      CMAKE_BIN_DIR: '/usr/bin'
+      MPI_DIR: '/usr'
+      CMAKE_FLAGS: '$(C_COMPILERS) $(MPI_FLAGS) -DENABLE_GTEST_DEATH_TESTS=OFF -DENABLE_OPENMP=ON -DENABLE_BENCHMARKS=ON'
+    linux_gcc11_gmock:
+      VM_ImageName: 'ubuntu-20.04'
+      Compiler_ImageName: 'axom/tpls:gcc-11_01-27-22_05h-56m'
+      C_COMPILER: '/usr/bin/gcc'
+      CXX_COMPILER: '/usr/bin/g++'
+      CMAKE_BIN_DIR: '/usr/bin'
+      MPI_DIR: '/usr'
+      CMAKE_FLAGS: '$(C_COMPILERS) $(MPI_FLAGS) -DENABLE_GTEST_DEATH_TESTS=OFF -DENABLE_OPENMP=ON -DENABLE_GMOCK=ON'
     linux_clang10:
       VM_ImageName: 'ubuntu-18.04'
       Compiler_ImageName: 'axom/tpls:clang-10_10-21-21_21h-28m'
@@ -25,17 +49,13 @@ strategy:
       CXX_COMPILER: '/usr/bin/clang++'
       CMAKE_BIN_DIR: '/usr/bin'
       MPI_DIR: '/usr'
-      MPI_FLAGS: '-DENABLE_MPI=ON -DMPI_C_COMPILER=$(MPI_DIR)/bin/mpicc -DMPI_CXX_COMPILER=$(MPI_DIR)/bin/mpicxx -DMPIEXEC=$(MPI_DIR)/bin/mpiexec -DMPIEXEC_NUMPROC_FLAG=-n'
-      CMAKE_FLAGS: '-DCMAKE_C_COMPILER=$(C_COMPILER) -DCMAKE_CXX_COMPILER=$(CXX_COMPILER) -DENABLE_GTEST_DEATH_TESTS=OFF $(MPI_FLAGS) -DENABLE_OPENMP=ON'
-      TEST_TARGET: 'linux_clang10'
+      CMAKE_FLAGS: '$(C_COMPILERS) $(MPI_FLAGS) -DENABLE_GTEST_DEATH_TESTS=OFF -DENABLE_OPENMP=ON'
     osx_gcc:
       VM_ImageName: 'macos-1015'
       CMAKE_FLAGS: ''
-      TEST_TARGET: 'osx_gcc'
     windows:
       VM_ImageName: 'windows-2019'
       CMAKE_FLAGS: ''
-      TEST_TARGET: 'win_vs'
 
 pool:
   vmImage: $(VM_ImageName)
@@ -81,5 +101,5 @@ steps:
   inputs:
     testResultsFormat: 'cTest'
     testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: '$(TEST_TARGET) Tests'
+    testRunTitle: '$(Agent.JobName) Tests'
     failTaskOnFailedTests: true

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -40,15 +40,21 @@ endif()
 ################
 # gbenchmark test
 ################
-if (ENABLE_BENCHMARKS)
+if(ENABLE_GBENCHMARKS)
     blt_add_executable(NAME blt_gbenchmark_smoke
                        SOURCES blt_gbenchmark_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                        DEPENDS_ON gbenchmark
                        FOLDER blt/benchmarks )
 
-    blt_add_benchmark( NAME blt_gbenchmark_smoke 
-                       COMMAND  blt_gbenchmark_smoke "--benchmark_min_time=0.0001")
+    if(ENABLE_BENCHMARKS)
+        blt_add_benchmark(NAME     blt_gbenchmark_smoke 
+                          COMMAND  blt_gbenchmark_smoke "--benchmark_min_time=0.0001")
+    else()
+        # A user could turn on gbenchmarks but turn off benchmarks
+        blt_add_test(NAME     blt_gbenchmark_smoke 
+                     COMMAND  blt_gbenchmark_smoke "--benchmark_min_time=0.0001")
+    endif()
 endif()
 
 

--- a/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h
+++ b/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h
@@ -173,6 +173,10 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
 #include <cassert>
 #include <cstddef>
 #include <iosfwd>
+// BLT PATCH START
+// gcc@11 requires this for std::numeric_limits
+#include <limits>
+// BLT PATCH END
 #include <map>
 #include <set>
 #include <string>

--- a/thirdparty_builtin/patches/gbenchmark-2022_02_16-limits.patch
+++ b/thirdparty_builtin/patches/gbenchmark-2022_02_16-limits.patch
@@ -1,0 +1,15 @@
+diff --git a/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h b/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h
+index 6cb96f5..0b1f451 100644
+--- a/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h
++++ b/thirdparty_builtin/benchmark-1.5.0/include/benchmark/benchmark.h
+@@ -173,6 +173,10 @@ BENCHMARK(BM_test)->Unit(benchmark::kMillisecond);
+ #include <cassert>
+ #include <cstddef>
+ #include <iosfwd>
++// BLT PATCH START
++// gcc@11 requires this for std::numeric_limits
++#include <limits>
++// BLT PATCH END
+ #include <map>
+ #include <set>
+ #include <string>


### PR DESCRIPTION
Users could turn on benchmarks but turn off gbenchmark and end up in a state where the smoke tests would fail.

This also does some small clean up to the azure CI.