### PR TITLE
Set CMP0146 to OLD to ensure FindCUDA is found

### DIFF
--- a/cmake/thirdparty/BLTSetupCUDA.cmake
+++ b/cmake/thirdparty/BLTSetupCUDA.cmake
@@ -3,6 +3,13 @@
 # 
 # SPDX-License-Identifier: (BSD-3-Clause)
 
+# Use legacy FindCUDA. This was deprecated in 3.10 and removed in 3.27.
+# TODO: Do not rely on this setting and use the new CUDA finding mechanism instead:
+# https://cmake.org/cmake/help/latest/module/FindCUDA.html
+if(POLICY CMP0146)
+  cmake_policy(SET CMP0146 OLD)
+endif()
+
 ################################
 # Sanity Checks
 ################################


### PR DESCRIPTION
CMake has deprecated FindCUDA with version 3.10 and moved to using `enable_language(CUDA)`. In 3.17, it introduced `FindCUDAToolkit`, and in 3.27 it removed FindCUDA all together.

This commit sets policy CMP0146 to OLD so that FindCUDA can still be used in versions after 3.27.

See also https://github.com/LLNL/blt/issues/727 regarding moving to 3.10 as minimum version.

Closes #734 