### PR TITLE
Harden two cases where projects do not enable C as a language

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,6 +13,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Removed GoogleTest, GoogleMock, and GoogleBenchmarks calling CMake's `GNUInstallDirs`
   which was causing non-deterministic install variables depending on your combination of
   static/shared libraries and if any of the previously mentioned TPLs were enabled.
+- Enable C language support and emit a warning when GoogleTest or GoogleMock are enabled but
+  not the C language.
+- Guard HIP C smoketest against projects that don't enable C as a language in their projects.
 
 ## [Version 0.6.2] - Release date 2024-03-15
 

--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -210,14 +210,17 @@ if (ENABLE_HIP)
     blt_add_test(NAME blt_hip_runtime_smoke
                  COMMAND blt_hip_runtime_smoke)
 
-    blt_add_executable(NAME blt_hip_runtime_c_smoke
-                       SOURCES blt_hip_runtime_c_smoke.c
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON blt::hip_runtime
-                       FOLDER blt/tests )
+    get_property(_enabled_langs GLOBAL PROPERTY ENABLED_LANGUAGES)
+    if("C" IN_LIST _enabled_langs)
+        blt_add_executable(NAME blt_hip_runtime_c_smoke
+                        SOURCES blt_hip_runtime_c_smoke.c
+                        OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
+                        DEPENDS_ON blt::hip_runtime
+                        FOLDER blt/tests )
 
-    blt_add_test(NAME blt_hip_runtime_c_smoke
-                 COMMAND blt_hip_runtime_c_smoke)
+        blt_add_test(NAME blt_hip_runtime_c_smoke
+                    COMMAND blt_hip_runtime_c_smoke)
+    endif()
 
     if(ENABLE_GTEST)
         blt_add_executable(NAME blt_hip_gtest_smoke

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -84,7 +84,19 @@ if(ENABLE_TESTS)
 
     message(STATUS "Google Test Support is ${ENABLE_GTEST}")
     message(STATUS "Google Mock Support is ${ENABLE_GMOCK}")
-    
+
+    # GoogleMock and GoogleTest both require the C language enabled.
+    # This can cause problems due to the language being enabled globally
+    # but variables like CMAKE_C_COMPILE_OBJECT being created directory scoped.
+    # Enable the C language for them but omit a warning.
+    if(ENABLE_GTEST OR ENABLE_GMOCK)
+      get_property(_enabled_langs GLOBAL PROPERTY ENABLED_LANGUAGES)
+      if(NOT "C" IN_LIST _enabled_langs)
+          message(WARNING "Enabling the C language due to Google Mock|Test requiring it. To quiet this warning, add C to your project(...) call.")
+          enable_language(C)
+      endif()
+    endif()
+
     #
     # Guard of googletest w/ ENABLE_GTEST
     # In BLT, ENABLE_GTEST is also required when using ENABLE_GMOCK


### PR DESCRIPTION
Fixes #660

This PR does two things:

* Guards a smoke test against projects who don't enable C as a language
* Enables the C language, and emits a warning, when projects use GTest or GMock and don't have the required C language enabled.

The latter is required due to GTest|GMock turning on C, which in CMake enables the language globally but several needed CMake variables are directory scoped. This causes a CMake error like this:

```
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_C_COMPILE_OBJECT
CMake Error: Error required internal CMake variable not set, cmake may not be built correctly.
Missing variable is:
CMAKE_C_LINK_EXECUTABLE
-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

The omitted warning looks like this:

```
CMake Warning at blt/repo/thirdparty_builtin/CMakeLists.txt:95 (message):
  Enabling the C language due to Google Mock|Test requiring it.  To quiet
  this warning, add C to your project(...) call.
```

@rcarson3