### PR TITLE
Fixes `blt_check_code_compiles` to work witih alias targets

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -22,7 +22,7 @@
 .build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 10 -q pci"
+    ALLOC_COMMAND: "lalloc 1 -W 15 -q pci"
   extends: [.build_script, .on_lassen]
   needs: []
 
@@ -31,7 +31,7 @@
 .run_project_integration_test_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 10 -q pci"
+    ALLOC_COMMAND: "lalloc 1 -W 15 -q pci"
   extends: [.run_project_integration_tests, .on_lassen]
   needs: []
 

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -22,7 +22,7 @@
 .build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 10 -q pdebug"
+    ALLOC_COMMAND: "lalloc 1 -W 10 -q pci"
   extends: [.build_script, .on_lassen]
   needs: []
 
@@ -31,7 +31,7 @@
 .run_project_integration_test_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: "lalloc 1 -W 10 -q pdebug"
+    ALLOC_COMMAND: "lalloc 1 -W 10 -q pci"
   extends: [.run_project_integration_tests, .on_lassen]
   needs: []
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -19,7 +19,7 @@ quartz_allocate:
   extends: [.on_quartz]
   stage: allocate
   script:
-    - salloc -p pdebug -N 1 -t 10 --no-shell --job-name=${PROJECT_ALLOC_NAME} --mpibind=off
+    - salloc --res=ci -N 1 -t 10 --no-shell --job-name=${PROJECT_ALLOC_NAME} --mpibind=off
   needs: []
 
 ####
@@ -39,7 +39,7 @@ quartz_release:
 .build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun --res=ci -t 10 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.build_script, .on_quartz]
   needs: [quartz_allocate]
 
@@ -48,7 +48,7 @@ quartz_release:
 .run_project_integration_test_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun --res=ci -t 10 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.run_project_integration_tests, .on_quartz]
   needs: [quartz_allocate]
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -39,7 +39,7 @@ quartz_release:
 .build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun -t 15 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.build_script, .on_quartz]
   needs: [quartz_allocate]
 
@@ -48,7 +48,7 @@ quartz_release:
 .run_project_integration_test_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun -t 15 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.run_project_integration_tests, .on_quartz]
   needs: [quartz_allocate]
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -39,7 +39,7 @@ quartz_release:
 .build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun --res=ci -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun -t 10 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.build_script, .on_quartz]
   needs: [quartz_allocate]
 
@@ -48,7 +48,7 @@ quartz_release:
 .run_project_integration_test_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun --res=ci -t 10 -N 1 ${ASSIGN_ID} --interactive"
+    ALLOC_COMMAND: "srun -t 10 -N 1 ${ASSIGN_ID} --interactive"
   extends: [.run_project_integration_tests, .on_quartz]
   needs: [quartz_allocate]
 

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -31,7 +31,7 @@ tioga-clang_14_0_0_hip:
   variables:
     HOST_CONFIG: "clang@14.0.0_hip.cmake"
   extends: .src_build_on_tioga
-  allow_failure: true
+
 
 ####
 # HIP project tests

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -14,7 +14,7 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux run -t10m -n1"
+    ALLOC_COMMAND: "flux run -t10m -n1 --queue pci"
   extends: [.build_script, .on_tioga]
 
 ####
@@ -22,7 +22,7 @@
 .run_project_integration_test_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux mini run -t10m -n1"
+    ALLOC_COMMAND: "flux run -t10m -n1 --queue pci"
   extends: [.run_project_integration_tests, .on_tioga]
 
 ####

--- a/.gitlab/build_tioga.yml
+++ b/.gitlab/build_tioga.yml
@@ -14,7 +14,7 @@
 .src_build_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux run -t10m -n1 --queue pci"
+    ALLOC_COMMAND: "flux run -t15m -n1 --queue pci"
   extends: [.build_script, .on_tioga]
 
 ####
@@ -22,7 +22,7 @@
 .run_project_integration_test_on_tioga:
   stage: build
   variables:
