### PR TITLE
Robustify blt_add_test in non mpi configs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,6 +12,11 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 ### Changed
 - Removed default use of `/bigobj` flag for Visual Studio builds. Projects should add this flag explicitly if needed for windows builds.
 
+### Fixed
+- In non-mpi configurations, `blt_add_test` will now throw a `FATAL_ERROR` if the user provides `NUM_MPI_RANKS`
+  and the requested number of ranks is greater than 1. Previously, if `MPI_EXECUTABLE` was not defined
+  `blt_add_test` would prepend the test command with the value of `NUM_MPI_RANKS`, and the test would fail to run.
+
 ## [Version 0.7.1] - Release date 2025-09-04
 
 ### Changed

--- a/cmake/BLTMacros.cmake
+++ b/cmake/BLTMacros.cmake
@@ -460,14 +460,27 @@ macro(blt_add_test)
 
     # Handle MPI
     if( arg_NUM_MPI_TASKS )
-        # Handle CMake changing MPIEXEC to MPIEXEC_EXECUTABLE
-        if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
-            set(_mpiexec ${MPIEXEC_EXECUTABLE})
-        else()
-            set(_mpiexec ${MPIEXEC})
+        # first check that the number of ranks is a positive integer
+        string(REGEX MATCH "^-?[0-9]+$" _is_integer "${arg_NUM_MPI_TASKS}")
+        if( NOT _is_integer OR arg_NUM_MPI_TASKS LESS 1)
+            message(FATAL_ERROR "In blt_add_test(), attempted to run an mpi test with invalid NUM_MPI_TASKS: ${arg_NUM_MPI_TASKS}")
         endif()
 
-        set(_test_command ${_mpiexec} ${MPIEXEC_NUMPROC_FLAG} ${arg_NUM_MPI_TASKS} ${BLT_MPI_COMMAND_APPEND} ${_test_command} )
+        # prefix command with mpi executable in MPI configs
+        if( BLT_ENABLE_MPI)
+            # Handle CMake changing MPIEXEC to MPIEXEC_EXECUTABLE
+            if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0" )
+                set(_mpiexec ${MPIEXEC_EXECUTABLE})
+            else()
+                set(_mpiexec ${MPIEXEC})
+            endif()
+
+            set(_test_command ${_mpiexec} ${MPIEXEC_NUMPROC_FLAG} ${arg_NUM_MPI_TASKS} ${BLT_MPI_COMMAND_APPEND} ${_test_command} )
+        elseif( arg_NUM_MPI_TASKS EQUAL 1)
+            # no-op: Allow NUM_MPI_TASKS to be 1 when not using MPI
+        else()
+            message(FATAL_ERROR "In blt_add_test(), attempted to invoke a test with ${arg_NUM_MPI_TASKS} ranks in a non-mpi configuration")
+        endif()
     endif()
 
     add_test(NAME              ${arg_NAME}


### PR DESCRIPTION
When the user provides `blt_add_test` with `NUM_MPI_RANKS`, we prepend the test command with the `MPIEXEC` and the number of ranks (e.g. `srun -n4`).

In non-mpi configurations, we should not add `MPIEXEC`, which is likely not a defined variable in CMake.

This PR fixes this, but also allows the `NUM_MPI_RANKS` to be 1 in non- mpi configurations.