### PR TITLE
Adds `BLT_ALLOW_MISSING_MPI_WRAPPER` option to allow Fortran configs with MPI to not have an MPI_Fortran_COMPILER

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,6 +16,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Update CUDA runtime smoketest to be compatible with CUDA 13
 - Adds `BLT_ALLOW_MISSING_MPI_WRAPPER` (default `OFF`) to allow setting up MPI without providing `MPI_<lang>_COMPILER` for some enabled languages.
   This supports niche cases (e.g. Fortran enabled without a compatible `MPI_Fortran_COMPILER`) while preserving the default behavior of requiring wrappers.
+- Checks for missing `MPI_<lang>_COMPILER` flags for each enabled language when `ENABLE_MPI` evaluates to `ON`
+  and `BLT_ALLOW_MISSING_MPI_WRAPPER` evaluates to `OFF`.
 
 ### Fixed
 - In non-mpi configurations, `blt_add_test` will now throw a `FATAL_ERROR` if the user provides `NUM_MPI_RANKS`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,8 +14,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Removed `-Winline` from being added to GoogleTest for Clang/Intel as it is a noop and caused a warning on Intel.
 - Toggle GoogleTest adding `-Wno-implicit-float-size-conversion` or `-Wno-sycl-implicit-float-size-conversion` based on Intel version.
 - Update CUDA runtime smoketest to be compatible with CUDA 13
-- Allows setting up MPI in configs with `C`, `CXX` and/or `Fortran` but without a corresponding `MPI_<lang>_COMPILER`. 
-  This came up in an msan config that needed Fortran, but did not have a compatible MPI wrapper for Fortran.
+- Adds `BLT_ALLOW_MISSING_MPI_WRAPPER` (default `OFF`) to allow setting up MPI without providing `MPI_<lang>_COMPILER` for some enabled languages.
+  This supports niche cases (e.g. Fortran enabled without a compatible `MPI_Fortran_COMPILER`) while preserving the default behavior of requiring wrappers.
 
 ### Fixed
 - In non-mpi configurations, `blt_add_test` will now throw a `FATAL_ERROR` if the user provides `NUM_MPI_RANKS`

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -14,6 +14,8 @@ The project release numbers follow [Semantic Versioning](http://semver.org/spec/
 - Removed `-Winline` from being added to GoogleTest for Clang/Intel as it is a noop and caused a warning on Intel.
 - Toggle GoogleTest adding `-Wno-implicit-float-size-conversion` or `-Wno-sycl-implicit-float-size-conversion` based on Intel version.
 - Update CUDA runtime smoketest to be compatible with CUDA 13
+- Allows setting up MPI in configs with `C`, `CXX` and/or `Fortran` but without a corresponding `MPI_<lang>_COMPILER`. 
+  This came up in an msan config that needed Fortran, but did not have a compatible MPI wrapper for Fortran.
 
 ### Fixed
 - In non-mpi configurations, `blt_add_test` will now throw a `FATAL_ERROR` if the user provides `NUM_MPI_RANKS`

--- a/cmake/BLTOptions.cmake
+++ b/cmake/BLTOptions.cmake
@@ -53,6 +53,17 @@ endif()
 option(ENABLE_FORTRAN      "Enables Fortran compiler support" ${_fortran_already_enabled})
 
 option(ENABLE_MPI          "Enables MPI support" OFF)
+
+# By default, we require MPI_<langl>_COMPILER to be provided for each
+# enabled language when ENABLE_MPI. The following options overrides this.
+cmake_dependent_option(BLT_ALLOW_MISSING_MPI_WRAPPER
+                           "Allow MPI_<lang>_COMPILER to be missing for some enabled languages"
+                           OFF
+                           "ENABLE_MPI"
+                           OFF)
+mark_as_advanced(BLT_ALLOW_MISSING_MPI_WRAPPER)
+
+
 option(ENABLE_OPENMP       "Enables OpenMP compiler support" OFF)
 option(ENABLE_CUDA         "Enable CUDA support" OFF)
 cmake_dependent_option(ENABLE_CLANG_CUDA   "Enable Clang's native CUDA support" OFF
@@ -146,6 +157,7 @@ set(BLT_RUN_BENCHMARKS_TARGET_NAME "run_benchmarks" CACHE STRING "Name of the ta
 # All advanced options should be marked as advanced
 mark_as_advanced(
     ENABLE_FIND_MPI
+    BLT_ALLOW_MISSING_MPI_WRAPPER
     ENABLE_GTEST_DEATH_TESTS
     ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC 
     BLT_CODE_CHECK_TARGET_NAME

--- a/cmake/BLTThirdPartyConfigFlags.cmake.in
+++ b/cmake/BLTThirdPartyConfigFlags.cmake.in
@@ -14,6 +14,9 @@ endif()
 if(NOT BLT_ENABLE_FIND_MPI)
     set(BLT_ENABLE_FIND_MPI       @ENABLE_FIND_MPI@)
 endif()
+if (NOT DEFINED BLT_ALLOW_MISSING_MPI_WRAPPER)
+    set(BLT_ALLOW_MISSING_MPI_WRAPPER @BLT_ALLOW_MISSING_MPI_WRAPPER@)
+endif()
 
 # Always prefer the current project if they turned it on
 if(ENABLE_CLANG_CUDA)

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -31,8 +31,23 @@ set(_mpi_includes )
 set(_mpi_libraries )
 set(_mpi_link_flags )
 
+# Allow user to selectively enable which languages have MPI targets
+# based on enabled languages and whether they've supplied MPI_<lang>_COMPILER
+get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+message(STATUS "Enabled languages: ${enabled_languages}")
+
+set(_blt_enable_mpi_c FALSE)
+if("C" IN_LIST enabled_languages AND MPI_C_COMPILER)
+    set(_blt_enable_mpi_c TRUE)
+endif()
+
+set(_blt_enable_mpi_cxx FALSE)
+if("CXX" IN_LIST enabled_languages AND MPI_CXX_COMPILER)
+    set(_blt_enable_mpi_cxx TRUE)
+endif()
+
 set(_blt_enable_mpi_fortran FALSE)
-if (BLT_ENABLE_FORTRAN AND MPI_Fortran_COMPILER)
+if ("Fortran" IN_LIST enabled_languages AND MPI_Fortran_COMPILER)
     set(_blt_enable_mpi_fortran TRUE)
 endif()
 
@@ -44,7 +59,9 @@ endif()
 
 
 if (BLT_ENABLE_FIND_MPI)
-    set(_blt_mpi_components C CXX)
+    set(_blt_mpi_components)
+    blt_list_append(TO _blt_mpi_components ELEMENTS C       IF _blt_enable_mpi_c)
+    blt_list_append(TO _blt_mpi_components ELEMENTS CXX     IF _blt_enable_mpi_cxx)
     blt_list_append(TO _blt_mpi_components ELEMENTS Fortran IF _blt_enable_mpi_fortran)
     find_package(MPI REQUIRED COMPONENTS ${_blt_mpi_components})
 
@@ -55,23 +72,27 @@ if (BLT_ENABLE_FIND_MPI)
     #-------------------
     # Compile flags
     #-------------------
-    set(_c_flag ${MPI_C_${_mpi_compile_flags_suffix}})
-    if (_c_flag AND BLT_ENABLE_CUDA)
-        list(APPEND _mpi_compile_flags
-                    $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_c_flag}>
-                    $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_c_flag}>)
-    else()
-        list(APPEND _mpi_compile_flags ${_c_flag})
+    if(_blt_enable_mpi_c)
+        set(_c_flag ${MPI_C_${_mpi_compile_flags_suffix}})
+        if (_c_flag AND BLT_ENABLE_CUDA)
+            list(APPEND _mpi_compile_flags
+                        $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_c_flag}>
+                        $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_c_flag}>)
+        else()
+            list(APPEND _mpi_compile_flags ${_c_flag})
+        endif()
     endif()
 
