### PR TITLE
GoogleTest: Quiet warning from clang@21

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,7 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - In non-mpi configurations, `blt_add_test` will now throw a `FATAL_ERROR` if the user provides `NUM_MPI_RANKS`
   and the requested number of ranks is greater than 1. Previously, if `MPI_EXECUTABLE` was not defined
   `blt_add_test` would prepend the test command with the value of `NUM_MPI_RANKS`, and the test would fail to run.
+- GoogleTest: Quiet warning on clang@21 about implicit cast (https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328)
 
 ## [Version 0.7.1] - Release date 2025-09-04
 

--- a/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h
+++ b/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h
@@ -521,11 +521,15 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
 
 GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
 inline void PrintTo(char16_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
+  // Also see https://github.com/google/googletest/issues/4762.
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #ifdef __cpp_lib_char8_t
 inline void PrintTo(char8_t c, ::std::ostream* os) {
-  PrintTo(ImplicitCast_<char32_t>(c), os);
+  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
+  // Also see https://github.com/google/googletest/issues/4762.
+  PrintTo(static_cast<char32_t>(c), os);
 }
 #endif
 

--- a/thirdparty_builtin/patches/gtest-2026-01-20-quiet-implicit-cast-warning.patch
+++ b/thirdparty_builtin/patches/gtest-2026-01-20-quiet-implicit-cast-warning.patch
@@ -1,0 +1,22 @@
+diff --git a/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h b/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h
+index 198a769..bbb0fa7 100644
+--- a/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h
++++ b/thirdparty_builtin/googletest-1.16.0/googletest/include/gtest/gtest-printers.h
+@@ -521,11 +521,15 @@ GTEST_API_ void PrintTo(wchar_t wc, ::std::ostream* os);
+ 
+ GTEST_API_ void PrintTo(char32_t c, ::std::ostream* os);
+ inline void PrintTo(char16_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #ifdef __cpp_lib_char8_t
+ inline void PrintTo(char8_t c, ::std::ostream* os) {
+-  PrintTo(ImplicitCast_<char32_t>(c), os);
++  // TODO(b/418738869): Incorrect for values not representing valid codepoints.
++  // Also see https://github.com/google/googletest/issues/4762.
++  PrintTo(static_cast<char32_t>(c), os);
+ }
+ #endif
+ 


### PR DESCRIPTION
Still an open issue for final fix but this quiets the warning.

https://github.com/google/googletest/issues/4762