### PR TITLE
Feature/probinso/hipcc support

### DIFF
--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -187,7 +187,9 @@ if (NOT BLT_LOADED)
     # File extension lists used to filter sources based on languages for code checks
     # and filtering Fortran sources out of cuda/hip source lists
     # Note: this filtering is case-insensitive
-    set(BLT_C_FILE_EXTS ".cpp" ".hpp" ".cxx" ".hxx" ".c" ".h" ".cc" ".hh" ".inl" ".cu" ".cuh"
+    set(BLT_C_FILE_EXTS ".c" ".h"
+               CACHE STRING "List of known file extensions used for C/CXX sources")
+    set(BLT_CXX_FILE_EXTS ".cpp" ".hpp" ".cxx" ".hxx"  ".cc" ".hh" ".inl" ".cu" ".cuh"
                CACHE STRING "List of known file extensions used for C/CXX sources")
     set(BLT_Fortran_FILE_EXTS ".f" ".f90"
                CACHE STRING "List of known file extensions used for Fortran sources")

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -678,8 +678,6 @@ macro(blt_add_library)
         add_library( ${arg_NAME} INTERFACE )
         target_sources( ${arg_NAME} INTERFACE
                         $<BUILD_INTERFACE:${_build_headers}>)
-
-        blt_print_target_properties(TARGET ${arg_NAME})
     endif()
 
     # Clear value of _have_fortran from previous calls
@@ -741,9 +739,6 @@ macro(blt_add_library)
         # the white-list of properties that are allowed
         blt_clean_target(TARGET ${arg_NAME})
     endif()
-    
-    blt_print_target_properties(TARGET ${arg_NAME})
-
 endmacro(blt_add_library)
 
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -654,6 +654,13 @@ macro(blt_add_library)
                 DEPENDS_ON   ${arg_DEPENDS_ON}
                 LIBRARY_TYPE ${_lib_type})
         endif()
+        if (ENABLE_HIP)
+           blt_setup_hip_target(
+                NAME         ${arg_NAME}
+                SOURCES      ${arg_SOURCES}
+                DEPENDS_ON   ${arg_DEPENDS_ON}
+                LIBRARY_TYPE ${_lib_type})
+        endif()
     else()
         #
         #  Header-only library support
@@ -671,6 +678,8 @@ macro(blt_add_library)
         add_library( ${arg_NAME} INTERFACE )
         target_sources( ${arg_NAME} INTERFACE
                         $<BUILD_INTERFACE:${_build_headers}>)
+
+        blt_print_target_properties(TARGET ${arg_NAME})
     endif()
 
     # Clear value of _have_fortran from previous calls
@@ -732,6 +741,8 @@ macro(blt_add_library)
         # the white-list of properties that are allowed
         blt_clean_target(TARGET ${arg_NAME})
     endif()
+    
+    blt_print_target_properties(TARGET ${arg_NAME})
 
 endmacro(blt_add_library)
 
@@ -772,6 +783,12 @@ macro(blt_add_executable)
 
     if (ENABLE_CUDA AND NOT ENABLE_CLANG_CUDA)
         blt_setup_cuda_target(
+            NAME         ${arg_NAME}
+            SOURCES      ${arg_SOURCES}
+            DEPENDS_ON   ${arg_DEPENDS_ON})
+    endif()
+    if (ENABLE_HIP)
+       blt_setup_hip_target(
             NAME         ${arg_NAME}
             SOURCES      ${arg_SOURCES}
             DEPENDS_ON   ${arg_DEPENDS_ON})

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -538,7 +538,7 @@ macro(blt_setup_hip_target)
     endif()
 
     if (${_depends_on_hip})
-        # if hip is in depends_on, flag each file's language as HIP 
+        # if hip is in depends_on, flag each file's language as HIP
         # instead of leaving it up to CMake to decide
         # Note: we don't do this when depending on just 'hip_runtime'
         set(_hip_sources)

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -22,7 +22,6 @@ if (NOT ROCM_PATH)
         /opt/rocm)
 endif()
 