-    set(_cxx_flag ${MPI_CXX_${_mpi_compile_flags_suffix}})
-    if (_cxx_flag AND NOT "${_c_flag}" STREQUAL "${_cxx_flag}")
-        if (BLT_ENABLE_CUDA)
-            list(APPEND _mpi_compile_flags
-            $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_cxx_flag}>
-            $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_cxx_flag}>)
-        else()
-            list(APPEND _mpi_compile_flags ${_cxx_flag})
+    if(_blt_enable_mpi_cxx)
+        set(_cxx_flag ${MPI_CXX_${_mpi_compile_flags_suffix}})
+        if (_cxx_flag AND NOT "${_c_flag}" STREQUAL "${_cxx_flag}")
+            if (BLT_ENABLE_CUDA)
+                list(APPEND _mpi_compile_flags
+                $<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:${_cxx_flag}>
+                $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${_cxx_flag}>)
+            else()
+                list(APPEND _mpi_compile_flags ${_cxx_flag})
+            endif()
         endif()
     endif()
 
@@ -88,25 +109,25 @@ if (BLT_ENABLE_FIND_MPI)
     #-------------------
     # Include paths
     #-------------------
-    list(APPEND _mpi_includes ${MPI_C_${_mpi_includes_suffix}}
-                              ${MPI_CXX_${_mpi_includes_suffix}})
-    if (_blt_enable_mpi_fortran)
-        list(APPEND _mpi_includes ${MPI_Fortran_${_mpi_includes_suffix}})
-    endif()
+    set(_mpi_includes)
+    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_C_${_mpi_includes_suffix}} IF _blt_enable_mpi_c)
+    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_CXX_${_mpi_includes_suffix}} IF _blt_enable_mpi_cxx)
+    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_Fortran_${_mpi_includes_suffix}} IF _blt_enable_mpi_fortran)
     blt_list_remove_duplicates(TO _mpi_includes)
 
     #-------------------
     # Link flags
     #-------------------
