### PR TITLE
Support if(... IN_LIST ...) in downstream non-blt projects

### DIFF
--- a/cmake/BLTSetupTargets.cmake
+++ b/cmake/BLTSetupTargets.cmake
@@ -8,6 +8,12 @@
 # The macro `blt_install_tpl_setups(DESTINATION <dir>)` installs this file
 # into the destination specified by the argument <dir>.
 
+# Support IN_LIST operator for if()
+# Policy added in 3.3+
+if(POLICY CMP0057)
+    cmake_policy(SET CMP0057 NEW)
+endif()
+
 # BLTInstallableMacros provides helper macros for setting up and creating
 # third-party library targets.  The below guard prevents the file from 
 # included twice when a project builds using BLT.


### PR DESCRIPTION
Error case:

* BLT project, "Foo", installs BLT targets via `blt_install_tpl_setups()` macro
* Downstream Non-BLT project loads Foo's installed config which includes' BLT's targets
* Downstream project possibly fails when BLT uses an `if` with an `IN_LIST` operator