### PR TITLE
Adds `blt_print_variables` macro

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Added `blt_print_variables` macro to print variables in current scope, with regex filtering on variable names and values
+
 ### Fixed
 - Guard HIP compiler flag ``--rocm-path=/path/to/rocm`` against Crayftn compiler earlier than 15.0.0.
 

--- a/docs/api/target_properties.rst
+++ b/docs/api/target_properties.rst
@@ -190,6 +190,44 @@ Output is of the form for each property:
     blt_print_target_properties(TARGET foo CHILDREN TRUE PROPERTY_NAME_REGEX "CXX")
     blt_print_target_properties(TARGET foo PROPERTY_NAME_REGEX "CXX" PROPERTY_VALUE_REGEX "ON")
 
+.. _blt_print_variables:
+
+blt_print_variables
+~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cmake
+
+    blt_print_variables(NAME_REGEX  <regular_expression_string>
+                        VALUE_REGEX <regular_expression_string>
+                        [IGNORE_CASE])
+
+Prints variables and their values in the current scope, with optional 
+regex filtering on the variable names and values.
+
+NAME_REGEX
+  Regular expression to apply to variable names (all by default)
+
+VALUE_REGEX
+  Regular expression to apply to variable values (all by default)
+
+IGNORE_CASE
+  Optionally ignore case of variable names and values when filtering
+
+
+Output is of the following form for each variable:
+ | [blt_print_variables] <decorated_name>: <value>
+
+Cache variables are marked as CACHE and will list their type, e.g. `CACHE{<name>}:TYPE`
+
+.. code-block:: cmake
+    :caption: **Example**
+    :linenos:
+
+    blt_print_variables()
+    blt_print_variables( NAME_REGEX "blt" IGNORE_CASE)
+    blt_print_variables( NAME_REGEX "_FOUND" VALUE_REGEX "^on$|^true$|^1$" IGNORE_CASE)
+    blt_print_variables( NAME_REGEX "LIB|LIBS|LIBRARY|LIBRARIES")
+
 .. _blt_set_target_folder:
 
 blt_set_target_folder

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -257,6 +257,7 @@ if (ENABLE_CUDA AND ENABLE_MPI AND
                  NUM_MPI_TASKS 4)
 endif()
 
+# Exercise blt_print_target_properties macro
 message(STATUS "")
 message(STATUS "Exercising blt_print_target_properties macro default options.")
 foreach(_target gtest example t_example_smoke not-a-target blt_header_only mpi cuda cuda_runtime blt::hip blt::hip_runtime)
@@ -281,6 +282,18 @@ blt_register_library(NAME foo DEPENDS_ON bar)
 blt_register_library(NAME bar DEPENDS_ON foo)
 blt_print_target_properties(TARGET bar CHILDREN true)
 
+# Exercise blt_print_variables macro
+message(STATUS "")
+message(STATUS [[Exercising blt_print_variables macro on using 'NAME_REGEX "blt" IGNORE_CASE':]])
+blt_print_variables( NAME_REGEX "blt" IGNORE_CASE)
+message(STATUS "")
+message(STATUS [[Exercising blt_print_variables macro on using 'NAME_REGEX "_FOUND" VALUE_REGEX "^on$|^true$|^1$" IGNORE_CASE']])
+blt_print_variables( NAME_REGEX "_FOUND" VALUE_REGEX "^on$|^true$|^1$" IGNORE_CASE)
+message(STATUS "")
+message(STATUS [[Exercising blt_print_variables macro on using 'NAME_REGEX "LIB|LIBS|LIBRARY|LIBRARIES"']])
+blt_print_variables( NAME_REGEX "LIB|LIBS|LIBRARY|LIBRARIES")
+
+# Test object libraries
 add_subdirectory(src/object_library_test)
 
 if(ENABLE_CLANGQUERY OR ENABLE_CLANGTIDY)


### PR DESCRIPTION
* This is a feature PR
* It adds a new macro `blt_print_variables` to log the variables in the calling scope
* Has optional regex filtering on variables names and values, via the `NAME_REGEX` and `VALUE_REGEX` arguments
* Also supports case-insensitive filtering via the `IGNORE_CASE` keyword

#### Example 1:
```cmake
blt_print_variables( NAME_REGEX "_FOUND" VALUE_REGEX "^on$|^true$|^1$" IGNORE_CASE)
```

```
-- [blt_print_variables] The following variables are defined at the calling site in '<blt>/tests/internal/CMakeLists.txt' --
-- [blt_print_variables] matching NAME_REGEX '_FOUND' (case insensitive)
-- [blt_print_variables] matching VALUE_REGEX '^on$|^true$|^1$' (case insensitive)
-- [blt_print_variables]   ASTYLE_FOUND := TRUE
-- [blt_print_variables]   AStyle_FOUND := TRUE
-- [blt_print_variables]   Doxygen_FOUND := TRUE
-- [blt_print_variables]   Doxygen_doxygen_FOUND := TRUE
-- [blt_print_variables]   GIT_FOUND := TRUE
-- [blt_print_variables]   Git_FOUND := TRUE
-- [blt_print_variables]   SPHINX_FOUND := TRUE
-- [blt_print_variables]   Sphinx_FOUND := TRUE
-- [blt_print_variables]   UNCRUSTIFY_FOUND := TRUE
-- [blt_print_variables]   Uncrustify_FOUND := TRUE
-- [blt_print_variables] ----------------------------------------------------------
```