-    set(_mpi_link_flags ${MPI_C_LINK_FLAGS})
-    if (NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_CXX_LINK_FLAGS}")
+    if(_blt_enable_mpi_c)
+        set(_mpi_link_flags ${MPI_C_LINK_FLAGS})
+    endif()
+
+    if(_blt_enable_mpi_cxx AND NOT "${_mpi_link_flags}" STREQUAL "${MPI_CXX_LINK_FLAGS}")
         list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
     endif()
-    if (_blt_enable_mpi_fortran)
-        if ((NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}") AND
-            (NOT "${MPI_CXX_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}"))
-            list(APPEND _mpi_link_flags ${MPI_Fortran_LINK_FLAGS})
-        endif()
+
+    if (_blt_enable_mpi_fortran AND NOT "${_mpi_link_flags}" STREQUAL "${MPI_Fortran_LINK_FLAGS}")
+        list(APPEND _mpi_link_flags ${MPI_Fortran_LINK_FLAGS})
     endif()
 
     # Selectively remove set of known locations of spaces
@@ -127,10 +148,9 @@ if (BLT_ENABLE_FIND_MPI)
     #-------------------
     # Libraries
     #-------------------
-    set(_mpi_libraries ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
-    if (_blt_enable_mpi_fortran)
-        list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
-    endif()
+    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_C_LIBRARIES} IF _blt_enable_mpi_c)
+    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_CXX_LIBRARIES} IF _blt_enable_mpi_cxx)
+    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_Fortran_LIBRARIES} IF _blt_enable_mpi_fortran)
     blt_list_remove_duplicates(TO _mpi_libraries)
 endif()
 

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -109,9 +109,15 @@ if (BLT_ENABLE_FIND_MPI)
     # Include paths
     #-------------------
     set(_mpi_includes)
-    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_C_${_mpi_includes_suffix}} IF _blt_enable_mpi_c)
-    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_CXX_${_mpi_includes_suffix}} IF _blt_enable_mpi_cxx)
-    blt_list_append(TO _mpi_includes ELEMENTS ${MPI_Fortran_${_mpi_includes_suffix}} IF _blt_enable_mpi_fortran)
+    if(_blt_enable_mpi_c)
+        list(APPEND _mpi_includes ${MPI_C_${_mpi_includes_suffix}})
+    endif()
+    if(_blt_enable_mpi_cxx)
+        list(APPEND _mpi_includes ${MPI_CXX_${_mpi_includes_suffix}})
+    endif()
+    if(_blt_enable_mpi_fortran)
+        list(APPEND _mpi_includes ${MPI_Fortran_${_mpi_includes_suffix}})
+    endif()
     blt_list_remove_duplicates(TO _mpi_includes)
 
     #-------------------
@@ -147,9 +153,15 @@ if (BLT_ENABLE_FIND_MPI)
     #-------------------
     # Libraries
     #-------------------
-    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_C_LIBRARIES} IF _blt_enable_mpi_c)
-    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_CXX_LIBRARIES} IF _blt_enable_mpi_cxx)
-    blt_list_append(TO _mpi_libraries ELEMENTS ${MPI_Fortran_LIBRARIES} IF _blt_enable_mpi_fortran)
+    if(_blt_enable_mpi_c)
+        list(APPEND _mpi_libraries ${MPI_C_LIBRARIES})
+    endif()
+    if(_blt_enable_mpi_cxx)
+        list(APPEND _mpi_libraries ${MPI_CXX_LIBRARIES})
+    endif()
+    if(_blt_enable_mpi_fortran)
+        list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
+    endif()
     blt_list_remove_duplicates(TO _mpi_libraries)
 endif()
 

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -34,7 +34,6 @@ set(_mpi_link_flags )
 # Allow user to selectively enable which languages have MPI targets
 # based on enabled languages and whether they've supplied MPI_<lang>_COMPILER
 get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
-message(STATUS "Enabled languages: ${enabled_languages}")
 
 set(_blt_enable_mpi_c FALSE)
 if("C" IN_LIST enabled_languages AND MPI_C_COMPILER)

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -31,6 +31,10 @@ set(_mpi_includes )
 set(_mpi_libraries )
 set(_mpi_link_flags )
 
+set(_blt_enable_mpi_fortran FALSE)
+if (BLT_ENABLE_FORTRAN AND MPI_Fortran_COMPILER)
+    set(_blt_enable_mpi_fortran TRUE)
+endif()
 
 if(BLT_ENABLE_FIND_MPI)
     message(STATUS "FindMPI Enabled  (ENABLE_FIND_MPI == ON)")
