### PR TITLE
quiet warning about if(ON) - cmp0012

### DIFF
--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -190,7 +190,7 @@ macro(blt_find_executable)
     string(TOUPPER ${arg_NAME} _ucname)
 
     message(STATUS "${arg_NAME} support is ${ENABLE_${_ucname}}")
-    if (${ENABLE_${_ucname}})
+    if (ENABLE_${_ucname})
         set(_exes ${arg_NAME})
         if (DEFINED arg_EXECUTABLES)
             set(_exes ${arg_EXECUTABLES})

--- a/docs/tutorial/third_party_libraries.rst
+++ b/docs/tutorial/third_party_libraries.rst
@@ -102,7 +102,7 @@ Then ``lua`` is available to be used in the ``DEPENDS_ON`` list in the following
     option to :ref:`blt_import_library` can also be used to manage visibility.
 
 
-Cmake's Find Modules
+CMake's Find Modules
 ~~~~~~~~~~~~~~~~~~~~
 
 This time we will do exactly the same thing but using the new CMake provided ``FindLua.cmake`` module.

--- a/host-configs/other/radiuss-aws-ec2.cmake
+++ b/host-configs/other/radiuss-aws-ec2.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-2022, Lawrence Livermore National Security, LLC and
+# other BLT Project Developers. See the top-level LICENSE file for details
+# 
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+#------------------------------------------------------------------------------
+# Example host-config file for the a basic AWS EC2 instance with OpenMPI
+#------------------------------------------------------------------------------
+#
+# This file provides CMake with paths / details for:
+#  C, C++, & Fortran compilers + MPI
+# 
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# gcc@7.3.1 compilers
+#------------------------------------------------------------------------------
+
+set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+
+set(ENABLE_FORTRAN ON CACHE BOOL "")
+set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
+
+#------------------------------------------------------------------------------
+# MPI Support
+#------------------------------------------------------------------------------
+set(ENABLE_MPI ON CACHE BOOL "")
+
+set(MPI_HOME             "/usr/lib64/openmpi" CACHE PATH "")
+
+set(MPI_C_COMPILER       "${MPI_HOME}/bin/mpicc" CACHE PATH "")
+set(MPI_CXX_COMPILER     "${MPI_HOME}/bin/mpicxx" CACHE PATH "")
+set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpif90" CACHE PATH "")
+
+set(MPIEXEC              "${MPI_HOME}/bin/mpirun" CACHE PATH "")
+set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
+setBLT_MPI_COMMAND_APPEND "-oversubscribe" CACHE STRING "")

--- a/host-configs/other/radiuss-aws-ec2.cmake
+++ b/host-configs/other/radiuss-aws-ec2.cmake
@@ -35,4 +35,4 @@ set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpif90" CACHE PATH "")
 
 set(MPIEXEC              "${MPI_HOME}/bin/mpirun" CACHE PATH "")
 set(MPIEXEC_NUMPROC_FLAG "-np" CACHE STRING "")
-setBLT_MPI_COMMAND_APPEND "-oversubscribe" CACHE STRING "")
+set(BLT_MPI_COMMAND_APPEND "--oversubscribe" CACHE STRING "")

--- a/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
+++ b/thirdparty_builtin/googletest-master-2020-01-07/googlemock/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gmock VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.0)
 
 if (COMMAND set_up_hermetic_build)
   set_up_hermetic_build()

--- a/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
+++ b/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt
@@ -53,7 +53,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION ${GOOGLETEST_VERSION} LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.0)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)


### PR DESCRIPTION
This is a very noisy warning in CMake 3.19.4.

```
-- Sphinx support is ON
CMake Warning (dev) at blt/cmake/BLTPrivateMacros.cmake:193 (if):
  if given arguments:

    "ON"

  An argument named "ON" appears in a conditional statement.  Policy CMP0012
  is not set: if() recognizes numbers and boolean constants.  Run "cmake
  --help-policy CMP0012" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
Call Stack (most recent call first):
  blt/cmake/thirdparty/SetupThirdParty.cmake:67 (blt_find_executable)
  blt/SetupBLT.cmake:123 (include)
  CMakeLists.txt:26 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Also quiets a warning by including gtest:

```
CMake Deprecation Warning at blt/thirdparty_builtin/googletest-master-2020-01-07/googletest/CMakeLists.txt:56 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```