### PR TITLE
Adds a `clang_tidy_style` target to allow clang-tidy to apply fixes inline

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Adds a `clang_tidy_style` target to allow `clang-tidy` to fix errors in-place.
   This requires a `CLANGAPPLYREPLACEMENTS_EXECUTABLE` CMake variable to point to
   the `clang-apply-replacements` executable in addition to the `CLANGTIDY_EXECUTABLE`.
+  Also adds a corresponding `ENABLE_CLANGAPPLYREPLACEMENTS` CMake option.
 
 ## [Version 0.5.3] - Release date 2023-06-05
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,10 +11,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added support for C++23. Note: XL and PGI do not support C++23.
-- Adds a `clang_tidy_style` target to allow `clang-tidy` to fix errors in-place.
+- Adds a `clang_tidy_style` CMake target to allow `clang-tidy` to fix errors in-place.
   This requires a `CLANGAPPLYREPLACEMENTS_EXECUTABLE` CMake variable to point to
   the `clang-apply-replacements` executable in addition to the `CLANGTIDY_EXECUTABLE`.
   Also adds a corresponding `ENABLE_CLANGAPPLYREPLACEMENTS` CMake option.
+  Note that the `clang_tidy_style` target is not added to the `style` target and must be run separately.
 
 ## [Version 0.5.3] - Release date 2023-06-05
 
@@ -23,6 +24,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   Commit: [12a5852e451baabc79c63a86c634912c563d57bc](https://github.com/google/googletest/commit/12a5852e451baabc79c63a86c634912c563d57bc).
   Note: this version of Googletest requires C++14, and PGI is not supported. If you are using PGI, set ENABLE_GTEST OFF.
 - Updated GoogleBenchmark to 1.8
+- The `clang_tidy_check` target is no longer registered with the main `check` target since its changes are not always safe/valid.
 
 ### Added
 - Added `blt_print_variables` macro to print variables in current scope, with regex filtering on variable names and values

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -11,6 +11,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Added
 - Added support for C++23. Note: XL and PGI do not support C++23.
+- Adds a `clang_tidy_style` target to allow `clang-tidy` to fix errors in-place.
+  This requires a `CLANGAPPLYREPLACEMENTS_EXECUTABLE` CMake variable to point to
+  the `clang-apply-replacements` executable in addition to the `CLANGTIDY_EXECUTABLE`.
 
 ## [Version 0.5.3] - Release date 2023-06-05
 

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -27,6 +27,8 @@ option(ENABLE_DOXYGEN      "Enables Doxygen support" ON)
 option(ENABLE_SPHINX       "Enables Sphinx support" ON)
 
 # Quality
+option(ENABLE_CLANGAPPLYREPLACEMENTS    
+                           "Enables clang-apply-replacements support" ON)
 option(ENABLE_CLANGQUERY   "Enables Clang-query support" ON)
 option(ENABLE_CLANGTIDY    "Enables clang-tidy support" ON)
 option(ENABLE_CPPCHECK     "Enables Cppcheck support" ON)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -87,10 +87,10 @@ if(CLANGTIDY_FOUND)
     add_custom_target(clang_tidy_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_check)
 
-    # targets for modifying code based via clang-tidy
+    # targets for modifying code based via clang-tidy; also require clang-apply-replacements
     if(CLANGAPPLYREPLACEMENTS_FOUND)
         add_custom_target(clang_tidy_style)
-        add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_style)
+        add_dependencies(${BLT_CODE_STYLE_TARGET_NAME} clang_tidy_style)
     endif()
 endif()
 
@@ -481,7 +481,11 @@ macro(blt_add_clang_tidy_target)
         endif()
 
         # hook our new target into the proper dependency chain
-        add_dependencies(clang_tidy_check ${arg_NAME})
+        if(arg_FIX)
+            add_dependencies(clang_tidy_style ${arg_NAME})
+        else()
+            add_dependencies(clang_tidy_check ${arg_NAME})
+        endif()
 
         # Code check targets should only be run on demand
         set_property(TARGET ${arg_NAME} PROPERTY EXCLUDE_FROM_ALL TRUE)

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -82,15 +82,15 @@ if(CLANGQUERY_FOUND)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_query_check)
 endif()
 
+# Note: clang-tidy targets are not added to the main `check` and `style` targets
+# since the changes are not always safe to apply
 if(CLANGTIDY_FOUND)
     # targets for verifying clang-tidy
     add_custom_target(clang_tidy_check)