@@ -40,7 +44,9 @@ endif()
 
 
 if (BLT_ENABLE_FIND_MPI)
-    find_package(MPI REQUIRED)
+    set(_blt_mpi_components C CXX)
+    blt_list_append(TO _blt_mpi_components ELEMENTS Fortran IF _blt_enable_mpi_fortran)
+    find_package(MPI REQUIRED COMPONENTS ${_blt_mpi_components})
 
     #-------------------
     # Merge found MPI info and remove duplication
@@ -69,7 +75,7 @@ if (BLT_ENABLE_FIND_MPI)
         endif()
     endif()
 
-    if (BLT_ENABLE_FORTRAN)
+    if (_blt_enable_mpi_fortran)
         set(_f_flag ${MPI_Fortran_${_mpi_compile_flags_suffix}})
         if (_f_flag AND NOT "${_c_flag}" STREQUAL "${_f_flag}")
             list(APPEND _mpi_compile_flags ${_f_flag})
@@ -84,7 +90,7 @@ if (BLT_ENABLE_FIND_MPI)
     #-------------------
     list(APPEND _mpi_includes ${MPI_C_${_mpi_includes_suffix}}
                               ${MPI_CXX_${_mpi_includes_suffix}})
-    if (BLT_ENABLE_FORTRAN)
+    if (_blt_enable_mpi_fortran)
         list(APPEND _mpi_includes ${MPI_Fortran_${_mpi_includes_suffix}})
     endif()
     blt_list_remove_duplicates(TO _mpi_includes)
@@ -96,7 +102,7 @@ if (BLT_ENABLE_FIND_MPI)
     if (NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_CXX_LINK_FLAGS}")
         list(APPEND _mpi_link_flags ${MPI_CXX_LINK_FLAGS})
     endif()
-    if (BLT_ENABLE_FORTRAN)
+    if (_blt_enable_mpi_fortran)
         if ((NOT "${MPI_C_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}") AND
             (NOT "${MPI_CXX_LINK_FLAGS}" STREQUAL "${MPI_Fortran_LINK_FLAGS}"))
             list(APPEND _mpi_link_flags ${MPI_Fortran_LINK_FLAGS})
@@ -122,7 +128,7 @@ if (BLT_ENABLE_FIND_MPI)
     # Libraries
     #-------------------
     set(_mpi_libraries ${MPI_C_LIBRARIES} ${MPI_CXX_LIBRARIES})
-    if (BLT_ENABLE_FORTRAN)
+    if (_blt_enable_mpi_fortran)
         list(APPEND _mpi_libraries ${MPI_Fortran_LIBRARIES})
     endif()
     blt_list_remove_duplicates(TO _mpi_libraries)
@@ -166,7 +172,7 @@ endif()
 message(STATUS "MPI Num Proc Flag:    ${MPIEXEC_NUMPROC_FLAG}")
 message(STATUS "MPI Command Append:   ${BLT_MPI_COMMAND_APPEND}")
 
