### PR TITLE
remove use of bigobj flag for msvc windows builds

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -9,6 +9,9 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 
 ## [Unreleased] - Release date yyyy-mm-dd
 
+### Changed
+- Removed default use of `/bigobj` flag for Visual Studio builds. Projects add this flag explicitly if needed for their windows builds.
+
 ## [Version 0.7.1] - Release date 2025-09-04
 
 ### Changed

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Changed
-- Removed default use of `/bigobj` flag for Visual Studio builds. Projects add this flag explicitly if needed for their windows builds.
+- Removed default use of `/bigobj` flag for Visual Studio builds. Projects should add this flag explicitly if needed for their windows builds.
 
 ## [Version 0.7.1] - Release date 2025-09-04
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,7 +10,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 ## [Unreleased] - Release date yyyy-mm-dd
 
 ### Changed
-- Removed default use of `/bigobj` flag for Visual Studio builds. Projects should add this flag explicitly if needed for their windows builds.
+- Removed default use of `/bigobj` flag for Visual Studio builds. Projects should add this flag explicitly if needed for windows builds.
 
 ## [Version 0.7.1] - Release date 2025-09-04
 

--- a/cmake/SetupCompilerOptions.cmake
+++ b/cmake/SetupCompilerOptions.cmake
@@ -123,12 +123,6 @@ if(BLT_DEFINES)
     message(STATUS "Added \"${BLT_DEFINES}\" to definitions")
 endif()
 
-if(COMPILER_FAMILY_IS_MSVC)
-    # Visual studio can give a warning that /bigobj is required due to the size of some object files
-    set( BLT_CXX_FLAGS "${BLT_CXX_FLAGS} /bigobj" )
-    set( BLT_C_FLAGS   "${BLT_C_FLAGS} /bigobj" )
-endif()
-
 ##########################################
 # If set, BLT_<LANG>_FLAGS are added to 
 # all targets that use <LANG>-Compiler


### PR DESCRIPTION
resolves #732 