#### Example 2:
```cmake
blt_print_variables( NAME_REGEX "blt" IGNORE_CASE)
```

```
-- [blt_print_variables] The following variables are defined at the calling site in '<blt>/tests/internal/CMakeLists.txt' --
-- [blt_print_variables] matching NAME_REGEX 'blt' (case insensitive)
-- [blt_print_variables]   CACHE{BLT_BUILD_DIR}:PATH := <blt>/build/blt
-- [blt_print_variables]   CACHE{BLT_CLANG_CUDA_ARCH}:STRING := sm_30
-- [blt_print_variables]   CACHE{BLT_CMAKE_FILE_EXTS}:STRING := .cmake
-- [blt_print_variables]   CACHE{BLT_CODE_CHECK_TARGET_NAME}:STRING := check
-- [blt_print_variables]   CACHE{BLT_CODE_STYLE_TARGET_NAME}:STRING := style
-- [blt_print_variables]   BLT_CXX_FLAGS :=  /bigobj
-- [blt_print_variables]   CACHE{BLT_CXX_STD}:STRING := c++14
-- [blt_print_variables]   CACHE{BLT_C_FILE_EXTS}:STRING := .cpp;.hpp;.cxx;.hxx;.c;.h;.cc;.hh;.inl;.cu;.cuh
-- [blt_print_variables]   BLT_C_FLAGS :=  /bigobj
-- [blt_print_variables]   CACHE{BLT_DOCS_TARGET_NAME}:STRING := docs
-- [blt_print_variables]   BLT_ENABLE_ALL_WARNINGS_CXX_FLAG :=  /W4
-- [blt_print_variables]   BLT_ENABLE_ALL_WARNINGS_C_FLAG :=  /W4
-- [blt_print_variables]   CACHE{BLT_ENABLE_MSVC_STATIC_MD_TO_MT}:BOOL := ON
-- [blt_print_variables]   BLT_ENABLE_MSVC_STATIC_MD_TO_MT_AVAILABLE := 1
-- [blt_print_variables]   CACHE{BLT_Fortran_FILE_EXTS}:STRING := .f;.f90
-- [blt_print_variables]   CACHE{BLT_LOADED}:UNINITIALIZED := True
-- [blt_print_variables]   CACHE{BLT_Python_FILE_EXTS}:STRING := .py
-- [blt_print_variables]   CACHE{BLT_ROOT_DIR}:PATH := <blt>
-- [blt_print_variables]   CACHE{BLT_RUN_BENCHMARKS_TARGET_NAME}:STRING := run_benchmarks
-- [blt_print_variables]   BLT_SOURCE_DIR := <blt>/tests/internal/../..
-- [blt_print_variables]   CACHE{BLT_VERSION}:STRING := 0.5.2
-- [blt_print_variables]   BLT_WARNINGS_AS_ERRORS_CXX_FLAG :=  /WX
-- [blt_print_variables]   BLT_WARNINGS_AS_ERRORS_C_FLAG :=  /WX
-- [blt_print_variables]   CACHE{_BLT_BAR_DEPENDS_ON}:STRING := foo
-- [blt_print_variables]   CACHE{_BLT_BAR_IS_REGISTERED_LIBRARY}:BOOL := TRUE
-- [blt_print_variables]   CACHE{_BLT_BAR_LIBRARIES}:STRING := BLT_NO_LIBRARIES
-- [blt_print_variables]   CACHE{_BLT_BASE_OBJECT_DEPENDS_ON}:STRING := inherited_base
-- [blt_print_variables]   CACHE{_BLT_BASE_OBJECT_IS_OBJECT_LIBRARY}:BOOL := TRUE
-- [blt_print_variables]   CACHE{_BLT_BASE_OBJECT_IS_REGISTERED_LIBRARY}:BOOL := TRUE
-- [blt_print_variables]   CACHE{_BLT_BASE_OBJECT_LIBRARIES}:STRING := BLT_NO_LIBRARIES
-- [blt_print_variables]   CACHE{_BLT_FOO_DEPENDS_ON}:STRING := bar
-- [blt_print_variables]   CACHE{_BLT_FOO_IS_REGISTERED_LIBRARY}:BOOL := TRUE
-- [blt_print_variables]   CACHE{_BLT_FOO_LIBRARIES}:STRING := BLT_NO_LIBRARIES
-- [blt_print_variables]   CACHE{_BLT_GTEST_COMPILE_FLAGS}:STRING :=  /wd4251
-- [blt_print_variables]   CACHE{_BLT_GTEST_DEFINES}:STRING := -DGTEST_HAS_DEATH_TEST=1
...
-- [blt_print_variables] ----------------------------------------------------------