### PR TITLE
Fix typo in tests tutorial

### DIFF
--- a/docs/tutorial/adding_tests.rst
+++ b/docs/tutorial/adding_tests.rst
@@ -236,8 +236,8 @@ you are modifying or adding code and need to understand how unit test details
 are working, for example.
 
 .. note:: 
-   You can pass arguments to ctest via the ``TEST_ARGS`` parameter, e.g.
-   ``make test TEST_ARGS="..."``
+   You can pass arguments to ctest via the ``ARGS`` parameter, e.g.
+   ``make test ARGS="..."``
    Useful arguments include:
 
    -R


### PR DESCRIPTION
Minor fix to the docs for adding tests.

Specifying flags to make test is done with 'ARGS=' not 'TEST_ARGS='.

Verified using make test ARGS="-VV" as working on an LLNL code.