### PR TITLE
Prevent general tests from running while running benchmarks custom target

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Enable C language support and emit a warning when GoogleTest or GoogleMock are enabled but
   not the C language.
 - Guard HIP C smoketest against projects that don't enable C as a language in their projects.
+- Changes benchmark custom target `run_benchmarks` to exclusively run benchmarks (not other general tests).
 
 ## [Version 0.6.2] - Release date 2024-03-15
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -480,11 +480,13 @@ macro(blt_add_benchmark)
     cmake_parse_arguments(arg
      "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
 
+    # The 'CONFIGURATIONS Benchmark' line excludes benchmarks 
+    # from the general list of tests
     blt_add_test( NAME            ${arg_NAME}
                   COMMAND         ${arg_COMMAND}
                   NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
                   NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
-                  CONFIGURATIONS  ${arg_CONFIGURATIONS})
+                  CONFIGURATIONS  Benchmarks ${arg_CONFIGURATIONS})
 
     # The 'LABELS Benchmark` prevents regular tests from
     # running when running benchmarks custom target

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -480,13 +480,16 @@ macro(blt_add_benchmark)
     cmake_parse_arguments(arg
      "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN} )
 
-    # The 'CONFIGURATIONS Benchmark' line excludes benchmarks 
-    # from the general list of tests
     blt_add_test( NAME            ${arg_NAME}
                   COMMAND         ${arg_COMMAND}
                   NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
                   NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
-                  CONFIGURATIONS  Benchmark ${arg_CONFIGURATIONS})
+                  CONFIGURATIONS  ${arg_CONFIGURATIONS})
+
+    # The 'LABELS Benchmark` prevents regular tests from
+    # running when running benchmarks custom target
+    set_tests_properties( ${arg_NAME}
+                          PROPERTIES LABELS "Benchmark")
 
 endmacro(blt_add_benchmark)
 

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -486,7 +486,7 @@ macro(blt_add_benchmark)
                   COMMAND         ${arg_COMMAND}
                   NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
                   NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
-                  CONFIGURATIONS  Benchmarks ${arg_CONFIGURATIONS})
+                  CONFIGURATIONS  Benchmark ${arg_CONFIGURATIONS})
 
     # The 'LABELS Benchmark` prevents regular tests from
     # running when running benchmarks custom target

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -40,8 +40,8 @@ CONFIGURATIONS
 
 This macro adds a benchmark test to the ``Benchmark`` CTest configuration
 which can be run by the ``run_benchmarks`` build target.  These tests are
-not run when you use the regular ``test`` build target.  The ``test``
-build target will not run benchmarks.
+not run when you use the regular ``test`` build target.  The ``run_benchmarks``
+build target will not run regular tests.
 
 This macro is just a thin wrapper around :ref:`blt_add_test` and assists 
 with building up the correct command line for running the benchmark.  For more

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -40,7 +40,8 @@ CONFIGURATIONS
 
 This macro adds a benchmark test to the ``Benchmark`` CTest configuration
 which can be run by the ``run_benchmarks`` build target.  These tests are
-not run when you use the regular ``test`` build target.
+not run when you use the regular ``test`` build target.  The ``test``
+build target will not run benchmarks.
 
 This macro is just a thin wrapper around :ref:`blt_add_test` and assists 
 with building up the correct command line for running the benchmark.  For more

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -198,7 +198,7 @@ if(ENABLE_BENCHMARKS)
 
     # This sets up a target to run the benchmarks
     add_custom_target(${BLT_RUN_BENCHMARKS_TARGET_NAME}
-                      COMMAND ctest -L Benchmark -VV
+                      COMMAND ctest -C Benchmark -L Benchmark -VV
                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
 

--- a/thirdparty_builtin/CMakeLists.txt
+++ b/thirdparty_builtin/CMakeLists.txt
@@ -198,7 +198,7 @@ if(ENABLE_BENCHMARKS)
 
     # This sets up a target to run the benchmarks
     add_custom_target(${BLT_RUN_BENCHMARKS_TARGET_NAME}
-                      COMMAND ctest -C Benchmark -VV
+                      COMMAND ctest -L Benchmark -VV
                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
 


### PR DESCRIPTION
### Issue

It is expected only benchmarks should run when executing `make run_benchmarks`.

The configuration `-C` option in `add_custom_target` prevents benchmarks from running while executing `make test`. However, all tests and benchmarks run while executing `make run_benchmarks`.

### This PR

Adds a "Benchmark" label `-L`. This means now only benchmarks will run during `make run_benchmarks`. And `make test` remains to only run general tests, no benchmarks.