### PR TITLE
Update SetupHIP.cmake

### DIFF
--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -33,7 +33,7 @@ endif()
 
 # Update CMAKE_PREFIX_PATH to make sure all the configs that hip depends on are
 # found.
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${ROCM_ROOT_DIR}/lib/cmake;${ROCM_PATH}")
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${ROCM_PATH};${ROCM_ROOT_DIR}/lib/cmake")
 
 find_package(hip REQUIRED CONFIG PATHS  ${HIP_PATH} ${ROCM_PATH} ${ROCM_ROOT_DIR}/lib/cmake/hip)
 

--- a/cmake/thirdparty/SetupHIP.cmake
+++ b/cmake/thirdparty/SetupHIP.cmake
@@ -33,9 +33,9 @@ endif()
 
 # Update CMAKE_PREFIX_PATH to make sure all the configs that hip depends on are
 # found.
-set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${ROCM_PATH}")
+set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};${ROCM_ROOT_DIR}/lib/cmake;${ROCM_PATH}")
 
-find_package(hip REQUIRED CONFIG PATHS ${HIP_PATH} ${ROCM_PATH})
+find_package(hip REQUIRED CONFIG PATHS  ${HIP_PATH} ${ROCM_PATH} ${ROCM_ROOT_DIR}/lib/cmake/hip)
 
 message(STATUS "ROCM path:        ${ROCM_PATH}")
 message(STATUS "HIP version:      ${hip_VERSION}")


### PR DESCRIPTION
The Rocm CMake paths are changing and it looks like RAJA, along with some other applications are going to break. In current releases FindHIP.cmake is in /opt/rocm/lib/cmake/hip. However, for backwards compatibility there has been a sym link in /opt/rocm/hip/cmake/FindHIP.cmake. That link is getting removed in up coming Rocm releases. Preemptively attempt to avoid breaking RAJA builds.