### PR TITLE
Add WORKING_DIRECTORY option to benchmarks and tests

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,8 +9,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Added
+- Added ``WORKING_DIRECTORY`` option to ``blt_add_test`` and ``blt_add_benchmark``.
+
 ### Changed
-- Modified `blt_convert_to_system_includes` to handle multiple targets and recursively update includes for dependencies
+- Modified `blt_convert_to_system_includes` to handle multiple targets and recursively update includes for dependencies.
 
 ### Fixed
 - Removed GoogleTest, GoogleMock, and GoogleBenchmarks calling CMake's `GNUInstallDirs`

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -471,11 +471,11 @@ endmacro(blt_add_test)
 
 
 ##------------------------------------------------------------------------------
-## blt_add_benchmark( NAME          [name] 
-##                    COMMAND       [command]
-##                    NUM_MPI_TASKS [n]
-##                    NUM_OMP_THREADS [n]
-##                    CONFIGURATIONS  [config1 [config2...]]
+## blt_add_benchmark( NAME              [name] 
+##                    COMMAND           [command]
+##                    NUM_MPI_TASKS     [n]
+##                    NUM_OMP_THREADS   [n]
+##                    CONFIGURATIONS    [config1 [config2...]]
 ##                    WORKING_DIRECTORY [dir])
 ##
 ## Adds a benchmark to the project.

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -374,18 +374,19 @@ endmacro(blt_add_executable)
 
 
 ##------------------------------------------------------------------------------
-## blt_add_test( NAME            [name]
-##               COMMAND         [command] 
-##               NUM_MPI_TASKS   [n]
-##               NUM_OMP_THREADS [n]
-##               CONFIGURATIONS  [config1 [config2...]])
+## blt_add_test( NAME              [name]
+##               COMMAND           [command] 
+##               NUM_MPI_TASKS     [n]
+##               NUM_OMP_THREADS   [n]
+##               CONFIGURATIONS    [config1 [config2...]]
+##               WORKING_DIRECTORY [dir])
 ##
 ## Adds a test to the project.
 ##------------------------------------------------------------------------------
 macro(blt_add_test)
 
     set(options )
-    set(singleValueArgs NAME NUM_MPI_TASKS NUM_OMP_THREADS)
+    set(singleValueArgs NAME NUM_MPI_TASKS NUM_OMP_THREADS WORKING_DIRECTORY)
     set(multiValueArgs COMMAND CONFIGURATIONS)
 
     # Parse the arguments to the macro
@@ -398,6 +399,13 @@ macro(blt_add_test)
 
     if ( NOT DEFINED arg_COMMAND )
         message(FATAL_ERROR "COMMAND is a required parameter to blt_add_test")
+    endif()
+
+    # Set default working directory if not set
+    if ( NOT DEFINED arg_WORKING_DIRECTORY )
+        set(_working_directory ${CMAKE_CURRENT_BINARY_DIR})
+    else()
+        set(_working_directory ${arg_WORKING_DIRECTORY})
     endif()
 
     # Extract test directory and executable from arg_NAME and arg_COMMAND
@@ -415,14 +423,14 @@ macro(blt_add_test)
     endif()
     
     # Append the test_directory to the test argument, accounting for multi-config generators
-    if(NOT CMAKE_CONFIGURATION_TYPES)
+    if( NOT CMAKE_CONFIGURATION_TYPES )
         if(NOT "${_test_directory}" STREQUAL "")
             set(_test_command ${_test_directory}/${arg_COMMAND} )
         else()
             set(_test_command ${arg_COMMAND})
         endif()
     else()
-        if(TARGET ${_test_executable})
+        if( TARGET ${_test_executable} )
             list(INSERT arg_COMMAND 0 "$<TARGET_FILE:${_test_executable}>")
             list(REMOVE_AT arg_COMMAND 1)
         endif()
@@ -450,7 +458,8 @@ macro(blt_add_test)
 
     add_test(NAME           ${arg_NAME}
              COMMAND        ${_test_command}
-             CONFIGURATIONS ${arg_CONFIGURATIONS})
+             CONFIGURATIONS ${arg_CONFIGURATIONS}
+             WORKING_DIRECTORY ${_working_directory})
 
     # Handle OpenMP
     if( arg_NUM_OMP_THREADS )
@@ -466,14 +475,15 @@ endmacro(blt_add_test)
 ##                    COMMAND       [command]
 ##                    NUM_MPI_TASKS [n]
 ##                    NUM_OMP_THREADS [n]
-##                    CONFIGURATIONS  [config1 [config2...]])
+##                    CONFIGURATIONS  [config1 [config2...]]
+##                    WORKING_DIRECTORY [dir])
 ##
 ## Adds a benchmark to the project.
 ##------------------------------------------------------------------------------
 macro(blt_add_benchmark)
 
     set(options)
-    set(singleValueArgs NAME NUM_MPI_TASKS NUM_OMP_THREADS)
+    set(singleValueArgs NAME NUM_MPI_TASKS NUM_OMP_THREADS WORKING_DIRECTORY)
     set(multiValueArgs COMMAND CONFIGURATIONS)
 
     ## parse the arguments to the macro
@@ -486,7 +496,8 @@ macro(blt_add_benchmark)
                   COMMAND         ${arg_COMMAND}
                   NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
                   NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
