### PR TITLE
Disable unnecessary tautological compare for LLVM based Intel builds.

### DIFF
--- a/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt
+++ b/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt
@@ -192,6 +192,9 @@ else()
     # See #631 for rationale.
     add_cxx_compiler_flag(-wd1786)
   endif()
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+    add_cxx_compiler_flag(-Wno-tautological-compare)
+  endif()
   # Disable deprecation warnings for release builds (when -Werror is enabled).
   if(BENCHMARK_ENABLE_WERROR)
       add_cxx_compiler_flag(-Wno-deprecated)

--- a/thirdparty_builtin/patches/gbenchmark-2024-10-09-suppress-tautological-intel-llvm.patch
+++ b/thirdparty_builtin/patches/gbenchmark-2024-10-09-suppress-tautological-intel-llvm.patch
@@ -1,0 +1,14 @@
+diff --git a/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt b/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt
+index 0dbf393..5870dfc 100644
+--- a/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt
++++ b/thirdparty_builtin/benchmark-1.8.0/CMakeLists.txt
+@@ -192,6 +192,9 @@ else()
+     # See #631 for rationale.
+     add_cxx_compiler_flag(-wd1786)
+   endif()
++  if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
++    add_cxx_compiler_flag(-Wno-tautological-compare)
++  endif()
+   # Disable deprecation warnings for release builds (when -Werror is enabled).
+   if(BENCHMARK_ENABLE_WERROR)
+       add_cxx_compiler_flag(-Wno-deprecated)


### PR DESCRIPTION
Hi @white238, in RAJA when we turn on our "benchmark" builds, we're getting the following error when building with `intel/2023.2.1-magic`:

```
cd /usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/build_lc_toss4-icpx-2023.2.1-magic/blt/thirdparty_builtin/benchmark-1.8.0/src && /usr/tce/packages/intel/intel-2023.2.1-magic/bin/icpx -DBENCHMARK_STATIC_DEFINE -DHAVE_POSIX_REGEX -DHAVE_STD_REGEX -DHAVE_STEADY_CLOCK -DHAVE_TH
READ_SAFETY_ATTRIBUTES -I/usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/blt/thirdparty_builtin/benchmark-1.8.0/include -I/usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/blt/thirdparty_builtin/benchmark-1.8.0/src -Wall -Wextra       -Wall  -Wex
tra  -Wshadow  -Wfloat-equal  -Werror  -Wsuggest-override  -pedantic  -pedantic-errors  -Wshorten-64-to-32  -fstrict-aliasing  -Wno-deprecated-declarations  -Wno-deprecated  -Wstrict-aliasing  -Wthread-safety -O3 -march=native -finline-functions -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -pthread -
std=c++11 -MD -MT blt/thirdparty_builtin/benchmark-1.8.0/src/CMakeFiles/benchmark.dir/json_reporter.cc.o -MF CMakeFiles/benchmark.dir/json_reporter.cc.o.d -o CMakeFiles/benchmark.dir/json_reporter.cc.o -c /usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/blt/thirdparty_builtin/b
enchmark-1.8.0/src/json_reporter.cc                                                                                                                                                                                                                                                                                   
/usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/blt/thirdparty_builtin/benchmark-1.8.0/src/json_reporter.cc:92:7: error: explicit comparison with NaN in fast floating point mode [-Werror,-Wtautological-constant-compare]
  if (std::isnan(value))                                                                                                                                                                                                                                                                                              
      ^~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                               
/usr/workspace/wsrzc/chen59/allraja/rajaarturobenchmark/raja_git_arturobenchmark/blt/thirdparty_builtin/benchmark-1.8.0/src/json_reporter.cc:94:12: error: explicit comparison with infinity in fast floating point mode [-Werror,-Wtautological-constant-compare]                                                    
  else if (std::isinf(value))                                              
           ^~~~~~~~~~~~~~~~~                                                                                                                                                                                                                                                                                          
2 errors generated.
```

This sort of check seems rather unnecessary, so this PR turns it off for the newer Intel compilers. To reproduce, build with `icpx` on this RAJA branch https://github.com/LLNL/RAJA/pull/1738.