### PR TITLE
Add blt namespace alias targets to mpi, cuda, cuda_runtime, and openmp

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Added the `blt_install_tpl_setups` macro, which installs files to setup and create
   targets for the third-party libraries OpenMP, MPI, CUDA, and HIP.  This macro is meant to 
   replace `blt_export_tpl_targets` as the preferred way to setup third-party libraries with BLT.
+- Added `blt::`` namespaced aliases for BLT targets, `cuda`, `cuda_runtime`, `mpi`, and `openmp`.
+  These targets still exist but but will be deprecated in a future release. It is recommended that you
+  move to the new alias names, `blt::cuda`, `blt::cuda_runtime`, `blt::mpi`, and `blt::openmp`
 
 ### Changed
 - SetupHIP now searches for user-defined or environment variables before CMake paths to find the ROCM_PATH.

--- a/cmake/BLTPrivateMacros.cmake
+++ b/cmake/BLTPrivateMacros.cmake
@@ -38,11 +38,13 @@ function(blt_fix_fortran_openmp_flags target_name)
             # from a "real" target back to a "fake" one as this is a sink vertex in
             # the DAG.  Only the link flags need to be modified.
             list(FIND target_link_libs "openmp" _omp_index)
-            if(${_omp_index} GREATER -1)
+            list(FIND target_link_libs "blt::openmp" _blt_omp_index)
+            if(${_omp_index} GREATER -1 OR ${_blt_omp_index} GREATER -1)
                 message(STATUS "Fixing OpenMP Flags for target[${target_name}]")
 
                 # Remove openmp from libraries
                 list(REMOVE_ITEM target_link_libs "openmp")
+                list(REMOVE_ITEM target_link_libs "blt::openmp")
                 set_target_properties( ${target_name} PROPERTIES
                                        LINK_LIBRARIES "${target_link_libs}" )
 

--- a/cmake/thirdparty/BLTSetupCUDA.cmake
+++ b/cmake/thirdparty/BLTSetupCUDA.cmake
@@ -175,4 +175,5 @@ blt_import_library(NAME       cuda_runtime
                    INCLUDES   ${CUDA_INCLUDE_DIRS}
                    LIBRARIES  ${CUDA_LIBRARIES}
                    EXPORTABLE ${BLT_EXPORT_THIRDPARTY})
+
 add_library(blt::cuda_runtime ALIAS cuda_runtime)

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -191,3 +191,5 @@ blt_import_library(NAME          mpi
                    COMPILE_FLAGS ${_mpi_compile_flags}
                    LINK_FLAGS    ${_mpi_link_flags}
                    EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})
+
+add_library(blt::mpi ALIAS mpi)

--- a/cmake/thirdparty/BLTSetupOpenMP.cmake
+++ b/cmake/thirdparty/BLTSetupOpenMP.cmake
@@ -56,3 +56,5 @@ blt_import_library(NAME openmp
                    COMPILE_FLAGS ${_compile_flags}
                    LINK_FLAGS    ${_link_flags}
                    EXPORTABLE    ${BLT_EXPORT_THIRDPARTY})
+
+add_library(blt::openmp ALIAS openmp)

--- a/docs/tutorial/calc_pi/CMakeLists.txt
+++ b/docs/tutorial/calc_pi/CMakeLists.txt
@@ -71,9 +71,9 @@ if(ENABLE_GTEST)
     if(MPI_FOUND)
     # _blt_tutorial_calcpi_test2_executable_start
         blt_add_library( NAME       calc_pi_mpi
-                        HEADERS    calc_pi_mpi.hpp calc_pi_mpi_exports.h
-                        SOURCES    calc_pi_mpi.cpp 
-                        DEPENDS_ON mpi)
+                         HEADERS    calc_pi_mpi.hpp calc_pi_mpi_exports.h
+                         SOURCES    calc_pi_mpi.cpp 
+                         DEPENDS_ON blt::mpi)
 
         if(WIN32 AND BUILD_SHARED_LIBS)
             target_compile_definitions(calc_pi_mpi PUBLIC WIN32_SHARED_LIBS)
@@ -86,8 +86,8 @@ if(ENABLE_GTEST)
 
     # _blt_tutorial_calcpi_test2_test_start
         blt_add_test( NAME          test_2 
-                    COMMAND       test_2
-                    NUM_MPI_TASKS 2) # number of mpi tasks to use
+                      COMMAND       test_2
+                      NUM_MPI_TASKS 2) # number of mpi tasks to use
     # _blt_tutorial_calcpi_test2_test_end
     endif()
 
@@ -99,9 +99,9 @@ if(ENABLE_GTEST)
     # _blt_tutorial_calcpi_cuda_start
         
         blt_add_library( NAME       calc_pi_cuda
-                        HEADERS    calc_pi_cuda.hpp calc_pi_cuda_exports.h
-                        SOURCES    calc_pi_cuda.cpp 
-                        DEPENDS_ON cuda)
+                         HEADERS    calc_pi_cuda.hpp calc_pi_cuda_exports.h
+                         SOURCES    calc_pi_cuda.cpp 
+                         DEPENDS_ON blt::cuda)
 
         if(WIN32 AND BUILD_SHARED_LIBS)
             target_compile_definitions(calc_pi_cuda PUBLIC WIN32_SHARED_LIBS)
@@ -109,10 +109,10 @@ if(ENABLE_GTEST)
 
         blt_add_executable( NAME       test_3
                             SOURCES    test_3.cpp 
-                            DEPENDS_ON calc_pi calc_pi_cuda gtest cuda_runtime)
+                            DEPENDS_ON calc_pi calc_pi_cuda gtest)
 
         blt_add_test( NAME    test_3
-                    COMMAND test_3)
+                      COMMAND test_3)
     # _blt_tutorial_calcpi_cuda_end
     endif()
 

--- a/docs/tutorial/common_hpc_dependencies.rst
+++ b/docs/tutorial/common_hpc_dependencies.rst
@@ -16,9 +16,10 @@ As previously mentioned in :ref:`AddingTests`, BLT also provides
 bundled versions of GoogleTest, GoogleMock, GoogleBenchmark, and FRUIT.  Not only are the source
 for these included, we provide named CMake targets for them as well.
 
-BLT's ``mpi``, ``cuda``, ``cuda_runtime``, ``blt::hip``, ``blt::hip_runtime``,and ``openmp`` targets are
-all defined via the :ref:`blt_import_library` macro. This creates a true CMake imported target that is inherited
-properly through the CMake's dependency graph.
+BLT's ``blt::mpi``, ``blt::cuda``, ``blt::cuda_runtime``, ``blt::hip``, ``blt::hip_runtime``,
+and ``blt::openmp`` targets are all defined via the :ref:`blt_import_library` macro.
+This creates a true CMake imported target that is inherited properly through the CMake's
+dependency graph.
 
 .. note::
     BLT also supports exporting its third-party targets via the ``BLT_EXPORT_THIRDPARTY`` option.
@@ -94,12 +95,12 @@ CUDA
 Finally, ``test_3`` builds and tests the ``calc_pi_cuda`` library,
 which uses CUDA to parallelize the calculation over the integration intervals.
 
-To enable CUDA, we set ``ENABLE_CUDA``, ``CMAKE_CUDA_COMPILER``, and
-``CUDA_TOOLKIT_ROOT_DIR`` in our host config file.  Also before enabling the
-CUDA language in CMake, you need to set ``CMAKE_CUDA_HOST_COMPILER`` in CMake 3.9+
-or ``CUDA_HOST_COMPILER`` in previous versions.  If you do not call 
-``enable_language(CUDA)``, BLT will set the appropriate host compiler variable
-for you and enable the CUDA language.
+To enable CUDA, we set ``ENABLE_CUDA``, ``CMAKE_CUDA_COMPILER``, 
+``CMAKE_CUDA_ARCHITECTURES``, and ``CUDA_TOOLKIT_ROOT_DIR`` in our host config file.
+Also before enabling the CUDA language in CMake, you need to set 
+``CMAKE_CUDA_HOST_COMPILER`` in CMake 3.9+ or ``CUDA_HOST_COMPILER`` in previous versions.
+If you do not call ``enable_language(CUDA)``, BLT will set the appropriate host
+compiler variable for you and enable the CUDA language.
 
 Here is a snippet with these settings for LLNL's Lassen Cluster:
 
@@ -115,11 +116,11 @@ Here, you can see how ``calc_pi_cuda`` and ``test_3`` use ``DEPENDS_ON``:
    :end-before:  _blt_tutorial_calcpi_cuda_end
    :language: cmake
 
-The ``cuda`` dependency for ``calc_pi_cuda``  is a little special, 
+The ``blt::cuda`` dependency for ``calc_pi_cuda`` is a little special, 
 along with adding the normal CUDA library and headers to your library or executable,
 it also tells BLT that this target's C/C++/CUDA source files need to be compiled via
 ``nvcc`` or ``cuda-clang``. If this is not a requirement, you can use the dependency
-``cuda_runtime`` which also adds the CUDA runtime library and headers but will not
+``blt::cuda_runtime`` which also adds the CUDA runtime library and headers but will not
 compile each source file with ``nvcc``.
 
 Some other useful CUDA flags are:
@@ -134,7 +135,7 @@ OpenMP
 ~~~~~~
 
 To enable OpenMP, set ``ENABLE_OPENMP`` in your host-config file or before loading
-``SetupBLT.cmake``.  Once OpenMP is enabled, simply add ``openmp`` to your library
+``SetupBLT.cmake``.  Once OpenMP is enabled, simply add ``blt::openmp`` to your library
 executable's ``DEPENDS_ON`` list.
 
 Here is an example of how to add an OpenMP enabled executable:
@@ -163,6 +164,7 @@ BLT also supports AMD's HIP via a mechanism very similar to our CUDA support.
 
 * ``ENABLE_HIP`` : Enables HIP support in BLT
 * ``HIP_ROOT_DIR`` : Root directory for HIP installation
+* ``CMAKE_HIP_ARCHITECTURES`` : GPU architecture to use when generating HIP/ROCm code
 
 **BLT Targets**
 

--- a/docs/tutorial/exporting_targets.rst
+++ b/docs/tutorial/exporting_targets.rst
@@ -54,7 +54,7 @@ Typical usage of the ``BLT_EXPORT_THIRDPARTY`` option is as follows:
     # Later, a project might mark a target as dependent on MPI
     blt_add_executable( NAME    example_1
                         SOURCES example_1.cpp
-                        DEPENDS_ON mpi )
+                        DEPENDS_ON blt::mpi )
 
     # Add the example_1 target to the example-targets export set
     install(TARGETS example_1 EXPORT example-targets)

--- a/tests/internal/CMakeLists.txt
+++ b/tests/internal/CMakeLists.txt
@@ -247,7 +247,7 @@ if (ENABLE_CUDA AND ENABLE_MPI AND
     blt_add_executable(
       NAME       test_cuda_mpi
       SOURCES    src/test_cuda_mpi.cpp
-      DEPENDS_ON cuda mpi hwloc)
+      DEPENDS_ON blt::cuda blt::mpi hwloc)
 
     # Tests on a 2^24 elements array.
     # It can go much bigger, but will not
@@ -260,13 +260,13 @@ endif()
 # Exercise blt_print_target_properties macro
 message(STATUS "")
 message(STATUS "Exercising blt_print_target_properties macro default options.")
-foreach(_target gtest gbenchmark example t_example_smoke not-a-target blt_header_only mpi cuda cuda_runtime blt::hip blt::hip_runtime)
+foreach(_target gtest gbenchmark example t_example_smoke not-a-target blt_header_only blt::mpi blt::cuda blt::cuda_runtime blt::hip blt::hip_runtime)
     blt_print_target_properties(TARGET ${_target})
 endforeach()
 
 message(STATUS "")
 message(STATUS "Exercising blt_print_target_properties macro using regex arguments.")
-foreach(_target gtest example t_example_smoke not-a-target blt_header_only mpi cuda cuda_runtime blt::hip blt::hip_runtime)
+foreach(_target gtest example t_example_smoke not-a-target blt_header_only blt::mpi blt::cuda blt::cuda_runtime blt::hip blt::hip_runtime)
     blt_print_target_properties(TARGET ${_target} CHILDREN true PROPERTY_NAME_REGEX "CXX_STANDARD_REQUIRED" PROPERTY_VALUE_REGEX "ON")
 endforeach()
 
@@ -449,10 +449,10 @@ endif()
 
 # create example depending on all available TPLs to test export
 set(_example_tpl_depends)
-blt_list_append(TO _example_tpl_depends ELEMENTS cuda cuda_runtime IF ENABLE_CUDA)
-blt_list_append(TO _example_tpl_depends ELEMENTS blt_hip blt_hip_runtime IF ENABLE_HIP)
-blt_list_append(TO _example_tpl_depends ELEMENTS openmp IF ENABLE_OPENMP)
-blt_list_append(TO _example_tpl_depends ELEMENTS mpi IF ENABLE_MPI)
+blt_list_append(TO _example_tpl_depends ELEMENTS blt::cuda blt::cuda_runtime IF ENABLE_CUDA)
+blt_list_append(TO _example_tpl_depends ELEMENTS blt::hip blt::hip_runtime IF ENABLE_HIP)
+blt_list_append(TO _example_tpl_depends ELEMENTS blt::openmp IF ENABLE_OPENMP)
+blt_list_append(TO _example_tpl_depends ELEMENTS blt::mpi IF ENABLE_MPI)
 
 blt_add_library( NAME    example-with-tpls
                  SOURCES "src/Example.cpp"

--- a/tests/internal/src/test_cuda_device_call_from_kernel/CMakeLists.txt
+++ b/tests/internal/src/test_cuda_device_call_from_kernel/CMakeLists.txt
@@ -19,14 +19,14 @@ set(t_cuda_device_call_from_kernel_sources
 blt_add_library(NAME       t_cuda_device_call_from_kernel_lib
                 SOURCES    ${t_cuda_device_call_from_kernel_sources}
                 HEADERS    ${t_cuda_device_call_from_kernel_headers}
-                DEPENDS_ON cuda)
+                DEPENDS_ON blt::cuda)
 
 set(t_cuda_device_call_from_kernel_exec_src
     CudaTests.cpp)
 
 blt_add_executable( NAME       t_cuda_device_call_from_kernel_exec
                     SOURCES    ${t_cuda_device_call_from_kernel_exec_src}
-                    DEPENDS_ON t_cuda_device_call_from_kernel_lib gtest cuda)
+                    DEPENDS_ON t_cuda_device_call_from_kernel_lib gtest blt::cuda)
 
 blt_add_test(NAME    t_cuda_device_call_from_kernel
              COMMAND t_cuda_device_call_from_kernel_exec)

--- a/tests/internal/unit/CMakeLists.txt
+++ b/tests/internal/unit/CMakeLists.txt
@@ -175,10 +175,10 @@ else()
 endif()
 
 if(ENABLE_HIP)
-  message(STATUS "Checking blt_hip_runtime imported target in blt_check_code_compiles")
+  message(STATUS "Checking blt::hip_runtime imported target in blt_check_code_compiles")
   blt_check_code_compiles(CODE_COMPILES  _hello_world_with_libs_compiled
                           VERBOSE_OUTPUT ON
-                          DEPENDS_ON blt_hip_runtime
+                          DEPENDS_ON blt::hip_runtime
                           SOURCE_STRING
   [=[
   #include <iostream>

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -94,7 +94,7 @@ if (ENABLE_OPENMP)
     blt_add_executable(NAME blt_openmp_smoke 
                        SOURCES blt_openmp_smoke.cpp 
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON openmp
+                       DEPENDS_ON blt::openmp
                        FOLDER blt/tests )
     # _blt_tutorial_openmp_executable_end
 
@@ -113,7 +113,7 @@ if (ENABLE_MPI)
     blt_add_executable(NAME blt_mpi_smoke
                        SOURCES blt_mpi_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON mpi
+                       DEPENDS_ON blt::mpi
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_mpi_smoke
@@ -128,7 +128,7 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_smoke
                        SOURCES blt_cuda_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda
+                       DEPENDS_ON blt::cuda
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_smoke
@@ -137,7 +137,7 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_runtime_smoke
                        SOURCES blt_cuda_runtime_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda_runtime
+                       DEPENDS_ON blt::cuda_runtime
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_runtime_smoke
@@ -146,7 +146,7 @@ if (ENABLE_CUDA)
     blt_add_executable(NAME blt_cuda_version_smoke
                        SOURCES blt_cuda_version_smoke.cpp
                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                       DEPENDS_ON cuda_runtime
+                       DEPENDS_ON blt::cuda_runtime
                        FOLDER blt/tests )
 
     blt_add_test(NAME blt_cuda_version_smoke
@@ -155,7 +155,7 @@ if (ENABLE_CUDA)
         blt_add_executable(NAME blt_cuda_openmp_smoke
                            SOURCES blt_cuda_openmp_smoke.cpp
                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
-                           DEPENDS_ON cuda openmp
+                           DEPENDS_ON blt::cuda blt::openmp
                            FOLDER blt/tests )
 
         blt_add_test(NAME blt_cuda_openmp_smoke
@@ -166,7 +166,7 @@ if (ENABLE_CUDA)
         blt_add_executable(NAME       blt_cuda_mpi_smoke
                            SOURCES    blt_cuda_mpi_smoke.cpp
                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON cuda mpi
+                           DEPENDS_ON blt::cuda blt::mpi
                            FOLDER blt/tests )
         blt_add_test(NAME    blt_cuda_mpi_smoke
                      COMMAND blt_cuda_mpi_smoke
@@ -177,7 +177,7 @@ if (ENABLE_CUDA)
         blt_add_executable(NAME blt_cuda_gtest_smoke
                            SOURCES blt_cuda_gtest_smoke.cpp
                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON cuda gtest
+                           DEPENDS_ON blt::cuda gtest
                            FOLDER blt/tests )
 
         blt_add_test(NAME    blt_cuda_gtest_smoke


### PR DESCRIPTION
This creates an `ALIAS` target to the following targets:

* `cuda` -> `blt::cuda` (done in a previous PR)
* `cuda_runtime` -> `blt::cuda_runtime` (done in a previous PR)
* `mpi` -> `blt::mpi`
* `openmp` -> `blt::openmp`

Also updates documentation and internal tests to use the targets.

Note: I would like to do a breaking release of BLT soon and plan to rename the underlying targets to `blt_<name>`.