### PR TITLE
Harden finding ROCM_PATH

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,6 +17,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
   Also adds a corresponding `ENABLE_CLANGAPPLYREPLACEMENTS` CMake option.
   Note that the `clang_tidy_style` target is not added to the `style` target and must be run separately.
 
+### Changed
+- SetupHIP now searches for user-defined or environment variables before CMake paths to find the ROCM_PATH.
+
 ## [Version 0.5.3] - Release date 2023-06-05
 
 ### Changed

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -8,15 +8,28 @@
 ################################
 
 if(NOT ROCM_PATH)
+    # First try finding paths given by the user
     find_path(ROCM_PATH
         hip
-        ENV{ROCM_DIR}
-        ENV{ROCM_PATH}
-        ENV{HIP_PATH}
-        ${HIP_PATH}/..
-        ${HIP_ROOT_DIR}/../
-        ${ROCM_ROOT_DIR}
-        /opt/rocm)
+        PATHS
+          $ENV{ROCM_DIR}
+          $ENV{ROCM_PATH}
+          $ENV{HIP_PATH}
+          ${HIP_PATH}/..
+          ${HIP_ROOT_DIR}/../
+          ${ROCM_ROOT_DIR}
+          /opt/rocm
+        NO_DEFAULT_PATH
+        NO_CMAKE_ENVIRONMENT_PATH
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_SYSTEM_PATH)
+
+    # If that fails, use CMake default paths
+    if(NOT ROCM_PATH)
+        # First try finding paths given by the user
+        find_path(ROCM_PATH hip)
+    endif()
 endif()
 
 # Update CMAKE_PREFIX_PATH to make sure all the configs that hip depends on are

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -27,7 +27,6 @@ if(NOT ROCM_PATH)
 
     # If that fails, use CMake default paths
     if(NOT ROCM_PATH)
-        # First try finding paths given by the user
         find_path(ROCM_PATH hip)
     endif()
 endif()


### PR DESCRIPTION
A recent Spack change to `CachedCMakePackage` now adds a lot of paths to the `CMAKE_PREFIX_PATH`. This exposed that this `find_path` call was not as robust as it probably could be.

The failure was in Axom, where a combination of paths that seemed fine would confuse this `find_path` call to end up with `ROCM_PATH` set to `/opt/rocm-5.2.3/include` instead of `/opt/rocm-5.2.3`.

The idea here is that we search the user-provided paths first, then the CMake defaults if nothing is found.