-    add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_check)
 
     # targets for modifying code based via clang-tidy; also require clang-apply-replacements
     if(CLANGAPPLYREPLACEMENTS_FOUND)
         add_custom_target(clang_tidy_style)
-        add_dependencies(${BLT_CODE_STYLE_TARGET_NAME} clang_tidy_style)
     endif()
 endif()
 

--- a/cmake/SetupCodeChecks.cmake
+++ b/cmake/SetupCodeChecks.cmake
@@ -83,15 +83,22 @@ if(CLANGQUERY_FOUND)
 endif()
 
 if(CLANGTIDY_FOUND)
+    # targets for verifying clang-tidy
     add_custom_target(clang_tidy_check)
     add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_check)
+
+    # targets for modifying code based via clang-tidy
+    if(CLANGAPPLYREPLACEMENTS_FOUND)
+        add_custom_target(clang_tidy_style)
+        add_dependencies(${BLT_CODE_CHECK_TARGET_NAME} clang_tidy_style)
+    endif()
 endif()
 
 # Code check targets should only be run on demand
 foreach(target 
         check cmakeformat_check yapf_check uncrustify_check astyle_check clangformat_check cppcheck_check
         style cmakeformat_style yapf_style uncrustify_style astyle_style clangformat_style
-        clang_query_check interactive_clang_query_check clang_tidy_check)
+        clang_query_check interactive_clang_query_check clang_tidy_check clang_tidy_style)
     if(TARGET ${target})
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_ALL TRUE)
         set_property(TARGET ${target} PROPERTY EXCLUDE_FROM_DEFAULT_BUILD TRUE)
@@ -308,7 +315,17 @@ macro(blt_add_code_checks)
         blt_error_if_target_exists(${_clang_tidy_target_name} ${_error_msg})
         blt_add_clang_tidy_target( NAME              ${_clang_tidy_target_name}
                                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                                   FIX               FALSE
                                    SRC_FILES         ${_c_sources})
+
+        if(CLANGAPPLYREPLACEMENTS_FOUND)
+            set(_clang_tidy_target_name ${arg_PREFIX}_clang_tidy_style)
+            blt_error_if_target_exists(${_clang_tidy_target_name} ${_error_msg})
+            blt_add_clang_tidy_target( NAME              ${_clang_tidy_target_name}
+                                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                                       FIX               TRUE
+                                       SRC_FILES         ${_c_sources})
+        endif()
     endif()
 
 endmacro(blt_add_code_checks)
@@ -413,6 +430,9 @@ endmacro(blt_add_clang_query_target)
 ##                            SRC_FILES         [FILE1 [FILE2 ...]] )
 ##
 ## Creates a new target with the given NAME for running clang-tidy over the given SRC_FILES
+##
+## Note: The FIX option requires the CLANGAPPLYREPLACEMENTS_EXECUTABLE CMake variable
+## to be defined and to point to the `clang-apply-replacements` executable.
 ##-----------------------------------------------------------------------------
 macro(blt_add_clang_tidy_target)
     if(CLANGTIDY_FOUND)
@@ -427,7 +447,7 @@ macro(blt_add_clang_tidy_target)
 
         # Check required parameters
         if(NOT DEFINED arg_NAME)
-             message(FATAL_ERROR "blt_add_clang_tidy_target requires a NAME parameter")
+            message(FATAL_ERROR "blt_add_clang_tidy_target requires a NAME parameter")
         endif()
 
         if(NOT DEFINED arg_SRC_FILES)
@@ -441,10 +461,10 @@ macro(blt_add_clang_tidy_target)
         endif()
    
         set(CLANG_TIDY_HELPER_SCRIPT ${BLT_ROOT_DIR}/cmake/run-clang-tidy.py)
-        set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_SCRIPT} -clang-tidy-binary=${CLANGTIDY_EXECUTABLE} -p ${CMAKE_BINARY_DIR})
+        set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_SCRIPT} -clang-tidy-binary=${CLANGTIDY_EXECUTABLE} -p=${CMAKE_BINARY_DIR})
 
         if(arg_FIX)
-            set(CLANG_TIDY_HELPER_COMMAND ${CLANG_TIDY_HELPER_COMMAND} -fix)
+            list(APPEND CLANG_TIDY_HELPER_COMMAND -clang-apply-replacements-binary=${CLANGAPPLYREPLACEMENTS_EXECUTABLE} -fix)
         endif()
 
         if(DEFINED arg_CHECKS)

