### PR TITLE
Improve error checking in `blt_list_append` macro

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -24,6 +24,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   CMAKE_CUDA_STANDARD if set otherwise falls back on BLT_CXX_STD or CMAKE_CXX_STANDARD.
 - Removed extra HIP offload flags that were being added as generator expressions as opposed to simple
   flags.
+- Skip check for valid `ELEMENTS` parameter in `blt_list_append` macro when not appending
 
 ### Removed
 - Removed support for deprecated HCC.

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -69,10 +69,6 @@ macro(blt_list_append)
         message(FATAL_ERROR "blt_list_append() requires a TO <list> argument")
     endif()
 
-    if ( NOT DEFINED arg_ELEMENTS )
-         message(FATAL_ERROR "blt_list_append() requires ELEMENTS to be specified" )
-    endif()
-
     # determine if we should add the elements to the list
     set(_shouldAdd FALSE )
     set(_listVar "${ARGN}")         # convert macro arguments to list variable
@@ -84,6 +80,11 @@ macro(blt_list_append)
 
     # append if
     if ( ${_shouldAdd} )
+        # check that ELEMENTS parameter is defined/non-empty before appending
+        if ( NOT DEFINED arg_ELEMENTS )
+            message(FATAL_ERROR "blt_list_append() requires ELEMENTS to be specified and non-empty" )
+        endif()
+
         list( APPEND ${arg_TO} ${arg_ELEMENTS} )
     endif()
 

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -227,6 +227,10 @@ if(ENABLE_GTEST)
     blt_list_append(TO _actual_list ELEMENTS "empty_escaped"        IF ${_defined_empty_var})
     blt_list_append(TO _actual_list ELEMENTS "nonempty_escaped"     IF ${_defined_nonempty_var})
 
+    # Check that ELEMENTS can be empty or missing when the IF condition is false
+    blt_list_append(TO _actual_list                                 IF FALSE)
+    blt_list_append(TO _actual_list ELEMENTS ""                     IF FALSE)
+
     # Check the results
     list(LENGTH _actual_list _actual_size)
     if(NOT "${_actual_list}" STREQUAL "${_expected_list}"


### PR DESCRIPTION
Only check if `ELEMENTS` was provided and non-empty when appending, i.e. when `IF` condition evaluates to `TRUE`

Fixes #587.