-if (BLT_ENABLE_FORTRAN)
+if (_blt_enable_mpi_fortran)
     # Determine if we should use fortran mpif.h header or fortran mpi module
     find_path(mpif_path
         NAMES "mpif.h"

--- a/cmake/thirdparty/BLTSetupMPI.cmake
+++ b/cmake/thirdparty/BLTSetupMPI.cmake
@@ -31,38 +31,59 @@ set(_mpi_includes )
 set(_mpi_libraries )
 set(_mpi_link_flags )
 
-# Allow user to selectively enable which languages have MPI targets
-# based on enabled languages and whether they've supplied MPI_<lang>_COMPILER
-get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+# Users must provide MPI_<lang>_COMPILER variables for each enabled language unless BLT_ALLOW_MISSING_MPI_WRAPPER
+# Check for each variable and print a warning/error message if appropriate
+get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
 
-set(_blt_enable_mpi_c FALSE)
-if("C" IN_LIST enabled_languages AND MPI_C_COMPILER)
-    set(_blt_enable_mpi_c TRUE)
-endif()
-
-set(_blt_enable_mpi_cxx FALSE)
-if("CXX" IN_LIST enabled_languages AND MPI_CXX_COMPILER)
-    set(_blt_enable_mpi_cxx TRUE)
-endif()
-
-set(_blt_enable_mpi_fortran FALSE)
-if ("Fortran" IN_LIST enabled_languages AND MPI_Fortran_COMPILER)
-    set(_blt_enable_mpi_fortran TRUE)
-endif()
-
-if(BLT_ENABLE_FIND_MPI)
+if (BLT_ENABLE_FIND_MPI)
     message(STATUS "FindMPI Enabled  (ENABLE_FIND_MPI == ON)")
+
+    set(_blt_missing_mpi_wrappers)
+    foreach(_lang "C" "CXX" "Fortran")
+        if (${_lang} IN_LIST _enabled_languages AND NOT MPI_${_lang}_COMPILER)
+            list(APPEND _blt_missing_mpi_wrappers "MPI_${_lang}_COMPILER")
+        endif()
+    endforeach()
+
+    if (_blt_missing_mpi_wrappers)
+        if (BLT_ALLOW_MISSING_MPI_WRAPPER)
+            message(STATUS "BLT_ALLOW_MISSING_MPI_WRAPPER == ON. Proceeding without: ${_blt_missing_mpi_wrappers}")
+        else()
+            message(FATAL_ERROR
+                    "MPI support is enabled, but missing MPI compiler wrapper(s): ${_blt_missing_mpi_wrappers}\n"
+                    "Provide MPI_<lang>_COMPILER for each enabled language or set BLT_ALLOW_MISSING_MPI_WRAPPER=ON to bypass this check.")
+        endif()
+    endif()
+    unset(_blt_missing_mpi_wrappers)
 else()
     message(STATUS "FindMPI Disabled (ENABLE_FIND_MPI == OFF) ")
 endif()
 
+set(_blt_enable_mpi_c FALSE)
+if("C" IN_LIST _enabled_languages AND MPI_C_COMPILER)
+    set(_blt_enable_mpi_c TRUE)
+endif()
+
+set(_blt_enable_mpi_cxx FALSE)
+if("CXX" IN_LIST _enabled_languages AND MPI_CXX_COMPILER)
+    set(_blt_enable_mpi_cxx TRUE)
+endif()
+
+set(_blt_enable_mpi_fortran FALSE)
+if ("Fortran" IN_LIST _enabled_languages AND MPI_Fortran_COMPILER)
+    set(_blt_enable_mpi_fortran TRUE)
+endif()
 
 if (BLT_ENABLE_FIND_MPI)
-    set(_blt_mpi_components)
-    blt_list_append(TO _blt_mpi_components ELEMENTS C       IF _blt_enable_mpi_c)
-    blt_list_append(TO _blt_mpi_components ELEMENTS CXX     IF _blt_enable_mpi_cxx)
-    blt_list_append(TO _blt_mpi_components ELEMENTS Fortran IF _blt_enable_mpi_fortran)
-    find_package(MPI REQUIRED COMPONENTS ${_blt_mpi_components})
+    if (BLT_ALLOW_MISSING_MPI_WRAPPER)
+        set(_blt_mpi_components)
+        blt_list_append(TO _blt_mpi_components ELEMENTS C       IF _blt_enable_mpi_c)
+        blt_list_append(TO _blt_mpi_components ELEMENTS CXX     IF _blt_enable_mpi_cxx)
+        blt_list_append(TO _blt_mpi_components ELEMENTS Fortran IF _blt_enable_mpi_fortran)
+        find_package(MPI REQUIRED COMPONENTS ${_blt_mpi_components})
+    else()
+        find_package(MPI REQUIRED)
+    endif()
 
     #-------------------
     # Merge found MPI info and remove duplication

--- a/docs/tutorial/common_hpc_dependencies.rst
+++ b/docs/tutorial/common_hpc_dependencies.rst
@@ -39,6 +39,7 @@ Our next example, ``test_2``, builds and tests the ``calc_pi_mpi`` library,
 which uses MPI to parallelize the calculation over the integration intervals.
 
 To enable MPI, we set ``ENABLE_MPI``, ``MPI_C_COMPILER``, and ``MPI_CXX_COMPILER``
+(and ``MPI_Fortran_COMPILER`` if your project enables Fortran)
 in our host config file. Here is a snippet with these settings for LLNL's Lassen Cluster:
 
 .. literalinclude:: ../../host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1.cmake
@@ -84,6 +85,16 @@ Test. ``test_2.cpp`` provides an example driver for MPI with GoogleTest.
   * ``BLT_MPI_LIBRARIES``
   * ``BLT_MPI_LINK_FLAGS``
   
+  By default (when ``ENABLE_MPI`` and ``ENABLE_FIND_MPI`` are ``ON``), BLT requires
+  an ``MPI_<lang>_COMPILER`` wrapper for each enabled language (e.g. ``MPI_C_COMPILER``,
+  ``MPI_CXX_COMPILER``, and/or ``MPI_Fortran_COMPILER``). If any required wrapper is
+  missing, BLT will stop with a configuration error.
+
+  For cases where a language is enabled but an MPI wrapper is unavailable or
+  incompatible (for example, enabling Fortran without a compatible ``MPI_Fortran_COMPILER``),
+  set ``BLT_ALLOW_MISSING_MPI_WRAPPER=ON``. BLT will print which wrappers are missing
+  and will only configure MPI support for the languages that have wrappers available.
+
   BLT also has the variable ``ENABLE_FIND_MPI`` which turns off all CMake's ``FindMPI``
   logic and then uses the MPI wrapper directly when you provide them as the default
   compilers.

--- a/docs/tutorial/host_configs.rst
+++ b/docs/tutorial/host_configs.rst
@@ -31,20 +31,20 @@ These files use standard CMake commands. CMake ``set()`` commands need to specif
     set(CMAKE_VARIABLE_NAME {VALUE} CACHE PATH "")
 
 Here is a snippet from a host-config file that specifies compiler details for
-using specific gcc (version 10.3.1 in this case) on the LLNL Pascal cluster: 
+using specific gcc (version 10.3.1 in this case) on the LLNL Dane cluster: 
 
-.. literalinclude:: ../../host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1_nvcc.cmake
-   :start-after: _blt_pascal_compiler_config_start
-   :end-before:  _blt_pascal_compiler_config_end
+.. literalinclude:: ../../host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1.cmake
+   :start-after: _blt_tutorial_compiler_config_start
+   :end-before:  _blt_tutorial_compiler_config_end
    :language: cmake
 
 
-Building and Testing on Pascal
+Building and Testing on Matrix
 ------------------------------
 
-Since compute nodes on the Pascal cluster have CPUs and GPUs, here is how you
+Since compute nodes on the Matrix cluster have CPUs and GPUs, here is how you
 can use the host-config file to configure a build of the ``calc_pi``  project with
-MPI and CUDA enabled on Pascal:
+MPI and CUDA enabled on Matrix:
 
 .. code-block:: bash
     
@@ -62,52 +62,6 @@ to run the unit tests that are using MPI and CUDA:
   bash-4.1$ salloc -A <valid bank>
   bash-4.1$ make   
   bash-4.1$ make test
-  
-  Running tests...
-  Test project blt/docs/tutorial/calc_pi/build
-      Start 1: test_1
-  1/8 Test #1: test_1 ...........................   Passed    0.01 sec
-      Start 2: test_2
-  2/8 Test #2: test_2 ...........................   Passed    2.79 sec
-      Start 3: test_3
-  3/8 Test #3: test_3 ...........................   Passed    0.54 sec
-      Start 4: blt_gtest_smoke
-  4/8 Test #4: blt_gtest_smoke ..................   Passed    0.01 sec
-      Start 5: blt_fruit_smoke
-  5/8 Test #5: blt_fruit_smoke ..................   Passed    0.01 sec
-      Start 6: blt_mpi_smoke
-  6/8 Test #6: blt_mpi_smoke ....................   Passed    2.82 sec
-      Start 7: blt_cuda_smoke
-  7/8 Test #7: blt_cuda_smoke ...................   Passed    0.48 sec
-      Start 8: blt_cuda_runtime_smoke
-  8/8 Test #8: blt_cuda_runtime_smoke ...........   Passed    0.11 sec
-
-  100% tests passed, 0 tests failed out of 8
-
-  Total Test time (real) =   6.80 sec
-
-
-Building and Testing on Matrix
-------------------------------
-
-Here is how you can use the host-config file to configure a build of the
-``calc_pi``  project with MPI and CUDA enabled on the LLNL's Matrix cluster:
-
-.. code-block:: bash
-    
-    # create build dir
-    mkdir build
-    cd build
-    # configure using host-config
-    cmake -C ../../host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1_nvcc.cmake  ..
-
-And here is how to build and test the code on Matrix:
-
-.. code-block:: console
-
-  bash-4.2$ salloc 1 -A <valid group>
-  bash-4.2$ make
-  bash-4.2$ make test
   
   Running tests...
   Test project projects/blt/docs/tutorial/calc_pi/build
@@ -128,8 +82,7 @@ And here is how to build and test the code on Matrix:
   
   100% tests passed, 0 tests failed out of 7
   
-  Total Test time (real) =   2.47 sec  
-
+  Total Test time (real) =   2.47 sec
 
 Building and Testing on Summit
 -------------------------------
@@ -190,7 +143,7 @@ And here is how to build and test the code on Summit:
 Example Host-configs
 --------------------
 
-Basic TOSS3 (for example: Quartz) host-config that has C, C++, and Fortran Compilers along with MPI support:
+Basic TOSS4 (for example: Dane) host-config that has C, C++, and Fortran Compilers along with MPI support:
 
 .. container:: toggle
 
@@ -202,20 +155,16 @@ Basic TOSS3 (for example: Quartz) host-config that has C, C++, and Fortran Compi
         :language: cmake
         :linenos:
 
-Here are the full example host-config files for LLNL's Pascal, Lassen, 
-and Quartz Clusters that uses the default compilers on the system:
+.. note::
+    When ``ENABLE_MPI`` is ``ON`` and you are using CMake's ``FindMPI`` (the default,
+    ``ENABLE_FIND_MPI=ON``), BLT expects an ``MPI_<lang>_COMPILER`` wrapper for each
+    enabled language. For example, if you enable Fortran, also set
+    ``MPI_Fortran_COMPILER`` in your host-config.
 