--- a/cmake/thirdparty/SetupThirdParty.cmake
+++ b/cmake/thirdparty/SetupThirdParty.cmake
@@ -110,6 +110,9 @@ if(CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja"
 
     blt_find_executable(NAME        ClangTidy
                         EXECUTABLES clang-tidy)
+
+    blt_find_executable(NAME        ClangApplyReplacements
+                        EXECUTABLES clang-apply-replacements)
 endif()
 
 #------------------------------------

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -273,6 +273,10 @@ coding standards and rules on your source code.  Clang-tidy is documented `here 
 ``CHECKS`` are the static analysis "rules" to specifically run on the target.
 If no checks are specified, clang-tidy will run the default available static analysis checks.
 
+.. note::
+  The ``FIX`` option requires ``clang-apply-replacements``, which is controlled by the ``ENABLE_CLANGAPPLYREPLACEMENTS`` CMake variable
+  and can be provided with the ``CLANGAPPLYREPLACEMENTS_EXECUTABLE`` CMake variable.
+
 
 .. _blt_add_astyle_target:
 

--- a/docs/api/code_check.rst
+++ b/docs/api/code_check.rst
@@ -63,6 +63,20 @@ functionality you will need to call the individual code check macros yourself.
   other codes.  The following check ``if ("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")``
   will stop your code checks from running unless you are the main CMake project.
 
+Enabled code checks produce a ``check`` build target that will test to see if you
+are out of compliance with your code formatting and a ``style`` build target that will actually
+modify your source files. These default names can be modified via the ``BLT_CODE_CHECK_TARGET_NAME``
+and ``BLT_CODE_STYLE_TARGET_NAME`` variables (e.g. if they conflict with existing project target names).
+
+Depending on enabled features, it also creates build targets that follow the following pattern
+``<PREFIX>_<astyle|clangformat|uncrustify|clang_tidy|cppcheck|clang_query>_<check|style>``.
+
+.. note::
+  Since clang-tidy can produce unsafe changes, BLT does not add ``clang_tidy_check`` to the main ``check``
+  target or ``clang_tidy_style`` to the main ``style`` target. User projects can do so by adding the following
+  CMake commands: ``add_dependencies(check clang_tidy_check)`` and/or ``add_dependencies(style clang_tidy_style)`` 
+  or can manually run the ``clang_tidy_check`` and ``clang_tidy_style`` targets.
+
 Sources are filtered based on file extensions for use in these code
 checks.  If you need additional file extensions defined add them to
 ``BLT_C_FILE_EXTS``, ``BLT_Python_FILE_EXTS``, ``BLT_CMAKE_FILE_EXTS``, and
@@ -88,7 +102,7 @@ This macro supports C/C++ code formatting with either AStyle, ClangFormat, or Un
   * ``UNCRUSTIFY_EXECUTABLE`` is defined and found prior to calling this macro
 
 .. note::
-  ClangFormat does not support a command line option for config files.  To work around this,
+  ClangFormat and clang-tidy do not support a command line option for config files.  To work around this,
   we copy the given config file to the build directory where this macro runs from.
 
 This macro also supports Python code formatting with Yapf only if the following requirements
@@ -102,10 +116,6 @@ This macro also supports CMake code formatting with CMakeFormat only if the foll
 * ``CMAKEFORMAT_CFG_FILE`` is given
 * ``CMAKEFORMAT_EXECUTABLE`` is defined and found prior to calling this macro
 
-Enabled code formatting checks produce a ``check`` build target that will test to see if you
-are out of compliance with your code formatting and a ``style`` build target that will actually
-modify your source files.  It also creates smaller child build targets that follow the pattern
-``<PREFIX>_<astyle|clangformat|uncrustify>_<check|style>``.
 
 If a particular version of a code formatting tool is required, you can
 configure BLT to enforce that version by setting
@@ -134,9 +144,8 @@ This macro supports the following static analysis tools with their requirements:
 - clang-tidy
 
   * ``CLANGTIDY_EXECUTABLE`` is defined and found prior to calling this macro
-
-These are added as children to the ``check`` build target and produce child build targets
-that follow the pattern ``<PREFIX>_<cppcheck|clang_query|clang_tidy>_check``.
+  * <optional> ``CLANGAPPLYREPLACEMENTS_EXECUTABLE`` should be defined and found prior to calling this macro
+    to support applying clang-tidy changes 
 
 
 .. _blt_add_clang_query_target:


### PR DESCRIPTION
Note: This feature relies on the `clang-apply-replacements` executable, which should be
provided via a CMake variable: `CLANGAPPLYREPLACEMENTS_EXECUTABLE`.