### PR TITLE
add comm size check to blt mpi smoke

### DIFF
--- a/tests/smoke/CMakeLists.txt
+++ b/tests/smoke/CMakeLists.txt
@@ -112,10 +112,11 @@ endif()
 if (ENABLE_MPI)
     blt_add_executable(NAME blt_mpi_smoke
                        SOURCES blt_mpi_smoke.cpp
-                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY} 
+                       OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
                        DEPENDS_ON blt::mpi
                        FOLDER blt/tests )
-
+    # This smoke test explicitly checks the number of MPI tasks.
+    # If NUM_MPI_TASKS is changed here, you must update blt_mpi_smoke.cpp.
     blt_add_test(NAME blt_mpi_smoke
                  COMMAND blt_mpi_smoke
                  NUM_MPI_TASKS 4)

--- a/tests/smoke/blt_mpi_smoke.cpp
+++ b/tests/smoke/blt_mpi_smoke.cpp
@@ -25,7 +25,12 @@ int main(int argc, char** argv)
   int commSize = -1;
   MPI_Comm_size(MPI_COMM_WORLD, &commSize);
 
-  // this test should be using 4 mpi tasks, check the commSize
+  // Check for expected commSize.
+  //
+  // We expect to have 4 MPI Tasks.
+  //
+  // The commSize check must stay in sync with the NUM_MPI_TASKS
+  // value passed to the corresponding blt_add_test call in CMakeLists.txt.
   if(commSize != 4)
   {
       std::cout << "Comm Size should equal 4" << std::endl;

--- a/tests/smoke/blt_mpi_smoke.cpp
+++ b/tests/smoke/blt_mpi_smoke.cpp
@@ -25,6 +25,15 @@ int main(int argc, char** argv)
   int commSize = -1;
   MPI_Comm_size(MPI_COMM_WORLD, &commSize);
 
+  // this test should be using 4 mpi tasks, check the commSize
+  if(commSize != 4)
+  {
+      std::cout << "Comm Size should equal 4" << std::endl;
+      std::cout << "Comm Size = " << commSize << std::endl;
+      MPI_Finalize();
+      return 1;
+  }
+
   // Do a basic mpi reduce to determine this actually works
   int globalValue = 0;
   int valueToSend = 1;


### PR DESCRIPTION
resolves #753, helps detect mpi env puzzles earlier