### PR TITLE
allow blt::cuda as target name for cuda

### DIFF
--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -369,8 +369,9 @@ macro(blt_setup_cuda_target)
 
     # Determine if cuda or cuda_runtime are in DEPENDS_ON
     list(FIND arg_DEPENDS_ON "cuda" _cuda_index)
+    list(FIND arg_DEPENDS_ON "blt::cuda" _cuda_index2)
     set(_depends_on_cuda FALSE)
-    if(${_cuda_index} GREATER -1)
+    if(${_cuda_index} GREATER -1 OR ${_cuda_index2} GREATER -1)
         set(_depends_on_cuda TRUE)
     endif()
     list(FIND arg_DEPENDS_ON "cuda_runtime" _cuda_runtime_index)

--- a/cmake/thirdparty/BLTSetupCUDA.cmake
+++ b/cmake/thirdparty/BLTSetupCUDA.cmake
@@ -163,6 +163,8 @@ blt_import_library(NAME          cuda
                    LINK_FLAGS    "${CMAKE_CUDA_LINK_FLAGS}"
                    EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})
 
+add_library(blt::cuda ALIAS cuda)
+
 # same as 'cuda' but we don't flag your source files as
 # CUDA language.  This causes your source files to use 
 # the regular C/CXX compiler. This is separate from 


### PR DESCRIPTION
What it says on the tin.  This is the minimum I could figure out to allow `blt::cuda` to mirror `blt::hip`.