### PR TITLE
Remove GNUInstallDirs from Builtin TPLs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Fixed
+- Removed GoogleTest, GoogleMock, and GoogleBenchmarks calling CMake's `GNUInstallDirs`
+  which was causing non-deterministic install variables depending on your combination of
+  static/shared libraries and if any of the previously mentioned TPLs were enabled.
+
 ## [Version 0.6.2] - Release date 2024-03-15
 
 ### Added

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -18,17 +18,17 @@ endif()
 # so we removed it and temporarily created variables it was creating, if the user
 # project has not set them already. These are restored to their values below.
 set(CMAKE_INSTALL_BINDIR_saved ${CMAKE_INSTALL_BINDIR})
-if(CMAKE_INSTALL_BINDIR)
+if(NOT CMAKE_INSTALL_BINDIR)
   set(CMAKE_INSTALL_BINDIR "bin")
 endif()
 
 set(CMAKE_INSTALL_DOCDIR_saved ${CMAKE_INSTALL_DOCDIR})
-if(CMAKE_INSTALL_DOCDIR)
+if(NOT CMAKE_INSTALL_DOCDIR)
   set(CMAKE_INSTALL_DOCDIR "share/docs")
 endif()
 
 set(CMAKE_INSTALL_INCLUDEDIR_saved ${CMAKE_INSTALL_INCLUDEDIR})
-if(CMAKE_INSTALL_INCLUDEDIR)
+if(NOT CMAKE_INSTALL_INCLUDEDIR)
   set(CMAKE_INSTALL_INCLUDEDIR "include")
 endif()
 

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -13,6 +13,30 @@ if(ENABLE_GBENCHMARK OR ENABLE_GTEST OR ENABLE_GMOCK)
   endif()
 endif()
 
+# NOTE: GoogleBenchmark, GoogleTest, and GoogleMock all rely on GNUInstallDir.
+# This was causing bleeding of settings in BLT projects that don't use that,
+# so we removed it and temporarily created variables it was creating, if the user
+# project has not set them already. These are restored to their values below.
+set(CMAKE_INSTALL_BINDIR_saved ${CMAKE_INSTALL_BINDIR})
+if(CMAKE_INSTALL_BINDIR)
+  set(CMAKE_INSTALL_BINDIR "bin")
+endif()
+
+set(CMAKE_INSTALL_DOCDIR_saved ${CMAKE_INSTALL_DOCDIR})
+if(CMAKE_INSTALL_DOCDIR)
+  set(CMAKE_INSTALL_DOCDIR "share/docs")
+endif()
+
+set(CMAKE_INSTALL_INCLUDEDIR_saved ${CMAKE_INSTALL_INCLUDEDIR})
+if(CMAKE_INSTALL_INCLUDEDIR)
+  set(CMAKE_INSTALL_INCLUDEDIR "include")
+endif()
+
+set(CMAKE_INSTALL_LIBDIR_saved ${CMAKE_INSTALL_LIBDIR})
+if(NOT CMAKE_INSTALL_LIBDIR)
+  set(CMAKE_INSTALL_LIBDIR "lib")
+endif()
+
 if(ENABLE_TESTS)
     include(CTest)
 
@@ -165,6 +189,14 @@ if(ENABLE_BENCHMARKS)
                       COMMAND ctest -C Benchmark -VV
                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
+
+# Restore user set install variables
+
+foreach(_var CMAKE_INSTALL_BINDIR CMAKE_INSTALL_DOCDIR CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR)
+    if(${_var}_saved)
+      set(${_var} ${${_var}_saved} CACHE PATH "")
+    endif()
+endforeach()
 
 # Set the folder property of the blt thirdparty libraries 
 if(ENABLE_FOLDERS)

--- a/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt
+++ b/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt
@@ -1,5 +1,4 @@
 # Allow the source files to find headers in src/
-include(GNUInstallDirs)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 
 if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)

--- a/thirdparty_builtin/googletest/CMakeLists.txt
+++ b/thirdparty_builtin/googletest/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 enable_testing()
 
 include(CMakeDependentOption)
-include(GNUInstallDirs)
 
 #Note that googlemock target already builds googletest
 option(BUILD_GMOCK "Builds the googlemock subproject" ON)

--- a/thirdparty_builtin/patches/gbenchmark-2024_06_19-remove_gnuinstalldirs.patch
+++ b/thirdparty_builtin/patches/gbenchmark-2024_06_19-remove_gnuinstalldirs.patch
@@ -1,0 +1,10 @@
+diff --git a/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt b/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt
+index 91ea5f4..876ea3b 100644
+--- a/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt
++++ b/thirdparty_builtin/benchmark-1.8.0/src/CMakeLists.txt
+@@ -1,5 +1,4 @@
+ # Allow the source files to find headers in src/
+-include(GNUInstallDirs)
+ include_directories(${PROJECT_SOURCE_DIR}/src)
+ 
+ if (DEFINED BENCHMARK_CXX_LINKER_FLAGS)

--- a/thirdparty_builtin/patches/gtest-2024_06_19-remove_gnuinstalldirs.patch
+++ b/thirdparty_builtin/patches/gtest-2024_06_19-remove_gnuinstalldirs.patch
@@ -1,0 +1,12 @@
+diff --git a/thirdparty_builtin/googletest/CMakeLists.txt b/thirdparty_builtin/googletest/CMakeLists.txt
+index b5ae2b0..7a18477 100644
+--- a/thirdparty_builtin/googletest/CMakeLists.txt
++++ b/thirdparty_builtin/googletest/CMakeLists.txt
+@@ -23,7 +23,6 @@ endif()
+ enable_testing()
+ 
+ include(CMakeDependentOption)
+-include(GNUInstallDirs)
+ 
+ #Note that googlemock target already builds googletest
+ option(BUILD_GMOCK "Builds the googlemock subproject" ON)


### PR DESCRIPTION
This was bleeding into user installs. I am not sure how this wasn't causing problems before.