-.. container:: toggle
+    If a wrapper is unavailable or incompatible for a specific language, you can set
+    ``BLT_ALLOW_MISSING_MPI_WRAPPER=ON`` to allow configuring MPI without that wrapper.
 
-    .. container:: label
-
-        ``gcc@10.3.1 host-config``
-
-    .. literalinclude::  ../../host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1_nvcc.cmake
-        :language: cmake
-        :linenos:
-
-More complicated host-config that has C, C++, MPI, and CUDA support:
+Here is the full example host-config files for LLNL's Matrix Cluster that uses  C, C++, MPI, and CUDA support:
 
 .. container:: toggle
 

--- a/host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1_nvcc.cmake
+++ b/host-configs/llnl/toss_4_x86_64_ib/gcc@10.3.1_nvcc.cmake
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 #------------------------------------------------------------------------------
-# Example host-config file for a cluster on a toss4 platform (e.g. dane) at LLNL
+# Example host-config file for a cluster on a toss4 platform with Nvidia GPUs
+# (e.g. matrix) at LLNL
 #------------------------------------------------------------------------------
 #
 # This file provides CMake with paths / details for:
@@ -16,7 +17,7 @@
 # gcc@10.3.1 compilers
 #------------------------------------------------------------------------------
 
-# _blt_pascal_compiler_config_start
+# _blt_matrix_compiler_config_start
 set(GCC_VERSION "gcc-10.3.1")
 set(GCC_HOME "/usr/tce/packages/gcc/${GCC_VERSION}")
 
