### PR TITLE
Add support for C++20

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,10 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Added support for C++20. Note: XL does not support C++20.
+  While PGI has C++20 support, it is currently disabled (A BLT fatal error will occur).
+
 ## [Version 0.5.0] - Release date 2022-03-07
 
 ### Added

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -263,7 +263,7 @@ endif ()
 SET( CMAKE_CXX_STANDARD_REQUIRED ON )
 
 set(BLT_CXX_STD "" CACHE STRING "Version of C++ standard")
-set_property(CACHE BLT_CXX_STD PROPERTY STRINGS c++98 c++11 c++14 c++17)
+set_property(CACHE BLT_CXX_STD PROPERTY STRINGS c++98 c++11 c++14 c++17 c++20)
 
 if (BLT_CXX_STD)
     if( BLT_CXX_STD STREQUAL c++98 ) 
@@ -296,9 +296,22 @@ if (BLT_CXX_STD)
             FLAGS_VAR CMAKE_CXX_FLAGS
             DEFAULT " "
             PGI "--c++17")
+    elseif( BLT_CXX_STD STREQUAL c++20)
+        # Error out on what does not support C++20
+        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "XL")
+            message(FATAL_ERROR "XL does not support C++20.")
+        endif()
+        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+            message(FATAL_ERROR "PGI is not yet supported using C++20.")
+        endif()
+        if (ENABLE_CUDA AND (NOT DEFINED CMAKE_CUDA_COMPILE_FEATURES OR (NOT "cuda_std_20" IN_LIST CMAKE_CUDA_COMPILE_FEATURES)))
+            message(FATAL_ERROR "CMake's CUDA_STANDARD does not support C++20.")
+        endif()
+
+        set(CMAKE_CXX_STANDARD 20)
     else()
         message(FATAL_ERROR "${BLT_CXX_STD} is an invalid entry for BLT_CXX_STD. "
-                            "Valid Options are ( c++98, c++11, c++14, c++17 )")
+                            "Valid Options are ( c++98, c++11, c++14, c++17, c++20 )")
     endif()
 
     if (ENABLE_CUDA)


### PR DESCRIPTION
I'm a new user of `Blt` and the code I'm hoping to use it for requires certain features from C++20 (equivalent to `gcc-9` or higher).  Therefore, I went ahead and added C++20 support.  It'd be great to get this support merged into `main`.

- I see that you just branched version 0.5 a few hours ago (congrats!), but had not yet updated `develop` yet, therefore I based this commit on [49fb804b15d781b3a4ce57e8835e0d6addec715d].  Please let me know if you need me to rebase to a different commit.
- I don't have immediate access to `PGI` to test and could only find documentation online for the `--c++17` flags and therefore cautiously disabled it along with `XL`.

I'd be happy to address any feedback or requested changes.