-    ALLOC_COMMAND: "flux run -t10m -n1 --queue pci"
+    ALLOC_COMMAND: "flux run -t15m -n1 --queue pci"
   extends: [.run_project_integration_tests, .on_tioga]
 
 ####

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -28,6 +28,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ### Fixed
 - Fixed infinite loop in `blt_find_target_dependencies`
+- `blt_check_code_compiles` now works with alias targets
 
 ## [Version 0.5.3] - Release date 2023-06-05
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1229,6 +1229,8 @@ macro(blt_check_code_compiles)
                     list(APPEND _deps ${_real_target})
                 endif()
             endforeach()
+        else()
+            set(_deps {arg_DEPENDS_ON})
         endif()
 
         try_compile(${arg_CODE_COMPILES}

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -1217,11 +1217,25 @@ macro(blt_check_code_compiles)
                 CXX_STANDARD ${CMAKE_CXX_STANDARD}
                 OUTPUT_VARIABLE _res)
     else()
+
+        if(${CMAKE_VERSION} VERSION_LESS "3.28.0")
+            # Workaround CMake bug where try_compile doesn't work with alias targets
+            set(_deps)
+            foreach(_dep ${arg_DEPENDS_ON})
+                get_target_property(_real_target ${_dep} ALIASED_TARGET)
+                if (NOT _real_target)
+                    list(APPEND _deps ${_dep})
+                else()
+                    list(APPEND _deps ${_real_target})
+                endif()
+            endforeach()
+        endif()
+
         try_compile(${arg_CODE_COMPILES}
                 ${CMAKE_CURRENT_BINARY_DIR}/CMakeTmp
                 SOURCES ${_fname}
                 CXX_STANDARD ${CMAKE_CXX_STANDARD}
-                LINK_LIBRARIES ${arg_DEPENDS_ON}
+                LINK_LIBRARIES ${_deps}
                 OUTPUT_VARIABLE _res)
     endif()
     file(REMOVE ${_fname})

--- a/host-configs/llnl/toss_4_x86_64_ib_cray/cce@13.0.1_clang_hip.cmake
+++ b/host-configs/llnl/toss_4_x86_64_ib_cray/cce@13.0.1_clang_hip.cmake
@@ -34,6 +34,10 @@ set(MPI_CXX_COMPILER "${MPI_HOME}/bin/mpicxx" CACHE PATH "")
 
 set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpif90" CACHE PATH "")
 
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
 #------------------------------------------------------------------------------
 # HIP support
 #------------------------------------------------------------------------------

--- a/host-configs/llnl/toss_4_x86_64_ib_cray/cce@13.0.1_clang_hip_c++17.cmake
+++ b/host-configs/llnl/toss_4_x86_64_ib_cray/cce@13.0.1_clang_hip_c++17.cmake
@@ -37,6 +37,10 @@ set(MPI_CXX_COMPILER "${MPI_HOME}/bin/mpicxx" CACHE PATH "")
 
 set(MPI_Fortran_COMPILER "${MPI_HOME}/bin/mpif90" CACHE PATH "")
 
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
+
+set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
+
 #------------------------------------------------------------------------------
 # HIP support
 #------------------------------------------------------------------------------

--- a/host-configs/llnl/toss_4_x86_64_ib_cray/clang@14.0.0_hip.cmake
+++ b/host-configs/llnl/toss_4_x86_64_ib_cray/clang@14.0.0_hip.cmake
@@ -29,7 +29,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-
 
 set(MPI_Fortran_COMPILER "/usr/tce/packages/cray-mpich-tce/cray-mpich-8.1.16-rocmcc-5.1.1/bin/mpif90" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/usr/bin/srun" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "/usr/global/tools/flux_wrappers/bin/srun" CACHE PATH "")
 
 set(MPIEXEC_NUMPROC_FLAG "-n" CACHE STRING "")
 


### PR DESCRIPTION
Fixes #670 .

Also swaps to the new CI partition and turns off `allow_failures` on Tioga.