### PR TITLE
add macro to assist in checking if code snippets compile

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added `blt_convert_to_system_includes` macro to convert existing interface includes to system interface includes.
+- `blt_check_code_compiles` which compiles a C++ code snippet and returns the result.
 
 ### Changed
 - Added three extra options to `blt_print_target_properties` macro to print properties of

--- a/SetupBLT.cmake
+++ b/SetupBLT.cmake
@@ -66,6 +66,13 @@ if (NOT BLT_LOADED)
         cmake_policy(SET CMP0057 NEW)
     endif()
 
+    # Make `check_cxx_source_compiles` honor `CMAKE_CXX_STANDARD`
+    # NOTE: This only works on a few CMake versions even though it was
+    #  added in CMake 3.14. (for example, 3.20.2, 3.21.1, and 3.23.1 did not work)
+    if(POLICY CMP0067)
+      cmake_policy(SET CMP0067 NEW)
+    endif()
+
     # Policy to use <PackageName>_ROOT variable in find_<Package> commands
     # Policy added in 3.12+
     if(POLICY CMP0074)

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1446,7 +1446,8 @@ endmacro()
 macro(blt_check_code_compiles)
 
     set(options)
-    set(singleValueArgs CODE_COMPILES VERBOSE_OUTPUT)
+    set(singleValueArgs CODE_COMPILES VERBOSE_OUTPUT )
+    # NOTE: SOURCE_STRING must be a multiValueArg otherwise CMake removes all semi-colons
     set(multiValueArgs SOURCE_STRING)
 
     # Parse the arguments to the macro

--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -101,8 +101,28 @@ SOURCE_STRING
 
 ``SOURCE_STRING`` must be a valid C++ program with a main() function and
 must be passed in as a quoted string variable. Otherwise, CMake will convert
-the string into a list and lose the semicolons.
-E.g. blt_check_code_compiles(SOURCE_STRING "${str_var}" ...)
+the string into a list and lose the semicolons.  You can use any CMake method
+of sending a string, but we recommend the
+`bracket argument method <https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#bracket-argument>`_
+shown below so you do not have to escape your quotes:
+
+.. code-block:: cmake
+
+    blt_check_code_compiles(CODE_COMPILES  hello_world_compiled
+                            SOURCE_STRING
+    [=[
+    #include <iostream>
+
+    int main(int, char**)
+    {
+
+        std::cout << "Hello World!" << std::endl;
+
+        return 0;
+    }
+    ]=])
+
+
 
 
 .. _blt_find_libraries:

--- a/docs/api/utility.rst
+++ b/docs/api/utility.rst
@@ -77,6 +77,34 @@ When using the Intel toolchain within Visual Studio, we use the
 ``MSVC_INTEL`` flag, when provided, with a fallback to the ``MSVC`` flag.
 
 
+.. blt_check_code_compiles:
+
+blt_check_code_compiles
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cmake
+
+     blt_check_code_compiles(CODE_COMPILES  <variable>
+                             VERBOSE_OUTPUT <ON|OFF (default OFF)>
+                             SOURCE_STRING  <quoted C++ program>)
+
+This macro checks if a snippet of C++ code compiles.
+
+CODE_COMPILES
+  The boolean variable that will be filled with the compilation result.
+
+VERBOSE_OUTPUT
+  Optional parameter to output debug information (Default: OFF)
+
+SOURCE_STRING
+  The source snippet to compile.
+
+``SOURCE_STRING`` must be a valid C++ program with a main() function and
+must be passed in as a quoted string variable. Otherwise, CMake will convert
+the string into a list and lose the semicolons.
+E.g. blt_check_code_compiles(SOURCE_STRING "${str_var}" ...)
+
+
 .. _blt_find_libraries:
 
 blt_find_libraries

--- a/tests/internal/unit/CMakeLists.txt
+++ b/tests/internal/unit/CMakeLists.txt
@@ -156,16 +156,17 @@ message(STATUS "Checking for blt_check_code_compiles")
 blt_check_code_compiles(CODE_COMPILES  _hello_world_compiled
                         VERBOSE_OUTPUT ON
                         SOURCE_STRING
-"#include <iostream>
+[=[
+#include <iostream>
 
 int main(int, char**)
 {
 
-    std::cout << \"Hello World!\" << std::endl;
+    std::cout << "Hello World!" << std::endl;
 
     return 0;
 }
-")
+]=])
 
 if(_hello_world_compiled)
   message(STATUS "... passed")

--- a/tests/internal/unit/CMakeLists.txt
+++ b/tests/internal/unit/CMakeLists.txt
@@ -151,3 +151,24 @@ message(
 "Tests passed for `blt_split_source_list_by_language`.\n"
 "*****************************************************")
 
+message(STATUS "Checking for blt_check_code_compiles")
+
+blt_check_code_compiles(CODE_COMPILES  _hello_world_compiled
+                        VERBOSE_OUTPUT ON
+                        SOURCE_STRING
+"#include <iostream>
+
+int main(int, char**)
+{
+
+    std::cout << \"Hello World!\" << std::endl;
+
+    return 0;
+}
+")
+
+if(_hello_world_compiled)
+  message(STATUS "... passed")
+else()
+  message(FATAL_ERROR "... failed to compile.")
+endif()


### PR DESCRIPTION
We ran into a problem where Umpire was trying to use CMake's macro `check_cxx_source_compiles`.  We found that it did not honor the `CMAKE_CXX_STANDARD`.  There is a policy to control this but I could only get it to work for CMake 3.14.5 and 3.18.0 but anything above that did not work.

This adds a macro we have used in Axom for a while.  It is much more reliable and also allows you to output verbosely to the screen.  For example:

```
-- [blt_check_code_compiles] Attempting to compile source string: 
#include <iostream>

  int main(int, char**)
  {

    std::cout << "Hello World!" << std::endl;

    return 0;
  }
-- [blt_check_code_compiles] Compiler output: 
Change Dir: /usr/WS2/white238/blt/repo/tests/internal/build/unit/CMakeTmp/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/gmake -f Makefile cmTC_5e24b/fast && /usr/bin/gmake  -f CMakeFiles/cmTC_5e24b.dir/build.make CMakeFiles/cmTC_5e24b.dir/build
gmake[1]: Entering directory `/usr/WS2/white238/blt/repo/tests/internal/build/unit/CMakeTmp/CMakeFiles/CMakeTmp'
Building CXX object CMakeFiles/cmTC_5e24b.dir/_bltCheckCompilesykiyL.cpp.o
/usr/tce/packages/gcc/gcc-10.2.1/bin/c++   -Wall -Wextra       -fPIE -std=c++11 -o CMakeFiles/cmTC_5e24b.dir/_bltCheckCompilesykiyL.cpp.o -c /usr/WS2/white238/blt/repo/tests/internal/build/unit/_bltCheckCompilesykiyL.cpp
Linking CXX executable cmTC_5e24b
/usr/tce/packages/cmake/cmake-3.20.2/bin/cmake -E cmake_link_script CMakeFiles/cmTC_5e24b.dir/link.txt --verbose=1
/usr/tce/packages/gcc/gcc-10.2.1/bin/c++  -Wall -Wextra       CMakeFiles/cmTC_5e24b.dir/_bltCheckCompilesykiyL.cpp.o -o cmTC_5e24b 
gmake[1]: Leaving directory `/usr/WS2/white238/blt/repo/tests/internal/build/unit/CMakeTmp/CMakeFiles/CMakeTmp'



-- [blt_check_code_compiles] The code snippet successfully compiled
```