### PR TITLE
CUDA clean up

### DIFF
--- a/cmake/thirdparty/BLTSetupCUDA.cmake
+++ b/cmake/thirdparty/BLTSetupCUDA.cmake
@@ -110,6 +110,7 @@ message(STATUS "CUDA Implicit Link Directories: ${CMAKE_CUDA_IMPLICIT_LINK_DIREC
 ############################################################
 # Check CUDA language standard is supported
 ############################################################
+# Note: change to use CUDAToolkit_VERSION after moving away from find_package(CUDA)
 if(CMAKE_CUDA_STANDARD STREQUAL "17")
     if(NOT DEFINED CMAKE_CUDA_COMPILE_FEATURES OR (NOT "cuda_std_17" IN_LIST CMAKE_CUDA_COMPILE_FEATURES))
         message(FATAL_ERROR "CUDA ${CUDA_VERSION_STRING} does not support C++17.")


### PR DESCRIPTION
- Since BLT now requires a minimum of CMake 3.15, logic for earlier versions can be removed
- Improve error message for CUDA versions that don't support the requested language standard
- Print out CMAKE_CUDA_STANDARD
- Print out CMAKE_CUDA_ARCHITECTURES if CMake version is greater than or equal to 3.18