-
 # Update CMAKE_PREFIX_PATH to make sure all the configs that hip depends on are
 # found.
 set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${ROCM_PATH}")
@@ -60,18 +59,13 @@ if(DEFINED AMDGPU_TARGETS)
     endforeach()
      if (${BLT_HIP_REMOVE_HIP_COMPILE_OPTIONS})
         message("ATTEMPTING REMOVAL ${_hip_compile_options}")
-#        set(_flag "-mllvm-amdgpu-early-inline-all=true-mllvm-amdgpu-function-calls=false")
-#        set(_generator_compile_flag "$<$<COMPILE_LANGUAGE:CXX>:SHELL:${_flag}>")
         list(REMOVE_ITEM _hip_compile_options "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-mllvm")
         list(REMOVE_ITEM _hip_compile_options "-amdgpu-early-inline-all=true")
         list(REMOVE_ITEM _hip_compile_options "-mllvm")
         list(REMOVE_ITEM _hip_compile_options "-amdgpu-function-calls=false>")
         message("AFTER REMOVAL ${_hip_compile_options}")
-        #blt_print_target_properties(TARGET hip-lang::device)
         get_target_property(_hip_lang_compile_options hip-lang::device INTERFACE_COMPILE_OPTIONS)
         message("ATTEMPTING REMOVAL ${_hip_lang_compile_options}")
-        set(_flag "-mllvm-amdgpu-early-inline-all=true-mllvm-amdgpu-function-calls=false")
-        set(_generator_compile_flag "$<$<COMPILE_LANGUAGE:HIP>:SHELL:${_flag}>")
         list(REMOVE_ITEM _hip_lang_compile_options "$<$<COMPILE_LANGUAGE:HIP>:SHELL:-mllvm")
         list(REMOVE_ITEM _hip_lang_compile_options "-amdgpu-early-inline-all=true")
         list(REMOVE_ITEM _hip_lang_compile_options "-mllvm")
@@ -83,8 +77,6 @@ if(DEFINED AMDGPU_TARGETS)
     set_property(TARGET hip::device PROPERTY INTERFACE_COMPILE_OPTIONS ${_hip_compile_options})
     set_property(TARGET hip::device PROPERTY INTERFACE_LINK_LIBRARIES ${_hip_link_libs})
 
-    blt_print_target_properties(TARGET hip::device)
-#    blt_print_target_properties(TARGET hip-lang::device)
     if(DEFINED CMAKE_HIP_ARCHITECTURES)
         set(AMDGPU_TARGETS "${CMAKE_HIP_ARCHITECTURES}" CACHE STRING "" FORCE)
     endif()
@@ -113,13 +105,6 @@ blt_import_library(NAME          blt_hip_runtime
                    EXPORTABLE    ${BLT_EXPORT_THIRDPARTY}
                    GLOBAL ${_blt_hip_is_global})
 
-blt_print_target_properties(TARGET hip::host)
 blt_inherit_target_info(TO blt_hip_runtime FROM hip::host OBJECT FALSE)
 
 add_library(blt::hip_runtime ALIAS blt_hip_runtime)
-
-
-blt_print_target_properties(TARGET blt::hip_runtime)
-blt_print_target_properties(TARGET blt::hip)
-
-


### PR DESCRIPTION
Add initial support for using CMAKE_HIP_COMPILER in cmake versions 3.21 and greater.

Differentiate between C_LIST and CXX_LIST for blt_split_source_list_by_language. (HIPCC will error if it's a c file, while cuda will just treat it as a C++ file).

SetupHIP now enables the hip language.

Add option BLT_HIP_REMOVE_HIP_COMPILE_OPTIONS to remove flags associated with pre-installed hip::device and hip-lang::device targets that are incompatible with hipcc.