-                  CONFIGURATIONS  Benchmark ${arg_CONFIGURATIONS})
+                  CONFIGURATIONS  Benchmark ${arg_CONFIGURATIONS}
+                  WORKING_DIRECTORY ${arg_WORKING_DIRECTORY})
 
     # The 'LABELS Benchmark` prevents regular tests from
     # running when running benchmarks custom target

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -456,9 +456,9 @@ macro(blt_add_test)
         set(_test_command ${_mpiexec} ${MPIEXEC_NUMPROC_FLAG} ${arg_NUM_MPI_TASKS} ${BLT_MPI_COMMAND_APPEND} ${_test_command} )
     endif()
 
-    add_test(NAME           ${arg_NAME}
-             COMMAND        ${_test_command}
-             CONFIGURATIONS ${arg_CONFIGURATIONS}
+    add_test(NAME              ${arg_NAME}
+             COMMAND           ${_test_command}
+             CONFIGURATIONS    ${arg_CONFIGURATIONS}
              WORKING_DIRECTORY ${_working_directory})
 
     # Handle OpenMP
@@ -492,11 +492,11 @@ macro(blt_add_benchmark)
 
     # The 'CONFIGURATIONS Benchmark' line excludes benchmarks 
     # from the general list of tests
-    blt_add_test( NAME            ${arg_NAME}
-                  COMMAND         ${arg_COMMAND}
-                  NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
-                  NUM_OMP_THREADS ${arg_NUM_OMP_THREADS}
-                  CONFIGURATIONS  Benchmark ${arg_CONFIGURATIONS}
+    blt_add_test( NAME              ${arg_NAME}
+                  COMMAND           ${arg_COMMAND}
+                  NUM_MPI_TASKS     ${arg_NUM_MPI_TASKS}
+                  NUM_OMP_THREADS   ${arg_NUM_OMP_THREADS}
+                  CONFIGURATIONS    Benchmark ${arg_CONFIGURATIONS}
                   WORKING_DIRECTORY ${arg_WORKING_DIRECTORY})
 
     # The 'LABELS Benchmark` prevents regular tests from

--- a/docs/api/target.rst
+++ b/docs/api/target.rst
@@ -13,11 +13,12 @@ blt_add_benchmark
 
 .. code-block:: cmake
 
-    blt_add_benchmark( NAME            [name]
-                       COMMAND         [command]
-                       NUM_MPI_TASKS   [n]
-                       NUM_OMP_THREADS [n]
-                       CONFIGURATIONS  [config1 [config2...]])
+    blt_add_benchmark( NAME              [name]
+                       COMMAND           [command]
+                       NUM_MPI_TASKS     [n]
+                       NUM_OMP_THREADS   [n]
+                       CONFIGURATIONS    [config1 [config2...]]
+                       WORKING_DIRECTORY [dir])
 
 Adds a benchmark to the project.
 
@@ -37,6 +38,11 @@ NUM_OMP_THREADS
 CONFIGURATIONS
   Optionally set additional CTest configuration(s) for this test. Benchmark tests
   will always be added to the ``Benchmark`` CTest configuration.
+
+WORKING_DIRECTORY
+  Set the test property ``WORKING_DIRECTORY`` in which to execute the test. If
+  not specified, the test will be run in ``CMAKE_CURRENT_BINARY_DIR``. The working
+  directory may be specified using generator expressions.
 
 This macro adds a benchmark test to the ``Benchmark`` CTest configuration
 which can be run by the ``run_benchmarks`` build target.  These tests are
@@ -261,11 +267,12 @@ blt_add_test
 
 .. code-block:: cmake
 
-    blt_add_test( NAME            [name]
-                  COMMAND         [command]
-                  NUM_MPI_TASKS   [n]
-                  NUM_OMP_THREADS [n]
-                  CONFIGURATIONS  [config1 [config2...]])
+    blt_add_test( NAME              [name]
+                  COMMAND           [command]
+                  NUM_MPI_TASKS     [n]
+                  NUM_OMP_THREADS   [n]
+                  CONFIGURATIONS    [config1 [config2...]]
+                  WORKING_DIRECTORY [dir])
 
 Adds a test to the project.
 
@@ -285,6 +292,11 @@ NUM_OMP_THREADS
 CONFIGURATIONS
   Set the CTest configuration for this test.  When not specified, the test
   will be added to the default CTest configuration.
+
+WORKING_DIRECTORY
+  Set the test property ``WORKING_DIRECTORY`` in which to execute the test. If
+  not specified, the test will be run in ``CMAKE_CURRENT_BINARY_DIR``. The working
+  directory may be specified using generator expressions.
 
 This macro adds the named test to CTest, which is run by the build target ``test``. This macro
 does not build the executable and requires a prior call to :ref:`blt_add_executable`.


### PR DESCRIPTION
This PR adds ``WORKING_DIRECTORY`` option to ``blt_add_test`` and ``blt_add_benchmark``. This is a parameter in CMake's `add_test`. https://cmake.org/cmake/help/latest/command/add_test.html

Serac has a use-case where we run many benchmarks using the `run_benchmarks` target, and it would be nice to have the resulting `.cali` files to be automatically put in `PROJECT_BINARY_DIR` as opposed to `CMAKE_CURRENT_BINARY_DIR`.