### PR TITLE
Patch include doubling

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed
 - Guard HIP compiler flag ``--rocm-path=/path/to/rocm`` against Crayftn compiler earlier than 15.0.0.
+- Fix doubling of `INTERFACE_INCLUDE_DIRECTORIES` in `blt_patch_target(... TREAT_INCLUDES_AS_SYSTEM true)`.
 
 ## [Version 0.5.2] - Release date 2022-10-05
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1541,13 +1541,13 @@ macro(blt_convert_to_system_includes)
 
     # PGI does not support -isystem
     if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
-        get_target_property(_include_dirs ${arg_NAME} INTERFACE_INCLUDE_DIRECTORIES)
+        get_target_property(_include_dirs ${arg_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
         # Don't copy if the target had no include directories
         if(_include_dirs)
             # Clear previous value in INTERFACE_INCLUDE_DIRECTORIES so it is not doubled
             # by target_include_directories
-            set_property(TARGET ${arg_NAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-            target_include_directories(${arg_NAME} SYSTEM INTERFACE ${_include_dirs})
+            set_property(TARGET ${arg_TARGET} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+            target_include_directories(${arg_TARGET} SYSTEM INTERFACE ${_include_dirs})
         endif()
     endif()
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -480,14 +480,8 @@ macro(blt_patch_target)
         endif()
     endif()
 
-    # PGI does not support -isystem
-    if( (${arg_TREAT_INCLUDES_AS_SYSTEM}) AND (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI"))
-        get_target_property(_target_includes ${arg_NAME} INTERFACE_INCLUDE_DIRECTORIES)
-        # Don't copy if the target had no include directories
-        if(_target_includes)
-            set_property(TARGET ${arg_NAME} PROPERTY
-                         INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${_target_includes})
-        endif()
+    if(${arg_TREAT_INCLUDES_AS_SYSTEM})
+        blt_convert_to_system_includes(TARGET ${arg_NAME})
     endif()
 
     # FIXME: Is this all that's needed?
@@ -1526,6 +1520,7 @@ macro(blt_export_tpl_targets)
     endforeach()
 endmacro()
 
+
 ##------------------------------------------------------------------------------
 ## blt_convert_to_system_includes(TARGET <target>)
 ##
@@ -1544,8 +1539,18 @@ macro(blt_convert_to_system_includes)
        message(FATAL_ERROR "TARGET is a required parameter for the blt_convert_to_system_includes macro.")
     endif()
 
-    get_target_property(_include_dirs ${arg_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
-    set_property(TARGET ${arg_TARGET} APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_include_dirs}")
+    # PGI does not support -isystem
+    if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "PGI")
+        get_target_property(_include_dirs ${arg_NAME} INTERFACE_INCLUDE_DIRECTORIES)
+        # Don't copy if the target had no include directories
+        if(_include_dirs)
+            # Clear previous value in INTERFACE_INCLUDE_DIRECTORIES so it is not doubled
+            # by target_include_directories
+            set_property(TARGET ${arg_NAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+            target_include_directories(${arg_NAME} SYSTEM INTERFACE ${_include_dirs})
+        endif()
+    endif()
+
     unset(_include_dirs)
 endmacro()
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -485,12 +485,8 @@ macro(blt_patch_target)
         get_target_property(_target_includes ${arg_NAME} INTERFACE_INCLUDE_DIRECTORIES)
         # Don't copy if the target had no include directories
         if(_target_includes)
-            if(_standard_lib_interface)
-                target_include_directories(${arg_NAME} SYSTEM ${_scope} ${_target_includes})
-            else()
-                set_property(TARGET ${arg_NAME} PROPERTY
-                            INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${_target_includes})
-            endif()
+            set_property(TARGET ${arg_NAME} PROPERTY
+                         INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${_target_includes})
         endif()
     endif()
 


### PR DESCRIPTION
`blt_patch_target()` was not only doubling the `INTERFACE_INCLUDE_DIRECTORIES` target property but also adding it to `INCLUDE_DIRECTORIES`. This doesn't make sense in any case.

Example:

```
add_library(foo)
target_include_directories(foo INTERFACE /test/path)
blt_patch_target(NAME foo TREAT_INCLUDES_AS_SYSTEM true)
```

Before:

```
-- [foo property] 'foo' is a CMake target
-- [foo property] INCLUDE_DIRECTORIES: /usr/workspace/white238/
-- [foo property] INTERFACE_INCLUDE_DIRECTORIES: /usr/workspace/white238/;/usr/workspace/white238/
-- [foo property] INTERFACE_SYSTEM_INCLUDE_DIRECTORIES: /usr/workspace/white238/
```

After:

```
-- [foo property] 'foo' is a CMake target
-- [foo property] INTERFACE_INCLUDE_DIRECTORIES: /usr/workspace/white238/
-- [foo property] INTERFACE_SYSTEM_INCLUDE_DIRECTORIES: /usr/workspace/white238/
```

Also there was some duplicated logic between `blt_patch_target()` and `blt_convert_to_system_includes()`.  I made `blt_patch_target()` call into `blt_convert_to_system_includes()`.