@@ -26,7 +27,7 @@ set(CMAKE_CXX_COMPILER "${GCC_HOME}/bin/g++" CACHE PATH "")
 # Fortran support
 set(ENABLE_FORTRAN ON CACHE BOOL "")
 set(CMAKE_Fortran_COMPILER "${GCC_HOME}/bin/gfortran" CACHE PATH "")
-# _blt_pascal_compiler_config_end
+# _blt_matrix_compiler_config_end
 
 #------------------------------------------------------------------------------
 # MPI Support

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/README.md
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/README.md
@@ -1,0 +1,5 @@
+# mpi-cpp-fortran-missing-wrapper
+
+Integration test that enables `MPI` and the `Fortran` language, but intentionally omits
+`MPI_Fortran_COMPILER` while setting `BLT_ALLOW_MISSING_MPI_WRAPPER=ON`.
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/base/CMakeLists.txt
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/base/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(mpi-cpp-fortran-missing-wrapper LANGUAGES CXX Fortran)
+
+set(BLT_CXX_STD c++14 CACHE STRING "")
+set(ENABLE_MPI ON CACHE BOOL "")
+set(BLT_ALLOW_MISSING_MPI_WRAPPER ON CACHE BOOL "")
+
+# Ensure this is treated as missing, even if the host-config provides it.
+set(MPI_Fortran_COMPILER "" CACHE FILEPATH "" FORCE)
+
+# Load BLT
+include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
+
+# Add third-party library setup files to the project's installation directory.
+blt_install_tpl_setups(DESTINATION lib/cmake/${PROJECT_NAME})
+
+blt_add_library(
+    NAME mpi-cpp-fortran-missing-wrapper
+    SOURCES mpi-cpp-fortran-missing-wrapper.cpp
+    DEPENDS_ON blt::mpi)
+
+blt_add_executable(
+    NAME non-mpi-fortran-example
+    SOURCES non_mpi_fortran_example.f90)
+
+install(TARGETS mpi-cpp-fortran-missing-wrapper
+  EXPORT mpi-cpp-fortran-missing-wrapper-targets)
+
+install(FILES
+  ${PROJECT_SOURCE_DIR}/mpi-cpp-fortran-missing-wrapper-config.cmake
+  DESTINATION lib/cmake/mpi-cpp-fortran-missing-wrapper)
+
+install(EXPORT mpi-cpp-fortran-missing-wrapper-targets
+    DESTINATION  lib/cmake/mpi-cpp-fortran-missing-wrapper)

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/base/mpi-cpp-fortran-missing-wrapper-config.cmake
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/base/mpi-cpp-fortran-missing-wrapper-config.cmake
@@ -1,0 +1,6 @@
+# This file exists so that when a downstream library calls `find_package`,
+# the installed TPL setup files will be included.
+
+include("${CMAKE_CURRENT_LIST_DIR}/mpi-cpp-fortran-missing-wrapper-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/BLTSetupTargets.cmake")
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/base/mpi-cpp-fortran-missing-wrapper.cpp
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/base/mpi-cpp-fortran-missing-wrapper.cpp
@@ -1,0 +1,9 @@
+#include <mpi.h>
+
+int main(int argc, char** argv)
+{
+  MPI_Init(&argc, &argv);
+  MPI_Finalize();
+  return 0;
+}
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/base/non_mpi_fortran_example.f90
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/base/non_mpi_fortran_example.f90
@@ -1,0 +1,11 @@
+program non_mpi_fortran_example
+  implicit none
+
+  integer :: value
+  value = 42
+
+  if (value .ne. 42) then
+    stop 1
+  end if
+end program non_mpi_fortran_example
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/CMakeLists.txt
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Clear variables set in the host-config so we can test that they are inherited
+# from the upstream project.
+foreach(_option MPI CUDA HIP OPENMP)
+    unset(ENABLE_${_option} CACHE)
+    unset(ENABLE_${_option})
+endforeach()
+
+unset(BLT_ALLOW_MISSING_MPI_WRAPPER CACHE)
+unset(BLT_ALLOW_MISSING_MPI_WRAPPER)
+
+cmake_minimum_required(VERSION 3.14)
+
+project(mpi-cpp-fortran-missing-wrapper-user LANGUAGES CXX Fortran)
+
+if (NOT MPI_Fortran_COMPILER)
+    message(FATAL_ERROR "ERROR: Missing MPI Fortran compiler wrapper (mpif90/mpifort).")
+endif()
+
+find_package(mpi-cpp-fortran-missing-wrapper REQUIRED
+             NO_DEFAULT_PATH
+             PATHS ${base_install_dir}/lib/cmake/mpi-cpp-fortran-missing-wrapper)
+
+if (NOT BLT_ALLOW_MISSING_MPI_WRAPPER)
+    message(FATAL_ERROR "ERROR: BLT_ALLOW_MISSING_MPI_WRAPPER was not inherited from the upstream project.")
+endif()
+
+add_executable(mpi-cpp-fortran-missing-wrapper-user mpi-cpp-fortran-missing-wrapper-user.cpp)
+target_link_libraries(mpi-cpp-fortran-missing-wrapper-user PUBLIC mpi-cpp-fortran-missing-wrapper)
+
+if (NOT DEFINED MPI_Fortran_USE_MPIF)
+    message(FATAL_ERROR "ERROR: Expected MPI_Fortran_USE_MPIF to be defined when MPI_Fortran_COMPILER is provided.")
+endif()
+
+if (MPI_Fortran_USE_MPIF)
+    set(_mpi_fortran_example_src mpi_fortran_example_mpif.f90)
+else()
+    set(_mpi_fortran_example_src mpi_fortran_example_module.f90)
+endif()
+
+add_executable(mpi-cpp-fortran-missing-wrapper-user-fortran-mpi ${_mpi_fortran_example_src})
+target_link_libraries(mpi-cpp-fortran-missing-wrapper-user-fortran-mpi PRIVATE mpi)
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi-cpp-fortran-missing-wrapper-user.cpp
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi-cpp-fortran-missing-wrapper-user.cpp
@@ -1,0 +1,9 @@
+#include <mpi.h>
+
+int main(int argc, char** argv)
+{
+  MPI_Init(&argc, &argv);
+  MPI_Finalize();
+  return 0;
+}
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi_fortran_example_module.f90
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi_fortran_example_module.f90
@@ -1,0 +1,10 @@
+program mpi_fortran_example
+  use mpi
+  implicit none
+
+  integer :: ierr
+
+  call MPI_Init(ierr)
+  call MPI_Finalize(ierr)
+end program mpi_fortran_example
+

--- a/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi_fortran_example_mpif.f90
+++ b/tests/projects/mpi-cpp-fortran-missing-wrapper/downstream/mpi_fortran_example_mpif.f90
@@ -1,0 +1,11 @@
+program mpi_fortran_example
+  implicit none
+
+  integer :: ierr
+
+  include 'mpif.h'
+
+  call MPI_Init(ierr)
+  call MPI_Finalize(ierr)
+end program mpi_fortran_example
+


### PR DESCRIPTION
This PR adds the `BLT_ALLOW_MISSING_MPI_WRAPPER ` option to enable users to configure MPI without providing some MPI_<lang>_COMPILER variables for some enabled languages.

This came up in an msan config where we need Fortran to be enabled (`ENABLE_FORTRAN=TRUE`) as well as MPI (`ENABLE_MPI=TRUE`), but we don't need an MPI wrapper for Fortran -- and more importantly, we don't have an MPI wrapper for Fortran that is compatible with our C and C++ MPI wrappers.