### PR TITLE
Fix HIP smoke tests

### DIFF
--- a/tests/smoke/blt_hip_gtest_smoke.cpp
+++ b/tests/smoke/blt_hip_gtest_smoke.cpp
@@ -8,14 +8,11 @@
 // file: blt_hip_smoke.cpp
 //
 //-----------------------------------------------------------------------------
-
-#include <iostream>
-#include <stdio.h>
 #include "gtest/gtest.h"
 #include "hip/hip_runtime.h"
 
 __device__ const char STR[] = "HELLO WORLD!";
-const char STR_LENGTH = 12;
+const int STR_LENGTH = 12;
 
 __global__ void hello()
 {
@@ -27,12 +24,13 @@ __global__ void hello()
 //------------------------------------------------------------------------------
 TEST(blt_hip_gtest_smoke,basic_assert_example)
 {
+  hipError_t rc;
   int num_threads = STR_LENGTH;
   int num_blocks = 1;
   hipLaunchKernelGGL((hello), dim3(num_blocks), dim3(num_threads),0,0);
-  if(hipSuccess != hipDeviceSynchronize())
-  {
-    std::cout << "ERROR: hipDeviceSynchronize failed!" << std::endl;
-  }
-  EXPECT_TRUE( true );
+  rc = hipGetLastError();
+  EXPECT_EQ(rc,hipSuccess) << "[HIP ERROR]: " << hipGetErrorString(rc) << "\n";
+
+  rc = hipDeviceSynchronize();
+  EXPECT_EQ(rc,hipSuccess) << "[HIP ERROR]: " << hipGetErrorString(rc) << "\n";
 }

--- a/tests/smoke/blt_hip_runtime_c_smoke.c
+++ b/tests/smoke/blt_hip_runtime_c_smoke.c
@@ -15,13 +15,26 @@
 
 int main()
 {
-  int nDevices;
+  hipError_t rc = hipSuccess;     
+  int nDevices = 0;
 
-  hipGetDeviceCount(&nDevices);
+  rc = hipGetDeviceCount(&nDevices);
+  if (rc != hipSuccess)
+  {
+    fprintf(stderr, "[HIP ERROR]: %s", hipGetErrorString(rc));
+    return -1;
+  }
+
   for (int i = 0; i < nDevices; i++)
   {
     hipDeviceProp_t prop;
-    hipGetDeviceProperties(&prop, i);
+    rc = hipGetDeviceProperties(&prop, i);
+    if (rc != hipSuccess)
+    {
+      fprintf(stderr, "[HIP ERROR]: %s", hipGetErrorString(rc));
+      return -1;
+    }
+
     printf("Device Number: %d\n", i);
     printf("  Device name: %s\n", prop.name);
     printf("  Memory Clock Rate (KHz): %d\n",

--- a/tests/smoke/blt_hip_runtime_smoke.cpp
+++ b/tests/smoke/blt_hip_runtime_smoke.cpp
@@ -8,27 +8,31 @@
 // file: blt_hip_runtime_smoke.cpp
 //
 //-----------------------------------------------------------------------------
-
-#include <iostream>
+#include <cstdio>
 #include "hip/hip_runtime_api.h"
-#include <stdio.h>
 
 int main()
 {
-  int nDevices;
+  hipError_t rc = hipSuccess; 
+  int nDevices{0};
 
-  if(hipSuccess != hipGetDeviceCount(&nDevices))
+  rc = hipGetDeviceCount(&nDevices);
+  if (rc != hipSuccess)
   {
-    std::cout << "ERROR: hipGetDeviceCount failed!" << std::endl;
+    fprintf(stderr, "[HIP ERROR]: %s", hipGetErrorString(rc));
+    return -1;
   }
 
   for (int i = 0; i < nDevices; i++)
   {
     hipDeviceProp_t prop;
-    if(hipSuccess != hipGetDeviceProperties(&prop, i))
+    rc = hipGetDeviceProperties(&prop, i);
+    if (rc != hipSuccess)
     {
-      std::cout << "ERROR: hipGetDeviceProperties failed!" << std::endl;
+      fprintf(stderr, "[HIP ERROR]: %s", hipGetErrorString(rc));
+      return -1;
     }
+
     printf("Device Number: %d\n", i);
     printf("  Device name: %s\n", prop.name);
     printf("  Memory Clock Rate (KHz): %d\n",

--- a/tests/smoke/blt_hip_smoke.cpp
+++ b/tests/smoke/blt_hip_smoke.cpp
@@ -9,12 +9,11 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include "hip/hip_runtime.h"
 
 __device__ const char STR[] = "HELLO WORLD!";
-const char STR_LENGTH = 12;
+const int STR_LENGTH = 12;
 
 __global__ void hello()
 {
@@ -23,12 +22,23 @@ __global__ void hello()
 
 int main()
 {
+  hipError_t rc = hipSuccess;
   int num_threads = STR_LENGTH;
   int num_blocks = 1;
+
   hipLaunchKernelGGL((hello), dim3(num_blocks), dim3(num_threads),0,0);
-  if(hipSuccess != hipDeviceSynchronize())
+  rc = hipGetLastError();
+  if (rc != hipSuccess) 
   {
-    std::cout << "ERROR: hipDeviceSynchronize failed!" << std::endl;
+    fprintf(stderr,"[HIP ERROR]: %s\n", hipGetErrorString(rc));
+    return -1;
+  }
+
+  rc = hipDeviceSynchronize(); 
+  if (rc != hipSuccess) 
+  {
+    fprintf(stderr, "[HIP ERROR]: %s\n", hipGetErrorString(rc));
+    return -1;
   }
 
   return 0;


### PR DESCRIPTION
The HIP smoke tests were not working properly and would always pass, even when errors occurred and were reported in the terminal. This commit ensures that errors are detected properly and that the tests fail as expected when an issue is encountered.